### PR TITLE
Adding a model to store a singular field in the Base MAP. refs #15

### DIFF
--- a/app/models/concerns/with_field_type.rb
+++ b/app/models/concerns/with_field_type.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module WithFieldType
+  extend ActiveSupport::Concern
+
+  included do
+    enum field_type: { string: 'string',
+                       text: 'text',
+                       numeric: 'numeric',
+                       date: 'date' }
+  end
+end

--- a/app/models/concerns/with_requirement_designation.rb
+++ b/app/models/concerns/with_requirement_designation.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module WithRequirementDesignation
+  extend ActiveSupport::Concern
+
+  included do
+    enum requirement_designation: { required_to_publish: 'required to publish',
+                                    recommended: 'recommended',
+                                    optional: 'optional' }
+  end
+end

--- a/app/models/metadata_application_profile_field.rb
+++ b/app/models/metadata_application_profile_field.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class MetadataApplicationProfileField < ApplicationRecord
+  include WithRequirementDesignation
+  include WithFieldType
+end

--- a/db/migrate/20170927135103_create_metadata_application_profile_fields.rb
+++ b/db/migrate/20170927135103_create_metadata_application_profile_fields.rb
@@ -1,0 +1,17 @@
+class CreateMetadataApplicationProfileFields < ActiveRecord::Migration[5.1]
+  def change
+    create_table :metadata_application_profile_fields do |t|
+      t.string :label
+      t.string :field_type
+      t.string :requirement_designation
+      t.string :validation
+      t.boolean :multiple
+      t.string :controlled_vocabulary
+      t.string :default_value
+      t.string :display_name
+      t.string :display_transformation
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170925192912) do
+ActiveRecord::Schema.define(version: 20170927135103) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,20 @@ ActiveRecord::Schema.define(version: 20170925192912) do
     t.datetime "updated_at", null: false
     t.index ["document_id"], name: "index_bookmarks_on_document_id"
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
+  end
+
+  create_table "metadata_application_profile_fields", force: :cascade do |t|
+    t.string "label"
+    t.string "field_type"
+    t.string "requirement_designation"
+    t.string "validation"
+    t.boolean "multiple"
+    t.string "controlled_vocabulary"
+    t.string "default_value"
+    t.string "display_name"
+    t.string "display_transformation"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "orm_resources", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|

--- a/spec/models/field_type_spec.rb
+++ b/spec/models/field_type_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WithFieldType, type: :model do
+  before (:all) do
+    class MyFieldModel < ApplicationRecord
+      include WithFieldType
+    end
+
+    ActiveRecord::Base.connection.create_table :my_field_models do |t|
+      t.string :field_type
+    end
+  end
+
+  after (:all) do
+    ActiveRecord::Base.connection.drop_table :my_field_models
+    ActiveSupport::Dependencies.remove_constant('MyFieldModel')
+  end
+
+  subject { model.field_type }
+
+  let(:field_type) { 'text' }
+  let(:model) { MyFieldModel.new(field_type: field_type) }
+
+  it { is_expected.to eq('text') }
+
+  it 'is text' do
+    expect(model).to be_text
+  end
+
+  it 'is not string' do
+    expect(model).not_to be_string
+  end
+
+  it 'is not date' do
+    expect(model).not_to be_date
+  end
+
+  it 'is not numeric' do
+    expect(model).not_to be_numeric
+  end
+
+  context 'field_type is set to date' do
+    before do
+      model.date!
+    end
+
+    it 'is date' do
+      expect(model).to be_date
+    end
+
+    it 'is not text' do
+      expect(model).not_to be_text
+    end
+
+    it 'is not string' do
+      expect(model).not_to be_string
+    end
+
+    it 'is not numeric' do
+      expect(model).not_to be_numeric
+    end
+  end
+
+  context 'field_type is set to numeric' do
+    before do
+      model.numeric!
+    end
+
+    it 'is numeric' do
+      expect(model).to be_numeric
+    end
+
+    it 'is not date' do
+      expect(model).not_to be_date
+    end
+
+    it 'is not text' do
+      expect(model).not_to be_text
+    end
+
+    it 'is not string' do
+      expect(model).not_to be_string
+    end
+  end
+
+  context 'field_type is set to string' do
+    before do
+      model.string!
+    end
+
+    it 'is string' do
+      expect(model).to be_string
+    end
+
+    it 'is not numeric' do
+      expect(model).not_to be_numeric
+    end
+
+    it 'is not date' do
+      expect(model).not_to be_date
+    end
+
+    it 'is not text' do
+      expect(model).not_to be_text
+    end
+  end
+
+  context 'field_type is bogus' do
+    let(:field_type) { 'bogus' }
+
+    it 'raises an error' do
+      expect { model }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/models/metadata_application_profile_field_spec.rb
+++ b/spec/models/metadata_application_profile_field_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MetadataApplicationProfileField, type: :model do
+  subject { model }
+
+  let(:model) { MetadataApplicationProfileField.new }
+
+  it { is_expected.to respond_to(:label) }
+  it { is_expected.to respond_to(:multiple) }
+  it { is_expected.to respond_to(:field_type) }
+  it { is_expected.to respond_to(:requirement_designation) }
+  it { is_expected.to respond_to(:controlled_vocabulary) }
+  it { is_expected.to respond_to(:default_value) }
+  it { is_expected.to respond_to(:display_name) }
+  it { is_expected.to respond_to(:display_transformation) }
+
+  it 'can be optional' do
+    model.optional!
+    expect(model.requirement_designation).to eq('optional')
+  end
+
+  it 'can be text' do
+    model.text!
+    expect(model.field_type).to eq('text')
+  end
+
+  context 'with metadata' do
+    let(:expected_metadata) { { 'controlled_vocabulary' => 'abc123_vocab',
+                                'created_at' => model.created_at,
+                                'default_value' => 'abc123',
+                                'display_name' => 'My Abc123',
+                                'display_transformation' => 'abc123_transform',
+                                'field_type' => 'date',
+                                'id' => model.id,
+                                'label' => 'abc123_label',
+                                'multiple' => false,
+                                'requirement_designation' => 'recommended',
+                                'updated_at' => model.updated_at,
+                                'validation' => 'abc123_validation' } }
+
+    before do
+      model.label = 'abc123_label'
+      model.date!
+      model.recommended!
+      model.controlled_vocabulary = 'abc123_vocab'
+      model.default_value = 'abc123'
+      model.display_name = 'My Abc123'
+      model.display_transformation = 'abc123_transform'
+      model.multiple = false
+      model.validation = 'abc123_validation'
+    end
+
+    it 'can be saved' do
+      model.save
+      model.reload
+      expect(model.attributes).to eq(expected_metadata)
+    end
+  end
+end

--- a/spec/models/requirement_designation_spec.rb
+++ b/spec/models/requirement_designation_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WithRequirementDesignation, type: :model do
+  before do
+    class MyModel < ApplicationRecord
+      include WithRequirementDesignation
+    end
+
+    ActiveRecord::Base.connection.create_table :my_models do |t|
+      t.string :requirement_designation
+    end
+  end
+
+  after do
+    ActiveRecord::Base.connection.drop_table :my_models
+    ActiveSupport::Dependencies.remove_constant('MyModel')
+  end
+
+  subject { model.requirement_designation }
+
+  let(:requirement_designation) { 'optional' }
+  let(:model) { MyModel.new(requirement_designation: requirement_designation) }
+
+  it { is_expected.to eq('optional') }
+
+  it 'is optional' do
+    expect(model).to be_optional
+  end
+
+  it 'is not required to publish' do
+    expect(model).not_to be_required_to_publish
+  end
+
+  it 'is not recommended' do
+    expect(model).not_to be_recommended
+  end
+
+  context 'requirement_desination is set to required' do
+    before do
+      model.required_to_publish!
+    end
+
+    it 'is required to publish' do
+      expect(model).to be_required_to_publish
+    end
+
+    it 'is not recommended' do
+      expect(model).not_to be_recommended
+    end
+
+    it 'is not optional' do
+      expect(model).not_to be_optional
+    end
+  end
+
+  context 'requirement_desination is set to recommended' do
+    before do
+      model.recommended!
+    end
+
+    it 'is recommended' do
+      expect(model).to be_recommended
+    end
+
+    it 'is not optional' do
+      expect(model).not_to be_optional
+    end
+
+    it 'is not required to publish' do
+      expect(model).not_to be_required_to_publish
+    end
+  end
+
+  context 'requirement_designation is bogus' do
+    let(:requirement_designation) { 'bogus' }
+
+    it 'raises an error' do
+      expect { model }.to raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
This is the basic model for storing information about a field in the Base MAP (Metadata Application Profile)

Each field can have the following specified:
  * label
  * field type
  * requirement designation
  * controlled vocabulary
  * default value
  * display name
  * display transformation
  * multiple
  * validation
