### PR TITLE
Create specific object types in the system, ref #239

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,10 +36,13 @@ group :development, :test do
 end
 
 group :development do
+  gem 'better_errors'
+  gem 'binding_of_caller'
   gem 'listen', '~> 3.0.5'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'web-console', '>= 3.3.0'
+  gem 'xray-rails'
 
   # Use Capistrano for deployment
   gem 'capistrano', '~> 3.7', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,13 @@ GEM
     ast (2.3.0)
     autoprefixer-rails (7.1.4.1)
       execjs
+    better_errors (2.3.0)
+      coderay (>= 1.0.0)
+      erubi (>= 1.0.0)
+      rack (>= 0.9.0)
     bindex (0.5.0)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
     blacklight (6.11.2)
       bootstrap-sass (~> 3.2)
       deprecation
@@ -159,6 +165,7 @@ GEM
       thor
     crass (1.0.2)
     database_cleaner (1.6.1)
+    debug_inspector (0.0.3)
     declarative (0.0.10)
     declarative-builder (0.1.0)
       declarative-option (< 0.2.0)
@@ -532,11 +539,15 @@ GEM
     xml-simple (1.1.5)
     xpath (2.1.0)
       nokogiri (~> 1.3)
+    xray-rails (0.3.1)
+      rails (>= 3.1.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  better_errors
+  binding_of_caller
   byebug
   capistrano (~> 3.7)
   capistrano-bundler (~> 1.2)
@@ -576,6 +587,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   valkyrie!
   web-console (>= 3.3.0)
+  xray-rails
 
 BUNDLED WITH
    1.15.4

--- a/app/adapters/indexing_adapter.rb
+++ b/app/adapters/indexing_adapter.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+# This is copied directly from https://github.com/samvera-labs/valkyrie
+##
+# The {IndexingAdapter} enables a choice between indexing into another
+# persister concurrently (via `#save`), or by doing a series of actions with the
+# primary persister, tracking those actions, and then persisting them all into
+# the `index_adapter` via a large `save_all` call. This is particularly
+# efficient when the `index_adapter` is significantly faster for `save_all`
+# than individual `saves` (such as with Solr).
+class IndexingAdapter
+  attr_reader :metadata_adapter, :index_adapter
+  # @param metadata_adapter [#persister,#query_service]
+  # @param index_adapter [#persister,#query_service]
+  def initialize(metadata_adapter:, index_adapter:)
+    @metadata_adapter = metadata_adapter
+    @index_adapter = index_adapter
+  end
+
+  def persister
+    IndexingAdapter::Persister.new(metadata_adapter: self)
+  end
+
+  delegate :query_service, to: :metadata_adapter
+
+  class Persister
+    attr_reader :metadata_adapter
+    delegate :index_adapter, to: :metadata_adapter
+    delegate :persister, to: :primary_adapter
+    def initialize(metadata_adapter:)
+      @metadata_adapter = metadata_adapter
+    end
+
+    def primary_adapter
+      metadata_adapter.metadata_adapter
+    end
+
+    def index_persister
+      index_adapter.persister
+    end
+
+    # (see Valkyrie::Persistence::Memory::Persister#save)
+    # @note This saves into both the `persister` and `index_persister`
+    #   concurrently.
+    def save(resource:)
+      composite_persister.save(resource: resource)
+    end
+
+    # (see Valkyrie::Persistence::Memory::Persister#save_all)
+    # @note This saves into both the `persister` and `index_persister`
+    #   concurrently.
+    def save_all(resources:)
+      composite_persister.save_all(resources: resources)
+    end
+
+    # (see Valkyrie::Persistence::Memory::Persister#delete)
+    # @note This deletes from both the `persister` and `index_persister`
+    #   concurrently.
+    def delete(resource:)
+      composite_persister.delete(resource: resource)
+    end
+
+    # Yields the primary persister. At the end of the block, this will use changes tracked
+    # by an in-memory persister to replicate new and deleted objects into the
+    # `index_persister` in bulk.
+    #
+    # @example Creating two items
+    #   indexing_persister.buffer_into_index do |persister|
+    #     persister.save(resource: Book.new)
+    #     persister.save(resource: Book.new)
+    #     solr_index.query_service.find_all # => []
+    #     persister.query_service.find_all # => [book1, book2]
+    #   end
+    #   solr_index.query_service.find_all # => [book1, book2]
+    def buffer_into_index
+      buffered_persister.with_buffer do |persist, buffer|
+        yield Valkyrie::AdapterContainer.new(persister: persist, query_service: metadata_adapter.query_service)
+        buffer.persister.deletes.uniq(&:id).each do |delete|
+          index_persister.delete(resource: delete)
+        end
+        index_persister.save_all(resources: buffer.query_service.find_all)
+      end
+    end
+
+    def composite_persister
+      @composite_persister ||= Valkyrie::Persistence::CompositePersister.new(persister, index_persister)
+    end
+
+    def buffered_persister
+      @buffered_persister ||= Valkyrie::Persistence::BufferedPersister.new(persister)
+    end
+  end
+end

--- a/app/change_set_persisters/change_set_persister.rb
+++ b/app/change_set_persisters/change_set_persister.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# @note This takes the the class from the Valkyrie MVP app and adds #buffer_into_index so that
+# we can use {IndexingAdapter} and store in Postgres while indexing in Solr at the same time.
+# @todo Includes a lot of commented-out methods dealing with adding files, and updating/deleting
+# parent objects. These could be used later, so they're being left here for possible future
+# implementation.
+# @see https://github.com/samvera-labs/valkyrie/blob/master/app/change_set_persisters/change_set_persister.rb
+class ChangeSetPersister
+  attr_reader :metadata_adapter, :storage_adapter
+  delegate :persister, :query_service, to: :metadata_adapter
+  def initialize(metadata_adapter:, storage_adapter:)
+    @metadata_adapter = metadata_adapter
+    @storage_adapter = storage_adapter
+  end
+
+  # @note uses a simple save method instead of the commented-out original version
+  # @todo Enable #before_save and #after_save methods to manage files and parent works
+  def save(change_set:)
+    # before_save(change_set: change_set)
+    # persister.save(resource: change_set.resource).tap do |output|
+    #   after_save(change_set: change_set, updated_resource: output)
+    # end
+    persister.save(resource: change_set.resource)
+  end
+
+  # @todo Enable methods to delete parent works
+  def delete(change_set:)
+    # before_delete(change_set: change_set)
+    persister.delete(resource: change_set.resource)
+  end
+
+  def save_all(change_sets:)
+    change_sets.map do |change_set|
+      save(change_set: change_set)
+    end
+  end
+
+  def buffer_into_index
+    metadata_adapter.persister.buffer_into_index do |buffered_adapter|
+      yield(buffered_adapter.persister)
+    end
+  end
+
+  # @note these are all private methods in the original.
+
+  # def before_save(change_set:)
+  #   create_files(change_set: change_set)
+  # end
+
+  # def after_save(change_set:, updated_resource:)
+  #   append(append_id: change_set.append_id, updated_resource: updated_resource) if change_set.append_id
+  # end
+
+  # def append(append_id:, updated_resource:)
+  #   parent_obj = query_service.find_by(id: append_id)
+  #   parent_obj.member_ids = parent_obj.member_ids + [updated_resource.id]
+  #   persister.save(resource: parent_obj)
+  # end
+
+  # @see https://github.com/samvera-labs/valkyrie/blob/master/app/services/file_appender.rb
+  # def create_files(change_set:)
+  #   appender = FileAppender.new(storage_adapter: storage_adapter, persister: persister, files: files(change_set: change_set))
+  #   appender.append_to(change_set.resource)
+  # end
+
+  # def files(change_set:)
+  #   change_set.try(:files) || []
+  # end
+
+  # def before_delete(change_set:)
+  #   parents = query_service.find_parents(resource: change_set.resource)
+  #   parents.each do |parent|
+  #     parent.member_ids -= [change_set.id]
+  #     persister.save(resource: parent)
+  #   end
+  # end
+end

--- a/app/change_sets/work_object_change_set.rb
+++ b/app/change_sets/work_object_change_set.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class WorkObjectChangeSet < Valkyrie::ChangeSet
+  self.fields = WorkObject.fields
+  validates :work_type, :title, presence: true
+
+  property :title, multiple: true, required: true
+  property :work_type, multiple: false, required: true
+end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -36,13 +36,13 @@ class CatalogController < ApplicationController
     # }
 
     # solr field configuration for search results/index views
-    # config.index.title_field = 'title_display'
-    # config.index.display_type_field = 'format'
+    config.index.title_field = 'title_tesim'
+    config.index.display_type_field = 'work_type_ssim'
     # config.index.thumbnail_field = 'thumbnail_path_ss'
 
     # solr field configuration for document/show views
-    # config.show.title_field = 'title_display'
-    # config.show.display_type_field = 'format'
+    config.show.title_field = 'title_tesim'
+    config.show.display_type_field = 'work_type_ssim'
     # config.show.thumbnail_field = 'thumbnail_path_ss'
 
     # solr fields that will be treated as facets by the blacklight application
@@ -69,7 +69,7 @@ class CatalogController < ApplicationController
     #  (useful when user clicks "more" on a large facet and wants to navigate alphabetically across a large set of results)
     # :index_range can be an array or range of prefixes that will be used to create the navigation (note: It is case sensitive when searching values)
 
-    # config.add_facet_field 'format', label: 'Format'
+    config.add_facet_field 'work_type_ssim', label: 'Work Type'
     # config.add_facet_field 'pub_date', label: 'Publication Year', single: true
     # config.add_facet_field 'subject_topic_facet', label: 'Topic', limit: 20, index_range: 'A'..'Z'
     # config.add_facet_field 'language_facet', label: 'Language', limit: true
@@ -92,32 +92,13 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
-    # config.add_index_field 'title_display', label: 'Title'
-    # config.add_index_field 'title_vern_display', label: 'Title'
-    # config.add_index_field 'author_display', label: 'Author'
-    # config.add_index_field 'author_vern_display', label: 'Author'
-    # config.add_index_field 'format', label: 'Format'
-    # config.add_index_field 'language_facet', label: 'Language'
-    # config.add_index_field 'published_display', label: 'Published'
-    # config.add_index_field 'published_vern_display', label: 'Published'
-    # config.add_index_field 'lc_callnum_display', label: 'Call number'
+    config.add_index_field 'title_tesim', label: 'Title'
+    config.add_index_field 'work_type_ssim', label: 'Work Type'
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
-    # config.add_show_field 'title_display', label: 'Title'
-    # config.add_show_field 'title_vern_display', label: 'Title'
-    # config.add_show_field 'subtitle_display', label: 'Subtitle'
-    # config.add_show_field 'subtitle_vern_display', label: 'Subtitle'
-    # config.add_show_field 'author_display', label: 'Author'
-    # config.add_show_field 'author_vern_display', label: 'Author'
-    # config.add_show_field 'format', label: 'Format'
-    # config.add_show_field 'url_fulltext_display', label: 'URL'
-    # config.add_show_field 'url_suppl_display', label: 'More Information'
-    # config.add_show_field 'language_facet', label: 'Language'
-    # config.add_show_field 'published_display', label: 'Published'
-    # config.add_show_field 'published_vern_display', label: 'Published'
-    # config.add_show_field 'lc_callnum_display', label: 'Call number'
-    # config.add_show_field 'isbn_t', label: 'ISBN'
+    config.add_show_field 'title_tesim', label: 'Title'
+    config.add_show_field 'work_type_ssim', label: 'Work Type'
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/controllers/work_objects_controller.rb
+++ b/app/controllers/work_objects_controller.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+class WorkObjectsController < ApplicationController
+  delegate :metadata_adapter, :storage_adapter, to: :change_set_persister
+  delegate :persister, :query_service, to: :metadata_adapter
+
+  # GET /work_objects/new
+  def new
+    @work = WorkObjectChangeSet.new(WorkObject.new).prepopulate!
+  end
+
+  # GET /work_objects/1/edit
+  def edit
+    @work = WorkObjectChangeSet.new(find_resource(params[:id])).prepopulate!
+  end
+
+  # POST /work_objects
+  # POST /work_objects.json
+  def create
+    change_set = WorkObjectChangeSet.new(WorkObject.new)
+    if change_set.validate(resource_params)
+      change_set.sync
+      obj = nil
+      change_set_persister.buffer_into_index do |buffered_changeset_persister|
+        obj = buffered_changeset_persister.save(resource: change_set)
+      end
+      redirect_to(polymorphic_path([:solr_document], id: "id-#{obj.id}"))
+    else
+      render :new
+    end
+  end
+
+  # PATCH/PUT /work_objects/1
+  # PATCH/PUT /work_objects/1.json
+  def update
+    change_set = WorkObjectChangeSet.new(find_resource(params[:id])).prepopulate!
+    if change_set.validate(resource_params)
+      change_set.sync
+      obj = nil
+      change_set_persister.buffer_into_index do |buffered_changeset_persister|
+        obj = buffered_changeset_persister.save(resource: change_set)
+      end
+      redirect_to(polymorphic_path([:solr_document], id: "id-#{obj.id}"))
+    else
+      render :edit
+    end
+  end
+
+  # DELETE /work_objects/1
+  # DELETE /work_objects/1.json
+  def destroy
+    change_set = WorkObjectChangeSet.new(find_resource(params[:id]))
+    change_set_persister.buffer_into_index do |buffered_changeset_persister|
+      buffered_changeset_persister.delete(resource: change_set)
+    end
+    flash[:alert] = "Deleted #{change_set.resource}"
+    redirect_to(root_path)
+  end
+
+  private
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def work_params
+      params.fetch(:work_object, {})
+    end
+
+    def find_resource(id)
+      query_service.find_by(id: Valkyrie::ID.new(id))
+    end
+
+    def resource_params
+      params[WorkObject.to_s.underscore.to_sym].to_unsafe_h
+    end
+
+    def change_set_persister
+      @change_set_persister ||= ChangeSetPersister.new(
+        metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister),
+        storage_adapter: Valkyrie.config.storage_adapter
+      )
+    end
+end

--- a/app/decorators/work_object_decorator.rb
+++ b/app/decorators/work_object_decorator.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class WorkObjectDecorator < Draper::Decorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+end

--- a/app/helpers/work_objects_helper.rb
+++ b/app/helpers/work_objects_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module WorkObjectsHelper
+end

--- a/app/models/concerns/base_map.rb
+++ b/app/models/concerns/base_map.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Contains all the fields available in the entire application.
+# @todo Only a placeholder module until all the field definitions are added.
+module BaseMAP
+  extend ActiveSupport::Concern
+
+  included do
+    # @todo Example property only; can be removed or renamed
+    attribute :title, Valkyrie::Types::Set
+  end
+end

--- a/app/models/work_object.rb
+++ b/app/models/work_object.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class WorkObject < Valkyrie::Resource
+  include Valkyrie::Resource::AccessControls
+  include BaseMAP
+  attribute :id, Valkyrie::Types::ID.optional
+  attribute :work_type, Valkyrie::Types::Set
+end

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,0 +1,9 @@
+<div id="content" class="<%= show_content_classes %>">
+  <%= render_document_main_content_partial %>
+
+  <%= link_to "Edit", edit_work_object_path(@document.id.gsub(/id-/,'')) %>
+</div>
+
+<div id="sidebar" class="<%= show_sidebar_classes %>">
+   <%= render_document_sidebar_partial %>
+</div>

--- a/app/views/work_objects/_form.html.erb
+++ b/app/views/work_objects/_form.html.erb
@@ -1,0 +1,28 @@
+<%= form_with(model: work, local: true) do |form| %>
+
+  <p>
+    <%= form.label :title %><br>
+    <%= form.text_field :title %>
+  </p>
+
+  <p>
+    <%= form.label :work_type %><br>
+    <%= form.select :work_type, ["Generic", "Still Image", "Map", "Document", "Audio/Visual"] %>
+  </p>
+
+  <% if work.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(work.errors.count, "error") %> prohibited this work from being saved:</h2>
+
+      <ul>
+      <% work.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/work_objects/edit.html.erb
+++ b/app/views/work_objects/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Work</h1>
+
+<%= render 'form', work: @work %>
+
+<%= link_to 'Show', @work %> |
+<%= link_to 'Back', work_objects_path %>

--- a/app/views/work_objects/new.html.erb
+++ b/app/views/work_objects/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Work</h1>
+
+<%= render 'form', work: @work %>
+
+<%= link_to 'Back', work_objects_path %>

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'valkyrie'
+Rails.application.config.to_prepare do
+  # Metadata Adapters
+
+  Valkyrie::MetadataAdapter.register(
+    Valkyrie::Persistence::Postgres::MetadataAdapter.new,
+    :postgres
+  )
+
+  Valkyrie::MetadataAdapter.register(
+    Valkyrie::Persistence::Memory::MetadataAdapter.new,
+    :memory
+  )
+
+  Valkyrie::MetadataAdapter.register(
+    Valkyrie::Persistence::Solr::MetadataAdapter.new(connection: Blacklight.default_index.connection,
+                                                     resource_indexer: Valkyrie::Indexers::AccessControlsIndexer),
+    :index_solr
+  )
+
+  Valkyrie::MetadataAdapter.register(
+    IndexingAdapter.new(
+      metadata_adapter: Valkyrie.config.metadata_adapter,
+      index_adapter: Valkyrie::MetadataAdapter.find(:index_solr)
+    ),
+    :indexing_persister
+  )
+
+  # Storage Adapters
+
+  Valkyrie::StorageAdapter.register(
+    Valkyrie::Storage::Disk.new(base_path: Rails.root.join('tmp', 'files')),
+    :disk
+  )
+
+  Valkyrie::StorageAdapter.register(
+    Valkyrie::Storage::Memory.new,
+    :memory
+  )
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,5 +24,5 @@ Rails.application.routes.draw do
     end
   end
 
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  resources :work_objects, except: [:show, :index]
 end

--- a/config/valkyrie.yml
+++ b/config/valkyrie.yml
@@ -1,0 +1,11 @@
+development:
+  metadata_adapter: postgres
+  storage_adapter: disk
+
+test:
+  metadata_adapter: postgres
+  storage_adapter: disk
+
+production:
+  metadata_adapter: postgres
+  storage_adapter: fedora

--- a/spec/adapters/indexing_adapter_spec.rb
+++ b/spec/adapters/indexing_adapter_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'valkyrie/specs/shared_specs'
+
+RSpec.describe IndexingAdapter do
+  let(:adapter) do
+    described_class.new(metadata_adapter: Valkyrie::Persistence::Memory::MetadataAdapter.new,
+                        index_adapter: index_solr)
+  end
+  let(:query_service) { adapter.query_service }
+  let(:persister)     { adapter.persister }
+  let(:index_solr)    { Valkyrie::MetadataAdapter.find(:index_solr) }
+
+  it_behaves_like 'a Valkyrie::Persister'
+
+  it 'updates Solr after saving to the metadata adapter' do
+    persister.buffer_into_index do |buffered_adapter|
+      buffered_adapter.persister.save(resource: build(:work))
+    end
+    expect(index_solr.query_service.find_all.to_a.length).to eq 1
+  end
+
+  it 'does not update Solr until after saving to the metadata adapter' do
+    persister.buffer_into_index do |buffered_adapter|
+      buffered_adapter.persister.save(resource: build(:work))
+      expect(index_solr.query_service.find_all.to_a.length).to eq 0
+    end
+  end
+end

--- a/spec/change_set_persisters/change_set_persister_spec.rb
+++ b/spec/change_set_persisters/change_set_persister_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'valkyrie/specs/shared_specs'
+
+RSpec.describe ChangeSetPersister do
+  let(:metadata_adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
+  let(:storage_adapter)  { Valkyrie.config.storage_adapter }
+  let(:change_set_persister) { described_class.new(metadata_adapter: metadata_adapter,
+                                                   storage_adapter: storage_adapter) }
+
+  it_behaves_like 'a Valkyrie::ChangeSetPersister'
+
+  describe '#buffer_into_index' do
+    let(:resource)   { build(:work, title: 'Buffer into index') }
+    let(:change_set) { WorkObjectChangeSet.new(resource) }
+
+    it 'persists a change set to Postgres' do
+      expect {
+        change_set_persister.buffer_into_index do |persist|
+          persist.save(resource: change_set)
+        end
+      }.to change { metadata_adapter.query_service.find_all.count }.by(1)
+    end
+
+    it 'persists a change set to Solr' do
+      expect {
+        change_set_persister.buffer_into_index do |persist|
+          persist.save(resource: change_set)
+        end
+      }.to change { metadata_adapter.index_adapter.query_service.find_all.count }.by(1)
+    end
+  end
+end

--- a/spec/change_sets/work_object_change_set_spec.rb
+++ b/spec/change_sets/work_object_change_set_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WorkObjectChangeSet do
+  subject(:change_set) { described_class.new(resource) }
+
+  let(:resource) { WorkObject.new }
+
+  describe '#append_id' do
+    before { change_set.append_id = Valkyrie::ID.new('test') }
+    its(:append_id) { is_expected.to eq(Valkyrie::ID.new('test')) }
+    its([:append_id]) { is_expected.to eq(Valkyrie::ID.new('test')) }
+  end
+
+  describe '#multiple?' do
+    it 'has multiple titles' do
+      expect(change_set).to be_multiple(:title)
+    end
+
+    it 'has a single work type' do
+      expect(change_set).not_to be_multiple(:work_type)
+    end
+  end
+
+  describe '#required?' do
+    it 'has a required title' do
+      expect(change_set).to be_required(:title)
+    end
+
+    it 'has a required work type' do
+      expect(change_set).to be_required(:work_type)
+    end
+  end
+
+  describe '#fields=' do
+    before { change_set.prepopulate! }
+    its(:title) { is_expected.to be_empty }
+    its(:work_type) { is_expected.to be_nil }
+  end
+
+  describe '#validate' do
+    subject { change_set.errors }
+
+    before { change_set.validate(params) }
+
+    context 'without a title' do
+      let(:params) { { work_type: 'work type' } }
+
+      its(:full_messages) { is_expected.to include("Title can't be blank") }
+    end
+
+    context 'without a work type' do
+      let(:params) { { title: 'title' } }
+
+      its(:full_messages) { is_expected.to include("Work type can't be blank") }
+    end
+
+    context 'with all required fields' do
+      let(:params) { { work_type: 'work type', title: 'Title' } }
+
+      its(:full_messages) { is_expected.to be_empty }
+    end
+  end
+end

--- a/spec/controllers/work_objects_controller_spec.rb
+++ b/spec/controllers/work_objects_controller_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WorkObjectsController do
+  let(:metadata_adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
+  let(:resource) { Valkyrie.config.metadata_adapter.persister.save(resource: build(:work)) }
+
+  describe 'GET #new' do
+    it 'returns a success response' do
+      get :new
+      expect(response).to be_success
+    end
+  end
+
+  describe 'GET #edit' do
+    it 'returns a success response' do
+      get :edit, params: { id: resource.id }
+      expect(response).to be_success
+    end
+  end
+
+  describe 'POST #create' do
+    let(:valid_attributes) { { title: 'New Title', work_type: 'type' } }
+    let(:resource) { metadata_adapter.query_service.find_all.to_a.last }
+
+    context 'with valid params' do
+      it 'creates a new WorkObject' do
+        expect {
+          post :create, params: { work_object: valid_attributes }
+        }.to change { metadata_adapter.query_service.find_all.to_a.count }.by(1)
+      end
+
+      it 'redirects to the created work' do
+        post :create, params: { work_object: valid_attributes }
+        expect(response).to redirect_to("/catalog/id-#{resource.id}")
+      end
+    end
+
+    context 'with an invalid change set' do
+      let(:invalid_attributes) { { title: 'Missing a work type' } }
+
+      it "returns a success response (i.e. to display the 'new' template)" do
+        post :create, params: { work_object: invalid_attributes }
+        expect(response).to be_success
+      end
+    end
+  end
+
+  describe 'PUT #update' do
+    let(:new_attributes) { { title: 'Updated Title' } }
+
+    context 'with valid params' do
+      let(:updated_resource) { metadata_adapter.query_service.find_by(id: resource.id) }
+
+      it 'updates the requested work' do
+        put :update, params: { id: resource.to_param, work_object: new_attributes }
+        expect(updated_resource.title).to contain_exactly('Updated Title')
+      end
+
+      it 'redirects to the work' do
+        put :update, params: { id: resource.to_param, work_object: new_attributes }
+        expect(response).to redirect_to("/catalog/id-#{resource.id}")
+      end
+    end
+
+    context 'with an invalid change set' do
+      let(:invalid_attributes) { { title: '' } }
+
+      it "returns a success response (i.e. to display the 'edit' template)" do
+        put :update, params: { id: resource.to_param, work_object: invalid_attributes }
+        expect(response).to be_success
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    before { resource }
+    it 'destroys the requested work' do
+      expect {
+        delete :destroy, params: { id: resource.to_param }
+      }.to change { metadata_adapter.query_service.find_all.to_a.count }.by(-1)
+    end
+
+    it 'redirects to the works list' do
+      delete :destroy, params: { id: resource.to_param }
+      expect(response).to redirect_to('/')
+    end
+  end
+end

--- a/spec/decorators/work_object_decorator_spec.rb
+++ b/spec/decorators/work_object_decorator_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WorkObjectDecorator do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/factories/work_objects.rb
+++ b/spec/factories/work_objects.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :work_object, aliases: [:work] do
+    title 'Sample Generic Work'
+    work_type 'Generic'
+  end
+end

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -3,17 +3,46 @@
 require 'rails_helper'
 
 RSpec.describe 'Catalog page' do
-  let(:query) { 'search query' }
+  context 'with no items in the repository' do
+    let(:query) { 'search query' }
 
-  it 'executes a search' do
-    visit('/catalog')
-    fill_in('q', with: query)
-    click_button('Search')
-    within('.constraints-container') do
-      expect(page).to have_link('Start Over')
-      expect(page).to have_link("Remove constraint #{query}")
-      expect(page).to have_content("You searched for: #{query}")
+    it 'returns a null search' do
+      visit('/catalog')
+      fill_in('q', with: query)
+      click_button('Search')
+      within('.constraints-container') do
+        expect(page).to have_link('Start Over')
+        expect(page).to have_link("Remove constraint #{query}")
+        expect(page).to have_content("You searched for: #{query}")
+      end
+      expect(page).to have_content('No results found for your search')
     end
-    expect(page).to have_content('No results found for your search')
+  end
+
+  context 'with an existing work' do
+    let(:work)  { build(:work, title: 'Some exceptional content') }
+    let(:query) { 'exceptional' }
+
+    # @todo this only persists the object into Solr; could use FactoryGirl here to make it easier.
+    before { Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: work) }
+
+    it 'searches and facets on the item' do
+      visit('/catalog')
+      fill_in('q', with: query)
+      click_button('Search')
+      within('.constraints-container') do
+        expect(page).to have_link('Start Over')
+        expect(page).to have_link("Remove constraint #{query}")
+        expect(page).to have_content("You searched for: #{query}")
+      end
+      expect(page).to have_content('Some exceptional content')
+      within('.facet_limit.blacklight-work_type_ssim') do
+        click_link('Generic')
+      end
+      within('.constraints-container') do
+        expect(page).to have_link('Remove constraint Work Type: Generic')
+      end
+      expect(page).to have_content('Some exceptional content')
+    end
   end
 end

--- a/spec/features/edit_work_object_spec.rb
+++ b/spec/features/edit_work_object_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Editing work objects' do
+  let(:work) { build(:work, title: 'Work to edit') }
+  let(:resource) { Valkyrie.config.metadata_adapter.persister.save(resource: work) }
+
+  it 'updates an existing work with new metadata' do
+    visit(edit_work_object_path(resource))
+    fill_in('work_object[title]', with: 'Updated Work Title')
+    click_button('Update Work object')
+    expect(page).to have_content('Updated Work Title')
+  end
+end

--- a/spec/features/new_work_object_spec.rb
+++ b/spec/features/new_work_object_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WorkObject do
+  it 'creates a new work object' do
+    visit(new_work_object_path)
+    fill_in('work_object[title]', with: 'New Title')
+    select('Generic', from: 'work_object[work_type]')
+    click_button('Create Work object')
+    expect(page).to have_content('New Title')
+    expect(page).to have_content('Generic')
+    expect(page).to have_link('Edit')
+  end
+end

--- a/spec/features/show_work_object_spec.rb
+++ b/spec/features/show_work_object_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Showing a work object' do
+  # @todo This persists the work in both Postgres and Solr, so we can display it, and then view the
+  # edit form. It would be nice if we could build this process into FactoryGirl to make it easier.
+  let!(:work) do
+    work = nil
+    Valkyrie::MetadataAdapter.find(:indexing_persister).persister.buffer_into_index do |buffered_adapter|
+      work = buffered_adapter.persister.save(resource: build(:work, title: 'An editable file'))
+    end
+    work
+  end
+
+  it 'displays its show page and links to the edit form' do
+    visit(polymorphic_path([:solr_document], id: "id-#{work.id}"))
+    expect(page).to have_content('An editable file')
+    expect(page).to have_content('Generic')
+    click_link('Edit')
+    expect(page).to have_field('work_object[title]', with: 'An editable file')
+    expect(page).to have_select('work_object[work_type]', with_selected: 'Generic')
+  end
+end

--- a/spec/helpers/work_objects_helper_spec.rb
+++ b/spec/helpers/work_objects_helper_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the WorkObjectsHelper. For example:
+#
+# describe WorkObjectsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe WorkObjectsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/work_object_spec.rb
+++ b/spec/models/work_object_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'valkyrie/specs/shared_specs'
+
+RSpec.describe WorkObject do
+  let(:resource_klass) { described_class }
+
+  it_behaves_like 'a Valkyrie::Resource'
+
+  describe '#title' do
+    it 'is nil when not set' do
+      expect(resource_klass.new.title).to be_empty
+    end
+
+    it 'can be set as an attribute' do
+      resource = resource_klass.new(title: 'test')
+      expect(resource.attributes[:title]).to contain_exactly('test')
+    end
+
+    it 'is included in the list of attributes' do
+      expect(resource_klass.new.has_attribute?(:title)).to eq true
+    end
+
+    it 'is included in the list of fields' do
+      expect(resource_klass.fields).to include(:title)
+    end
+  end
+
+  describe '#work_type' do
+    it 'is nil when not set' do
+      expect(resource_klass.new.work_type).to be_empty
+    end
+
+    it 'can be set as an attribute' do
+      resource = resource_klass.new(work_type: 'test')
+      expect(resource.attributes[:work_type]).to contain_exactly('test')
+    end
+
+    it 'is included in the list of attributes' do
+      expect(resource_klass.new.has_attribute?(:work_type)).to eq true
+    end
+
+    it 'is included in the list of fields' do
+      expect(resource_klass.fields).to include(:work_type)
+    end
+  end
+end

--- a/spec/routing/work_objects_routing_spec.rb
+++ b/spec/routing/work_objects_routing_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WorkObjectsController, type: :routing do
+  describe 'routing' do
+    it 'has no route to #index' do
+      expect(get: '/work_objects').not_to route_to('work_objects#index')
+    end
+
+    it 'routes to #new' do
+      expect(get: '/work_objects/new').to route_to('work_objects#new')
+    end
+
+    it 'routes to #show' do
+      expect(get: '/work_objects/1').not_to route_to('work_objects#show', id: '1')
+    end
+
+    it 'routes to #edit' do
+      expect(get: '/work_objects/1/edit').to route_to('work_objects#edit', id: '1')
+    end
+
+    it 'routes to #create' do
+      expect(post: '/work_objects').to route_to('work_objects#create')
+    end
+
+    it 'routes to #update via PUT' do
+      expect(put: '/work_objects/1').to route_to('work_objects#update', id: '1')
+    end
+
+    it 'routes to #update via PATCH' do
+      expect(patch: '/work_objects/1').to route_to('work_objects#update', id: '1')
+    end
+
+    it 'routes to #destroy' do
+      expect(delete: '/work_objects/1').to route_to('work_objects#destroy', id: '1')
+    end
+  end
+end

--- a/spec/support/clean_solr.rb
+++ b/spec/support/clean_solr.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.before do
+    Blacklight.default_index.connection.delete_by_query('*:*')
+    Blacklight.default_index.connection.commit
+  end
+end

--- a/spec/support/clear_memory_adapter.rb
+++ b/spec/support/clear_memory_adapter.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.before do
+    Valkyrie::MetadataAdapter.adapters.each_value do |adapter|
+      next unless adapter.is_a?(Valkyrie::Persistence::Memory::MetadataAdapter)
+      adapter.cache = {}
+    end
+  end
+end

--- a/spec/views/work_objects/edit.html.erb_spec.rb
+++ b/spec/views/work_objects/edit.html.erb_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'work_objects/edit', type: :view do
+  let(:work) { build(:work, title: ['Editable title'], id: 'id') }
+  let(:change_set) { WorkObjectChangeSet.new(work) }
+
+  before do
+    @work = assign(:work, change_set)
+    render
+  end
+
+  it 'renders the edit form' do
+    assert_select 'form[action=?][method=?]', work_object_path(@work), 'post' do
+      assert_select 'input[name=?]', 'work_object[title]'
+    end
+  end
+end

--- a/spec/views/work_objects/new.html.erb_spec.rb
+++ b/spec/views/work_objects/new.html.erb_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'work_objects/new', type: :view do
+  let(:change_set) { WorkObjectChangeSet.new(WorkObject.new) }
+
+  before do
+    assign(:work, change_set)
+    render
+  end
+
+  it 'renders the new form' do
+    assert_select 'form[action=?][method=?]', work_objects_path, 'post' do
+      assert_select 'input[name=?]', 'work_object[title]'
+    end
+  end
+end


### PR DESCRIPTION
Creates a generic WorkObject class to represent still images, maps,
documents, audio-visual sources, or any other generic type of object in
a collection.

Assumes that each object will have a title, and allows for creating and
editing objects, as well as searching for them via Blacklight.