### PR TITLE
Exempting view tests from Rubocop length restrictions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,7 @@ RSpec/DescribeClass:
 RSpec/ExampleLength:
   Exclude:
     - 'spec/features/**/*'
+    - 'spec/views/**/*'
 
 RSpec/MultipleExpectations:
   Exclude:


### PR DESCRIPTION
This is to get master passing again. We can make this a default by adding these exemptions to our guides.

I've put in a ticket to discuss if we want to make these changes standard:
https://github.com/psu-stewardship/guides/issues/7.