### PR TITLE
Enable deleting works from the UI

### DIFF
--- a/app/controllers/work_objects_controller.rb
+++ b/app/controllers/work_objects_controller.rb
@@ -53,7 +53,7 @@ class WorkObjectsController < ApplicationController
     change_set_persister.buffer_into_index do |buffered_changeset_persister|
       buffered_changeset_persister.delete(resource: change_set)
     end
-    flash[:alert] = "Deleted #{change_set.resource}"
+    flash[:alert] = "#{change_set.title.first} has been deleted"
     redirect_to(root_path)
   end
 

--- a/app/views/work_objects/edit.html.erb
+++ b/app/views/work_objects/edit.html.erb
@@ -15,4 +15,6 @@
 <% end %>
 
 <%= link_to 'Show', @work %> |
-<%= link_to 'Back', work_objects_path %>
+<%= link_to 'Back', work_objects_path %> |
+<%= link_to "Delete #{@work.work_type.titleize}", work_object_path(@work),
+            data: {:confirm => 'Are you sure?'}, :method => :delete %>

--- a/spec/features/edit_work_object_spec.rb
+++ b/spec/features/edit_work_object_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Editing work objects' do
   let(:work) { build(:work, title: 'Work to edit') }
   let(:resource) { Valkyrie.config.metadata_adapter.persister.save(resource: work) }
+  let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
 
   context 'with all the required metadata' do
     it 'updates an existing work with new metadata' do
@@ -21,6 +22,16 @@ RSpec.describe 'Editing work objects' do
       fill_in('work_object[title]', with: '')
       click_button('Update Generic')
       expect(page).to have_content("Title can't be blank")
+    end
+  end
+
+  context 'when deleting a work' do
+    it 'removes the work from the system' do
+      visit(edit_work_object_path(resource))
+      click_link('Delete Generic')
+      expect(page).to have_content('Work to edit has been deleted')
+      expect(adapter.metadata_adapter.query_service.find_all.count).to eq(0)
+      expect(adapter.index_adapter.query_service.find_all.count).to eq(0)
     end
   end
 end


### PR DESCRIPTION
Provides the standard Rails delete link to remove a work object from the
system. This will delete it from both Solr and Postgres.