### PR TITLE
Adding display transformation base

### DIFF
--- a/app/cho/display_transformation/base.rb
+++ b/app/cho/display_transformation/base.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module DisplayTransformation
+  class Base
+    def transform(_field)
+      raise Error.new('DisplayTransformation.transform is abstract. Children must implement.')
+    end
+  end
+end

--- a/app/cho/display_transformation/error.rb
+++ b/app/cho/display_transformation/error.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module DisplayTransformation
+  class Error < StandardError
+  end
+end

--- a/app/cho/display_transformation/factory.rb
+++ b/app/cho/display_transformation/factory.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module DisplayTransformation
+  class Factory
+    def self.transformations=(new_transformations)
+      non_transformations = new_transformations.reject { |_label, transformation| transformation.is_a? DisplayTransformation::Base }
+      if non_transformations.present?
+        error_list = non_transformations.keys.join(', ')
+        raise Error.new("Invalid display transformations(s) in transformation list: #{error_list}")
+      end
+
+      @transformations = new_transformations.merge(none: DisplayTransformation::None.new)
+    end
+
+    def self.transformations
+      @transformations ||= { none: DisplayTransformation::None.new }
+    end
+
+    def self.lookup(transformation_name)
+      transformations[transformation_name]
+    end
+  end
+end

--- a/app/cho/display_transformation/none.rb
+++ b/app/cho/display_transformation/none.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module DisplayTransformation
+  class None < Base
+    def transform(field)
+      field
+    end
+  end
+end

--- a/spec/cho/display_transformation/factory_spec.rb
+++ b/spec/cho/display_transformation/factory_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DisplayTransformation::Factory, type: :model do
+  before (:all) do
+    class MyTransformation < DisplayTransformation::Base
+    end
+    class OtherTransformation < DisplayTransformation::Base
+    end
+  end
+
+  after (:all) do
+    ActiveSupport::Dependencies.remove_constant('MyTransformation')
+    ActiveSupport::Dependencies.remove_constant('OtherTransformation')
+  end
+
+  subject(:factory) { described_class.new }
+
+  it { within_block_is_expected.not_to raise_exception }
+
+  describe '#tranformations=' do
+    subject { described_class.transformations = transformations }
+
+    let(:transformations) { { mine: MyTransformation.new, abc: OtherTransformation.new } }
+
+    it { within_block_is_expected.not_to raise_exception }
+
+    context 'invalid transformations set' do
+      let(:transformations) { { mine: MyTransformation.new, abc: '123' } }
+
+      it { within_block_is_expected.to raise_exception(DisplayTransformation::Error, 'Invalid display transformations(s) in transformation list: abc') }
+    end
+  end
+
+  describe '#tranformations' do
+    subject { described_class.transformations.keys }
+
+    let(:transformations) { {} }
+
+    before do
+      described_class.transformations = transformations
+    end
+
+    it { is_expected.to eq([:none]) }
+
+    context 'valid transformations set' do
+      let(:transformations) { { abc: MyTransformation.new, other: OtherTransformation.new } }
+
+      it { is_expected.to eq([:abc, :other, :none]) }
+    end
+  end
+
+  describe '#lookup' do
+    subject { described_class.lookup(:mine) }
+
+    let(:mine) { MyTransformation.new }
+
+    before do
+      described_class.transformations = { mine: mine }
+    end
+
+    it { is_expected.to eq(mine) }
+
+    context 'missing transformation' do
+      subject { described_class.lookup(:bogus) }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/cho/display_transformation/none_spec.rb
+++ b/spec/cho/display_transformation/none_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DisplayTransformation::None, type: :model do
+  subject { described_class.new }
+
+  it { within_block_is_expected.not_to raise_exception(DisplayTransformation::Error) }
+
+  describe '#transform' do
+    subject { described_class.new.transform('abc') }
+
+    it { is_expected.to eq('abc') }
+  end
+end


### PR DESCRIPTION
Here is another way to do the Factory.

Not sure if this better or worse than the validation pattern.  The is a single factory for the system, which can have the transformations set on it.