### PR TITLE
Avoid false-positives when checking for errors

### DIFF
--- a/app/cho/validation/error.rb
+++ b/app/cho/validation/error.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Validation
+  class Error < StandardError
+  end
+end

--- a/app/cho/validation/validator.rb
+++ b/app/cho/validation/validator.rb
@@ -3,7 +3,7 @@
 module Validation
   class Validator
     def validate(_field)
-      raise 'Validation.validate is abstract. Children must implement.'
+      raise Error, 'Validation.validate is abstract. Children must implement.'
     end
   end
 end

--- a/spec/cho/display_transformation/none_spec.rb
+++ b/spec/cho/display_transformation/none_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe DisplayTransformation::None, type: :model do
   subject { described_class.new }
 
-  it { within_block_is_expected.not_to raise_exception(DisplayTransformation::Error) }
+  it { within_block_is_expected.not_to raise_error }
 
   describe '#transform' do
     subject { described_class.new.transform('abc') }

--- a/spec/cho/validation/validator_spec.rb
+++ b/spec/cho/validation/validator_spec.rb
@@ -27,6 +27,9 @@ RSpec.describe Validation::Validator, type: :model do
   context 'invalid validator' do
     let(:testing_class) { OtherValidator }
 
-    it { within_block_is_expected.to raise_exception }
+    it { within_block_is_expected.to raise_exception(
+      Validation::Error,
+      'Validation.validate is abstract. Children must implement.'
+    ) }
   end
 end


### PR DESCRIPTION
RSpec was complaining about tests that check for exceptions.

This specifies which errors should be raised when they're supposed to,
and specifies that any error shouldn't be raise when it's not supposed
to.