### PR TITLE
Catch false positives in ControlledVocabulary::None

### DIFF
--- a/spec/cho/controlled_vocabulary/none_spec.rb
+++ b/spec/cho/controlled_vocabulary/none_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe ControlledVocabulary::None, type: :model do
   subject { described_class.new }
 
-  it { within_block_is_expected.not_to raise_exception(ControlledVocabulary::Error) }
+  it { within_block_is_expected.not_to raise_exception }
 
   describe '#transform' do
     subject { described_class.new.lookup('abc') }


### PR DESCRIPTION
Ensure that no exception is raised, no matter the specific type. @cam156 sorry, I missed this one on the PR review.