### PR TITLE
Use FactoryGirl::create_for_repository

### DIFF
--- a/spec/blacklight/catalog_spec.rb
+++ b/spec/blacklight/catalog_spec.rb
@@ -21,11 +21,9 @@ RSpec.describe 'Catalog page', type: :feature do
   end
 
   context 'with an existing work' do
-    let(:work)  { build(:work, title: 'Some exceptional content') }
     let(:query) { 'exceptional' }
 
-    # @todo this only persists the object into Solr; could use FactoryGirl here to make it easier.
-    before { Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: work) }
+    before { create_for_repository(:work, title: 'Some exceptional content') }
 
     it 'searches and facets on the item' do
       visit('/catalog')

--- a/spec/cho/data_dictionary/csv_importer_spec.rb
+++ b/spec/cho/data_dictionary/csv_importer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe DataDictionary::CsvImporter do
   end
 
   context 'record exists' do
-    before { create(:data_dictionary_field) }
+    before { create_for_repository(:data_dictionary_field) }
 
     it 'will update records' do
       expect {

--- a/spec/cho/data_dictionary/fields_controller_spec.rb
+++ b/spec/cho/data_dictionary/fields_controller_spec.rb
@@ -43,14 +43,9 @@ RSpec.describe DataDictionary::FieldsController, type: :controller do
   let(:valid_session) { {} }
 
   context 'valid object created' do
-    let(:resource) { DataDictionary::FieldChangeSet.new(build(:data_dictionary_field)) }
-    let(:dictionary_field) { Valkyrie.config.metadata_adapter.persister.save(resource: resource) }
+    let!(:dictionary_field) { create_for_repository(:data_dictionary_field) }
     let(:title_field) { DataDictionary::Field.all.to_a.keep_if { |f| f.label == 'title' }.first }
     let(:reloaded_dictionary_field) { Valkyrie.config.metadata_adapter.query_service.find_by(id: dictionary_field.id) }
-
-    before do
-      dictionary_field
-    end
 
     describe 'GET #index' do
       it 'returns a success response' do

--- a/spec/cho/work_object/edit_spec.rb
+++ b/spec/cho/work_object/edit_spec.rb
@@ -3,8 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Editing work objects', type: :feature do
-  let(:work) { build(:work, title: 'Work to edit') }
-  let(:resource) { Valkyrie.config.metadata_adapter.persister.save(resource: work) }
+  let(:resource) { create_for_repository(:work, title: 'Work to edit') }
   let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
 
   context 'with all the required metadata' do

--- a/spec/cho/work_object/show_spec.rb
+++ b/spec/cho/work_object/show_spec.rb
@@ -3,15 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Showing a work object', type: :feature do
-  # @todo This persists the work in both Postgres and Solr, so we can display it, and then view the
-  # edit form. It would be nice if we could build this process into FactoryGirl to make it easier.
-  let!(:work) do
-    work = nil
-    Valkyrie::MetadataAdapter.find(:indexing_persister).persister.buffer_into_index do |buffered_adapter|
-      work = buffered_adapter.persister.save(resource: build(:work, title: 'An editable file'))
-    end
-    work
-  end
+  let(:work) { create_for_repository(:work, title: 'An editable file') }
 
   it 'displays its show page and links to the edit form' do
     visit(polymorphic_path([:solr_document], id: work.id))

--- a/spec/cho/work_object/work_objects_controller_spec.rb
+++ b/spec/cho/work_object/work_objects_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe WorkObjectsController, type: :controller do
   let(:metadata_adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
-  let(:resource) { Valkyrie.config.metadata_adapter.persister.save(resource: build(:work)) }
+  let(:resource) { create_for_repository(:work) }
 
   describe 'GET #new' do
     it 'returns a success response' do
@@ -22,13 +22,13 @@ RSpec.describe WorkObjectsController, type: :controller do
 
   describe 'POST #create' do
     let(:valid_attributes) { { title: 'New Title', work_type: 'type' } }
-    let(:resource) { metadata_adapter.query_service.find_all.to_a.last }
+    let(:resource) { WorkObject.all.last }
 
     context 'with valid params' do
       it 'creates a new WorkObject' do
         expect {
           post :create, params: { work_object: valid_attributes }
-        }.to change { metadata_adapter.query_service.find_all.to_a.count }.by(1)
+        }.to change { WorkObject.count }.by(1)
       end
 
       it 'redirects to the created work' do
@@ -51,7 +51,7 @@ RSpec.describe WorkObjectsController, type: :controller do
     let(:new_attributes) { { title: 'Updated Title' } }
 
     context 'with valid params' do
-      let(:updated_resource) { metadata_adapter.query_service.find_by(id: resource.id) }
+      let(:updated_resource) { WorkObject.find(resource.id) }
 
       it 'updates the requested work' do
         put :update, params: { id: resource.to_param, work_object: new_attributes }

--- a/spec/factories/field.rb
+++ b/spec/factories/field.rb
@@ -12,10 +12,9 @@ FactoryGirl.define do
     display_transformation 'no_transformation'
     multiple false
     validation 'no_validation'
-  end
 
-  to_create do |resource|
-    change_set = DataDictionary::FieldChangeSet.new(resource)
-    Valkyrie.config.metadata_adapter.persister.save(resource: change_set)
+    to_create do |resource|
+      Valkyrie.config.metadata_adapter.persister.save(resource: resource)
+    end
   end
 end

--- a/spec/factories/work_objects.rb
+++ b/spec/factories/work_objects.rb
@@ -4,5 +4,9 @@ FactoryGirl.define do
   factory :work_object, aliases: [:work] do
     title 'Sample Generic Work'
     work_type 'Generic'
+
+    to_create do |resource|
+      Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: resource)
+    end
   end
 end

--- a/spec/support/create_for_repository.rb
+++ b/spec/support/create_for_repository.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Factories in Factory Girl don't return the value returned via `to_create`.
+# This custom strategy is necessary to enable data mapper patterns in Factory
+# Girl.
+#
+# Copied from:
+#   https://github.com/thoughtbot/factory_girl/issues/565
+class CreateStategyForRepositoryPattern
+  def association(runner)
+    runner.run
+  end
+
+  def result(evaluation)
+    result = nil
+    evaluation.object.tap do |instance|
+      evaluation.notify(:after_build, instance)
+      evaluation.notify(:before_create, instance)
+      result = evaluation.create(instance)
+      evaluation.notify(:after_create, result)
+    end
+
+    result
+  end
+end
+FactoryGirl.register_strategy(:create_for_repository, CreateStategyForRepositoryPattern)


### PR DESCRIPTION
This uses a new method for creating factory resources that allows us to
use the data mapper pattern. It was copied from Princeton's Figgy
application, which was in turn taking from an issue in FactoryGirl
itself.

FactoryGirl doesn't support persistence via a data mapper pattern, but
the CreateStategyForRepositoryPattern adds the ability to it.