### PR TITLE
Removing subject and author from catalog controller

### DIFF
--- a/app/blacklight/catalog_controller.rb
+++ b/app/blacklight/catalog_controller.rb
@@ -134,26 +134,6 @@ class CatalogController < ApplicationController
     # case for a BL "search field", which is really a dismax aggregate
     # of Solr search fields.
 
-    config.add_search_field('author') do |field|
-      field.solr_parameters = { 'spellcheck.dictionary': 'author' }
-      field.solr_local_parameters = {
-        qf: '$author_qf',
-        pf: '$author_pf'
-      }
-    end
-
-    # Specifying a :qt only to show it's possible, and so our internal automated
-    # tests can test it. In this case it's the same as
-    # config[:default_solr_parameters][:qt], so isn't actually neccesary.
-    config.add_search_field('subject') do |field|
-      field.solr_parameters = { 'spellcheck.dictionary': 'subject' }
-      field.qt = 'search'
-      field.solr_local_parameters = {
-        qf: '$subject_qf',
-        pf: '$subject_pf'
-      }
-    end
-
     # "sort results by" select (pulldown)
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc

--- a/spec/blacklight/catalog_spec.rb
+++ b/spec/blacklight/catalog_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Catalog page', type: :feature do
     it 'returns a null search' do
       visit('/catalog')
       fill_in('q', with: query)
-      expect(page).to have_select('search_field', options: ['Title', 'All Fields', 'Author', 'Subject'])
+      expect(page).to have_select('search_field', options: ['Title', 'All Fields'])
       click_button('Search')
       within('.constraints-container') do
         expect(page).to have_link('Start Over')


### PR DESCRIPTION
If the user wants a subject or author field they should define a DataDictionary field.  This refrence conflicted with the data dictionary fields