### PR TITLE
Add find_using as a class method

### DIFF
--- a/app/cho/shared/common_queries.rb
+++ b/app/cho/shared/common_queries.rb
@@ -13,5 +13,11 @@ module CommonQueries
     def find(id)
       Valkyrie.config.metadata_adapter.query_service.custom_queries.find_model(model: self, id: id)
     end
+
+    def find_using(query)
+      query[:model] = self
+      Valkyrie.config.metadata_adapter.query_service.custom_queries.find_using(query)
+    end
+    alias_method :where, :find_using
   end
 end

--- a/app/valkyrie/find_using.rb
+++ b/app/valkyrie/find_using.rb
@@ -14,8 +14,9 @@ class FindUsing
   end
 
   def find_using(query)
+    model = query.delete(:model)
     raise ArgumentError, 'only one query term is supported' if query.length > 1
-    sql = "SELECT * FROM orm_resources WHERE metadata @> '{\"#{query.keys.first}\":\"#{query.values.first}\"}';"
+    sql = "SELECT * FROM orm_resources WHERE #{build_where_clause(query, model)};"
     run_query(sql)
   end
 
@@ -23,5 +24,11 @@ class FindUsing
     orm_class.find_by_sql(sql).lazy.map do |object|
       resource_factory.to_resource(object: object)
     end
+  end
+
+  def build_where_clause(query, model)
+    clause = ["metadata @> '{\"#{query.keys.first}\":\"#{query.values.first}\"}'"]
+    clause.push("internal_resource = '#{model}'") if model
+    clause.join(' AND ')
   end
 end

--- a/spec/cho/shared/common_queries_spec.rb
+++ b/spec/cho/shared/common_queries_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe CommonQueries do
     class CommonResource < Valkyrie::Resource
       include CommonQueries
       attribute :id, Valkyrie::Types::ID.optional
+      attribute :label, Valkyrie::Types::String
     end
   end
 
@@ -15,6 +16,12 @@ RSpec.describe CommonQueries do
   end
 
   subject { CommonResource }
+
+  describe '#where' do
+    it 'is aliased to #find_using' do
+      expect(CommonResource.method(:find_using) == CommonResource.method(:where)).to be(true)
+    end
+  end
 
   context 'with no resources present' do
     its(:all)   { is_expected.to be_empty }
@@ -62,6 +69,19 @@ RSpec.describe CommonQueries do
       subject { CommonResource.find(common_resource.id) }
 
       its(:id) { is_expected.to eq(common_resource.id) }
+    end
+  end
+
+  context "with the resource we're looking for" do
+    let(:resource1) { CommonResource.new(label: 'first resource') }
+    let(:resource2) { CommonResource.new(label: 'second resource') }
+
+    it 'retrieves a resource based on its label' do
+      persisted_resource = Valkyrie.config.metadata_adapter.persister.save(resource: resource1)
+      Valkyrie.config.metadata_adapter.persister.save(resource: resource2)
+      results = CommonResource.find_using(label: 'first resource')
+      expect(results.count).to eq(1)
+      expect(results.first.id).to eq(persisted_resource.id)
     end
   end
 end


### PR DESCRIPTION
This takes the existing find_using custom query and extends it to
Valkyrie resources so that we can run ad hoc queries on specific
resource types. Ex:

    >  MyClass.find_using(label: 'foo')
    => [MyClass< label: foo>]

I've found myself needing this feature lately as I look for specific work types and fields via their labels. It's been aliased to `where` to give it a more ActiveRecord flavor.