### PR TITLE
Truncate orm_resources table in test

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,5 +1,20 @@
 # frozen_string_literal: true
 
+# Remove any artifacts leftover in the database from a previous test run.
+#   Because fields are assigned dynamically, this must be done here before
+#   the test suite is initialized.
+conn = PG.connect(dbname: Rails.configuration.database_configuration['test']['database'])
+
+sql = "SELECT EXISTS (
+   SELECT 1
+   FROM   information_schema.tables
+   WHERE  table_schema = 'schema_name'
+   AND    table_name = 'orm_resources'
+   );"
+
+exists = conn.exec(sql).values.reduce
+conn.exec('truncate table orm_resources') unless exists.include?('f')
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 


### PR DESCRIPTION
This prevents the test suite from failing to start after debugging a
previous run. If you use `byebug` and then forcibly quit the debugger,
there are artifacts leftover in the database that must be removed even
before the application can start up.