### PR TITLE
 Implement set of required work types

### DIFF
--- a/app/blacklight/catalog_controller.rb
+++ b/app/blacklight/catalog_controller.rb
@@ -155,7 +155,6 @@ class CatalogController < ApplicationController
     config.autocomplete_enabled = true
     config.autocomplete_path = 'suggest'
 
-    config.add_nav_action :work
     config.add_nav_action :data_dictionary
   end
 end

--- a/app/cho/work/submission_indexer.rb
+++ b/app/cho/work/submission_indexer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Work
+  class SubmissionIndexer
+    attr_reader :resource
+    def initialize(resource:)
+      @resource = resource
+    end
+
+    def to_solr
+      return {} unless resource.try(:work_type)
+      {
+        work_type_ssim: label_for_id
+      }
+    end
+
+    # @return [String]
+    # @note returns the label associated with the work_type_id
+    def label_for_id
+      work_type = Work::Type.find(Valkyrie::ID.new(resource.work_type))
+      return resource.work_type if work_type.nil?
+      work_type.label
+    end
+  end
+end

--- a/app/cho/work/submissions_controller.rb
+++ b/app/cho/work/submissions_controller.rb
@@ -7,7 +7,13 @@ module Work
 
     # GET /works/new
     def new
-      @work = SubmissionChangeSet.new(Submission.new).prepopulate!
+      work_type = params.fetch(:work_type, nil)
+      if work_type
+        @work = SubmissionChangeSet.new(Submission.new(work_type: work_type)).prepopulate!
+      else
+        flash[:alert] = 'You must specify a work type'
+        redirect_to(root_path)
+      end
     end
 
     # GET /works/1/edit

--- a/app/cho/work/type.rb
+++ b/app/cho/work/type.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Work
+  class Type < Valkyrie::Resource
+    include Valkyrie::Resource::AccessControls
+    include CommonQueries
+
+    attribute :id, Valkyrie::Types::ID.optional
+    attribute :label, Valkyrie::Types::String
+    attribute :metadata_schema_id, Valkyrie::Types::ID.optional
+    attribute :processing_schema, Valkyrie::Types::String
+    attribute :display_schema, Valkyrie::Types::String
+  end
+end

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -4,6 +4,7 @@
       <li><%= action %></li>
     <% end %>
     <%= render '/collection/nav' %>
+    <%= render '/work/submissions/nav' %>
   </ul>
 
   <% if has_user_authentication_provider? %>

--- a/app/views/application/_work.html.erb
+++ b/app/views/application/_work.html.erb
@@ -1,1 +1,0 @@
-<%= link_to t('cho.header_links.new_work'), new_work_path, class: 'nav-link' %>

--- a/app/views/work/submissions/_nav.html.erb
+++ b/app/views/work/submissions/_nav.html.erb
@@ -1,0 +1,10 @@
+<li class="dropdown">
+  <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+    <%= t('cho.header_links.create_submission') %> <span class="caret"></span>
+  </a>
+  <ul class="dropdown-menu">
+    <% Work::Type.all.each do |type| %>
+      <li><%= link_to type.label, new_work_path(work_type: type.id) %></li>
+    <% end %>
+  </ul>
+</li>

--- a/app/views/work/submissions/new.html.erb
+++ b/app/views/work/submissions/new.html.erb
@@ -1,24 +1,31 @@
-<h1>New Work</h1>
+<%# move this into the change set or some other kind of form object %>
+<% work_type = Work::Type.find(Valkyrie::ID.new(@work.work_type)) %>
 
-<%= form_for(@work.model, url: works_path) do |form| %>
+<% if work_type %>
+  <h1>New <%= work_type.label %> Submission</h1>
 
-  <%- @work.fields.except('work_type').each do |field_name, field_value| %>
-    <p>
-      <%= form.label field_name %><br>
-      <%= form.text_field field_name %>
-    </p>
-  <%- end  %>
+  <%= form_for(@work.model, url: works_path) do |form| %>
 
-  <p>
-    <%= form.label :work_type %><br>
-    <%= form.select :work_type, ["Generic", "Still Image", "Map", "Document", "Audio/Visual"] %>
-  </p>
+    <%- @work.fields.except('work_type').each do |field_name, field_value| %>
+      <p>
+        <%= form.label field_name %><br>
+        <%= form.text_field field_name %>
+      </p>
+    <%- end  %>
 
-  <%= render 'errors', work: @work if @work.errors.any? %>
+    <%= form.hidden_field :work_type, value: work_type.id %>
 
-  <div class="actions">
-    <%= form.submit %>
-  </div>
+    <%= render 'errors', work: @work if @work.errors.any? %>
+
+    <div class="actions">
+      <%= form.submit %>
+    </div>
+  <% end %>
+
+<% else %>
+
+<p>Unable to find work type</p>
+
 <% end %>
 
 <%= link_to 'Back', works_path %>

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -14,9 +14,20 @@ Rails.application.config.to_prepare do
     :memory
   )
 
+  # Valkyrie::MetadataAdapter.register(
+  #   Valkyrie::Persistence::Solr::MetadataAdapter.new(connection: Blacklight.default_index.connection,
+  #                                                    resource_indexer: Valkyrie::Indexers::AccessControlsIndexer),
+  #   :index_solr
+  # )
+
   Valkyrie::MetadataAdapter.register(
-    Valkyrie::Persistence::Solr::MetadataAdapter.new(connection: Blacklight.default_index.connection,
-                                                     resource_indexer: Valkyrie::Indexers::AccessControlsIndexer),
+    Valkyrie::Persistence::Solr::MetadataAdapter.new(
+      connection: Blacklight.default_index.connection,
+      resource_indexer: Valkyrie::Persistence::Solr::CompositeIndexer.new(
+        Valkyrie::Indexers::AccessControlsIndexer,
+        Work::SubmissionIndexer
+      )
+    ),
     :index_solr
   )
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,79 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+# Loads required fields, schemas, and work types for use with CHO
+
+# @todo move this to a CSV-based process
+def title_field
+  DataDictionary::Field.new(
+    label: 'title',
+    requirement_designation: 'required_to_publish',
+    field_type: 'string',
+    validation: 'no_validation',
+    controlled_vocabulary: 'no_vocabulary',
+    display_transformation: 'no_transformation',
+    multiple: true,
+    help_text: 'help me',
+    index_type: 'no_facet'
+  )
+end
+
+# @todo move this to a CSV-based process
+def subtitle_field
+  DataDictionary::Field.new(
+    label: 'subtitle',
+    requirement_designation: 'optional',
+    field_type: 'string',
+    validation: 'no_validation',
+    controlled_vocabulary: 'no_vocabulary',
+    display_transformation: 'no_transformation',
+    multiple: true,
+    help_text: 'help me',
+    index_type: 'no_facet'
+  )
+end
+
+# @todo move this to a CSV-based process
+def description_field
+  DataDictionary::Field.new(
+    label: 'description',
+    requirement_designation: 'optional',
+    field_type: 'string',
+    validation: 'no_validation',
+    controlled_vocabulary: 'no_vocabulary',
+    display_transformation: 'no_transformation',
+    multiple: true,
+    help_text: 'help me',
+    index_type: 'no_facet'
+  )
+end
+
+def default_metadata_schema
+  Schema::Metadata.new(
+    label: 'default',
+    core_fields: DataDictionary::Field.all.map(&:id)
+  )
+end
+
+def work_type(type)
+  Work::Type.new(
+    label: type,
+    metadata_schema_id: Schema::Metadata.find_using(label: 'default').first.id,
+    processing_schema: 'default',
+    display_schema: 'default'
+  )
+end
+
+def load_work_types
+  ["Generic", "Document", "Still Image", "Map", "Moving Image", "Audio"].each do |type|
+    seed_resource(work_type(type))
+  end
+end
+
+def seed_resource(resource)
+  return if resource.class.where(label: resource.label).count > 0
+  Valkyrie.config.metadata_adapter.persister.save(resource: resource)
+end
+
+seed_resource(default_metadata_schema)
+seed_resource(title_field)
+seed_resource(subtitle_field)
+seed_resource(description_field)
+load_work_types

--- a/spec/cho/home_page_spec.rb
+++ b/spec/cho/home_page_spec.rb
@@ -6,10 +6,7 @@ RSpec.describe 'Home Page', type: :feature do
   it 'has all the navigation options' do
     visit('/')
     expect(page).to have_content('Cultural Heritage Objects')
-    expect(page).to have_link('New Work')
     expect(page).to have_link('Data Dictionary')
-    click_link('New Work')
-    expect(page).to have_css("form[action='/works']")
     click_link('Data Dictionary')
     expect(page).to have_content('Data Dictionary Fields')
     expect(page).to have_link('Create Collection')
@@ -19,5 +16,10 @@ RSpec.describe 'Home Page', type: :feature do
     expect(page).to have_content('New Library Collection')
     click_link('Curated Collection')
     expect(page).to have_content('New Curated Collection')
+    expect(page).to have_link('Create Submission')
+    click_link('Generic')
+    expect(page).to have_content('New Generic Submission')
+    click_link('Document')
+    expect(page).to have_content('New Document Submission')
   end
 end

--- a/spec/cho/work/submissions/indexer_spec.rb
+++ b/spec/cho/work/submissions/indexer_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Work::SubmissionIndexer do
+  let(:indexer) { described_class.new(resource: resource) }
+
+  describe '#to_solr' do
+    subject { indexer.to_solr }
+
+    context "when the resource doesn't have a work type" do
+      let(:resource) { instance_double('Resource') }
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when the resource's work type is nil" do
+      let(:resource) { instance_double('Resource', work_type: nil) }
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when the resource's work type isn't an id or doesn't exist" do
+      let(:resource) { instance_double('Resource', work_type: "I don't exist") }
+
+      it { is_expected.to eq(work_type_ssim: "I don't exist") }
+    end
+
+    context "when the resource's work type does exist" do
+      let(:work_type) { create_for_repository(:work_type, label: 'Indexed Label') }
+      let(:resource) { instance_double('Resource', work_type: work_type.id) }
+
+      it { is_expected.to eq(work_type_ssim: 'Indexed Label') }
+    end
+  end
+end

--- a/spec/cho/work/submissions/new_spec.rb
+++ b/spec/cho/work/submissions/new_spec.rb
@@ -3,11 +3,20 @@
 require 'rails_helper'
 
 RSpec.describe Work::Submission, type: :feature do
+  context 'when no work type is provided' do
+    it 'redirects to the home page with an error' do
+      visit(new_work_path)
+      expect(page).to have_content('You must specify a work type')
+    end
+  end
+
   context 'when filling in all the required fields' do
     it 'creates a new work object' do
-      visit(new_work_path)
+      visit(root_path)
+      click_link('Create Submission')
+      click_link('Generic')
+      expect(page).to have_content('New Generic Submission')
       fill_in('work_submission[title]', with: 'New Title')
-      select('Generic', from: 'work_submission[work_type]')
       click_button('Create Submission')
       expect(page).to have_content('New Title')
       expect(page).to have_content('Generic')
@@ -17,10 +26,24 @@ RSpec.describe Work::Submission, type: :feature do
 
   context 'without providing a title' do
     it 'reports the errors' do
-      visit(new_work_path)
-      select('Generic', from: 'work_submission[work_type]')
+      visit(root_path)
+      click_link('Create Submission')
+      click_link('Document')
+      expect(page).to have_content('New Document Submission')
       click_button('Create Submission')
       expect(page).to have_content("Title can't be blank")
+      fill_in('work_submission[title]', with: 'Required Title')
+      click_button('Create Submission')
+      expect(page).to have_content('Required Title')
+      expect(page).to have_content('Document')
+      expect(page).to have_link('Edit')
+    end
+  end
+
+  context 'with a non-existent work type' do
+    it 'reports the error in the form' do
+      visit(new_work_path(work_type: 'bogus-work-type-id'))
+      expect(page).to have_content('Unable to find work type')
     end
   end
 end

--- a/spec/cho/work/submissions/submissions_controller_spec.rb
+++ b/spec/cho/work/submissions/submissions_controller_spec.rb
@@ -8,10 +8,19 @@ RSpec.describe Work::SubmissionsController, type: :controller do
   let(:index_solr)    { Valkyrie::MetadataAdapter.find(:index_solr) }
 
   describe 'GET #new' do
-    it 'returns a success response' do
-      get :new
-      expect(response).to be_success
-      expect(assigns(:work)).to be_a(Work::SubmissionChangeSet)
+    context 'with a work type' do
+      it 'returns a success response' do
+        get :new, params: { work_type: 'type' }
+        expect(response).to be_success
+        expect(assigns(:work)).to be_a(Work::SubmissionChangeSet)
+      end
+    end
+
+    context 'without a work type' do
+      it 'redirects to the home page' do
+        get :new
+        expect(response).to redirect_to('/')
+      end
     end
   end
 

--- a/spec/cho/work/type_spec.rb
+++ b/spec/cho/work/type_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'valkyrie/specs/shared_specs'
+
+RSpec.describe Work::Type do
+  let(:resource_klass) { described_class }
+
+  it_behaves_like 'a Valkyrie::Resource'
+
+  describe '#label' do
+    it 'is nil when not set' do
+      expect(resource_klass.new.label).to be_nil
+    end
+
+    it 'can be set as an attribute' do
+      resource = resource_klass.new(label: 'test')
+      expect(resource.attributes[:label]).to eq('test')
+    end
+
+    it 'is included in the list of attributes' do
+      expect(resource_klass.new.has_attribute?(:label)).to eq true
+    end
+
+    it 'is included in the list of fields' do
+      expect(resource_klass.fields).to include(:label)
+    end
+  end
+
+  describe '#display_schema' do
+    it 'is nil when not set' do
+      expect(resource_klass.new.metadata_schema_id).to be_nil
+    end
+
+    it 'can be set as an attribute' do
+      resource = resource_klass.new(metadata_schema_id: 'test')
+      expect(resource.attributes[:metadata_schema_id]).to eq(Valkyrie::ID.new('test'))
+    end
+
+    it 'is included in the list of attributes' do
+      expect(resource_klass.new.has_attribute?(:metadata_schema_id)).to eq true
+    end
+
+    it 'is included in the list of fields' do
+      expect(resource_klass.fields).to include(:metadata_schema_id)
+    end
+  end
+
+  describe '#processing_schema' do
+    it 'is nil when not set' do
+      expect(resource_klass.new.processing_schema).to be_nil
+    end
+
+    it 'can be set as an attribute' do
+      resource = resource_klass.new(processing_schema: 'test')
+      expect(resource.attributes[:processing_schema]).to eq('test')
+    end
+
+    it 'is included in the list of attributes' do
+      expect(resource_klass.new.has_attribute?(:processing_schema)).to eq true
+    end
+
+    it 'is included in the list of fields' do
+      expect(resource_klass.fields).to include(:processing_schema)
+    end
+  end
+
+  describe '#display_schema' do
+    it 'is nil when not set' do
+      expect(resource_klass.new.display_schema).to be_nil
+    end
+
+    it 'can be set as an attribute' do
+      resource = resource_klass.new(display_schema: 'test')
+      expect(resource.attributes[:display_schema]).to eq('test')
+    end
+
+    it 'is included in the list of attributes' do
+      expect(resource_klass.new.has_attribute?(:display_schema)).to eq true
+    end
+
+    it 'is included in the list of fields' do
+      expect(resource_klass.fields).to include(:display_schema)
+    end
+  end
+end

--- a/spec/factories/work_types.rb
+++ b/spec/factories/work_types.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :work_type, class: Work::Type do
+    label 'Sample Work Type'
+
+    to_create do |resource|
+      Valkyrie.config.metadata_adapter.persister.save(resource: resource)
+    end
+  end
+end

--- a/spec/support/seed_map.rb
+++ b/spec/support/seed_map.rb
@@ -10,6 +10,9 @@ class SeedMAP
       Valkyrie.config.metadata_adapter.persister.save(resource: title_field)
       Valkyrie.config.metadata_adapter.persister.save(resource: subtitle_field)
       Valkyrie.config.metadata_adapter.persister.save(resource: description_field)
+      Valkyrie.config.metadata_adapter.persister.save(resource: default_metadata_schema)
+      Valkyrie.config.metadata_adapter.persister.save(resource: generic_work_type)
+      Valkyrie.config.metadata_adapter.persister.save(resource: document_work_type)
     end
 
     def title_field
@@ -51,6 +54,31 @@ class SeedMAP
         multiple: true,
         help_text: 'help me',
         index_type: 'no_facet'
+      )
+    end
+
+    def default_metadata_schema
+      Schema::Metadata.new(
+        label: 'default',
+        core_fields: DataDictionary::Field.all.map(&:id)
+      )
+    end
+
+    def generic_work_type
+      Work::Type.new(
+        label: 'Generic',
+        metadata_schema_id: Schema::Metadata.find_using(label: 'default').first.id,
+        processing_schema: 'default',
+        display_schema: 'default'
+      )
+    end
+
+    def document_work_type
+      Work::Type.new(
+        label: 'Document',
+        metadata_schema_id: Schema::Metadata.find_using(label: 'default').first.id,
+        processing_schema: 'default',
+        display_schema: 'default'
       )
     end
   end

--- a/spec/views/work_submissions/new.html.erb_spec.rb
+++ b/spec/views/work_submissions/new.html.erb_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'work/submissions/new', type: :view do
-  let(:change_set) { Work::SubmissionChangeSet.new(Work::Submission.new) }
+  let(:work_type)  { Work::Type.where(label: 'Document').first }
+  let(:change_set) { Work::SubmissionChangeSet.new(Work::Submission.new(work_type: work_type.id)) }
 
   before do
     assign(:work, change_set)


### PR DESCRIPTION
This gives us the ability to create new works with pre-defined work types. It does not include the changes required to make the work form display only fields that are available via the work type. I'd like to see that work get separated out into a different ticket, because there may be some outstanding questions, but mainly I wanted to get these changes up and in front of our eyes sooner rather than later.

![works](https://user-images.githubusercontent.com/312085/35991946-ce331490-0cd6-11e8-90f6-e3f25f1323b8.png)

