### PR TITLE
Add facet for collection types, ref #374

### DIFF
--- a/app/blacklight/catalog_controller.rb
+++ b/app/blacklight/catalog_controller.rb
@@ -81,7 +81,8 @@ class CatalogController < ApplicationController
     #  (useful when user clicks "more" on a large facet and wants to navigate alphabetically across a large set of results)
     # :index_range can be an array or range of prefixes that will be used to create the navigation (note: It is case sensitive when searching values)
 
-    config.add_facet_field 'work_type_ssim', label: 'Work Type'
+    config.add_facet_field 'work_type_ssim', label: I18n.t('cho.field_label.work_type')
+    config.add_facet_field 'collection_type_ssim', label: I18n.t('cho.field_label.collection_type')
     # config.add_facet_field 'pub_date', label: 'Publication Year', single: true
     # config.add_facet_field 'subject_topic_facet', label: 'Topic', limit: 20, index_range: 'A'..'Z'
     # config.add_facet_field 'language_facet', label: 'Language', limit: true
@@ -104,15 +105,17 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
-    config.add_index_field 'work_type_ssim', label: 'Work Type'
-    config.add_index_field 'visibility_ssim', label: 'Visibility'
-    config.add_index_field 'workflow_ssim', label: 'Workflow'
+    config.add_index_field 'work_type_ssim', label: I18n.t('cho.field_label.work_type')
+    config.add_index_field 'visibility_ssim', label: I18n.t('cho.field_label.visibility')
+    config.add_index_field 'workflow_ssim', label: I18n.t('cho.field_label.workflow')
+    config.add_index_field 'collection_type_ssim', label: I18n.t('cho.field_label.collection_type')
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
-    config.add_show_field 'work_type_ssim', label: 'Work Type'
-    config.add_show_field 'visibility_ssim', label: 'Visibility'
-    config.add_show_field 'workflow_ssim', label: 'Workflow'
+    config.add_show_field 'work_type_ssim', label: I18n.t('cho.field_label.work_type')
+    config.add_show_field 'visibility_ssim', label: I18n.t('cho.field_label.visibility')
+    config.add_show_field 'workflow_ssim', label: I18n.t('cho.field_label.workflow')
+    config.add_show_field 'collection_type_ssim', label: I18n.t('cho.field_label.collection_type')
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/cho/collection/type_indexer.rb
+++ b/app/cho/collection/type_indexer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Collection
+  class TypeIndexer
+    attr_reader :resource
+    def initialize(resource:)
+      @resource = resource
+    end
+
+    def to_solr
+      return {} unless resource.class.to_s.split('::').include?('Collection')
+      {
+        collection_type_ssim: resource.model_name.human.titleize
+      }
+    end
+  end
+end

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -14,18 +14,13 @@ Rails.application.config.to_prepare do
     :memory
   )
 
-  # Valkyrie::MetadataAdapter.register(
-  #   Valkyrie::Persistence::Solr::MetadataAdapter.new(connection: Blacklight.default_index.connection,
-  #                                                    resource_indexer: Valkyrie::Indexers::AccessControlsIndexer),
-  #   :index_solr
-  # )
-
   Valkyrie::MetadataAdapter.register(
     Valkyrie::Persistence::Solr::MetadataAdapter.new(
       connection: Blacklight.default_index.connection,
       resource_indexer: Valkyrie::Persistence::Solr::CompositeIndexer.new(
         Valkyrie::Indexers::AccessControlsIndexer,
-        Work::SubmissionIndexer
+        Work::SubmissionIndexer,
+        Collection::TypeIndexer
       )
     ),
     :index_solr

--- a/config/locales/cho.yml
+++ b/config/locales/cho.yml
@@ -4,3 +4,9 @@ en:
       metadata: "Basic Metadata"
       workflow: "Workflow"
       visibility: "Visibility"
+    field_label:
+      # For fields that are not in the data dictionary
+      collection_type: "Collection Type"
+      work_type: "Work Type"
+      workflow: "Workflow"
+      visibility: "Visibility"

--- a/spec/cho/collection/archival_collections/index_spec.rb
+++ b/spec/cho/collection/archival_collections/index_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Collection::Archival, type: :feature do
+  before { create_for_repository(:archival_collection, title: 'Archival collection index view') }
+
+  it 'displays facets and the collection in an index view' do
+    visit(root_path)
+    within('div#facet-collection_type_ssim') do
+      click_link('Archival Collection')
+    end
+    within('div.documents-list') do
+      expect(page).to have_link('Archival collection index view')
+      expect(page).to have_blacklight_label('title_tesim').with('Title')
+      expect(page).to have_blacklight_field('title_tesim').with('Archival collection index view')
+      expect(page).to have_blacklight_label('collection_type_ssim').with('Collection Type')
+      expect(page).to have_blacklight_field('collection_type_ssim').with('Archival Collection')
+    end
+  end
+end

--- a/spec/cho/collection/curated_collections/index_spec.rb
+++ b/spec/cho/collection/curated_collections/index_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Collection::Curated, type: :feature do
+  before { create_for_repository(:curated_collection, title: 'Curated collection index view') }
+
+  it 'displays facets and the collection in an index view' do
+    visit(root_path)
+    within('div#facet-collection_type_ssim') do
+      click_link('Curated Collection')
+    end
+    within('div.documents-list') do
+      expect(page).to have_link('Curated collection index view')
+      expect(page).to have_blacklight_label('title_tesim').with('Title')
+      expect(page).to have_blacklight_field('title_tesim').with('Curated collection index view')
+      expect(page).to have_blacklight_label('collection_type_ssim').with('Collection Type')
+      expect(page).to have_blacklight_field('collection_type_ssim').with('Curated Collection')
+    end
+  end
+end

--- a/spec/cho/collection/library_collections/index_spec.rb
+++ b/spec/cho/collection/library_collections/index_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Collection::Library, type: :feature do
+  before { create_for_repository(:library_collection, title: 'Library collection index view') }
+
+  it 'displays facets and the collection in an index view' do
+    visit(root_path)
+    within('div#facet-collection_type_ssim') do
+      click_link('Library Collection')
+    end
+    within('div.documents-list') do
+      expect(page).to have_link('Library collection index view')
+      expect(page).to have_blacklight_label('title_tesim').with('Title')
+      expect(page).to have_blacklight_field('title_tesim').with('Library collection index view')
+      expect(page).to have_blacklight_label('collection_type_ssim').with('Collection Type')
+      expect(page).to have_blacklight_field('collection_type_ssim').with('Library Collection')
+    end
+  end
+end

--- a/spec/cho/collection/type_indexer_spec.rb
+++ b/spec/cho/collection/type_indexer_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Collection::TypeIndexer do
+  let(:indexer) { described_class.new(resource: resource) }
+
+  describe '#to_solr' do
+    subject { indexer.to_solr }
+
+    context 'with an archival collection' do
+      let(:resource) { Collection::Archival.new }
+
+      it { is_expected.to eq(collection_type_ssim: 'Archival Collection') }
+    end
+
+    context 'with a library collection' do
+      let(:resource) { Collection::Library.new }
+
+      it { is_expected.to eq(collection_type_ssim: 'Library Collection') }
+    end
+
+    context 'with a curated collection' do
+      let(:resource) { Collection::Curated.new }
+
+      it { is_expected.to eq(collection_type_ssim: 'Curated Collection') }
+    end
+
+    context 'with a submission' do
+      let(:resource) { Work::Submission.new }
+
+      it { is_expected.to be_empty }
+    end
+  end
+end

--- a/spec/support/matchers/blacklight.rb
+++ b/spec/support/matchers/blacklight.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :have_blacklight_field do |field|
+  match do |_actual|
+    within('dd.blacklight-' + field) do
+      page.has_content(value)
+    end
+  end
+
+  chain :with do |value|
+    @value = value
+  end
+end
+
+RSpec::Matchers.define :have_blacklight_label do |field|
+  match do |_actual|
+    within('dt.blacklight-' + field) do
+      page.has_content(value)
+    end
+  end
+
+  chain :with do |value|
+    @value = value
+  end
+end


### PR DESCRIPTION
## Description

Each collection type should have a facet for discovery of additional
collections of the same type. This adds a custom indexer to index the
collection type value into Solr.

## Changes

Are there any major changes in this PR that will change the release process? No.

## Checklist

- [x] i18n enabled
- [x] adequate test coverage
- [x] accessible interface
