### PR TITLE
Accessible Form Updates and i18n

### DIFF
--- a/app/assets/stylesheets/form.scss
+++ b/app/assets/stylesheets/form.scss
@@ -1,0 +1,13 @@
+// Place all the styles related to the Collection Form here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/
+
+h1        { margin-bottom: 2rem; }
+fieldset  { margin-bottom: 3rem; }
+legend    { border: none; }
+.basic_metadata input { margin-bottom: 1rem; }
+.no_bold  { font-weight: normal; }
+.required {
+  color: red;
+  vertical-align: super;
+}

--- a/app/views/collection/archival_collections/new.html.erb
+++ b/app/views/collection/archival_collections/new.html.erb
@@ -1,4 +1,4 @@
-<h1>New Archival Collection</h1>
+<h1>New <%= t('cho.header_links.archival_collection') %></h1>
 
 <%= render 'collection/base/form', collection: @collection %>
 

--- a/app/views/collection/base/_form.html.erb
+++ b/app/views/collection/base/_form.html.erb
@@ -1,48 +1,41 @@
 <%= form_with(model: collection) do |form| %>
+  <fieldset class="basic_metadata">
+    <legend><%= t('cho.form.metadata')%></legend>
+    <%= form.label :title do %>
+      Title<span class="required no_bold"> required</span>
+    <% end %>
+      <%= form.text_field :title, id: :title, :required => true %>
+    <%= form.label :subtitle %>
+      <%= form.text_field :subtitle, id: :subtitle %>
+    <%= form.label :description %>
+    <%= form.text_area :description, id: :description %>
+  </fieldset>
 
-  <p>
-    <%= form.label :title %><br>
-    <%= form.text_field :title %>
-  </p>
-
-  <p>
-    <%= form.label :subtitle %><br>
-    <%= form.text_field :subtitle %>
-  </p>
-
-  <p>
-    <%= form.label :description %><br>
-    <%= form.text_area :description %>
-  </p>
-
-  <p>
-    <%= form.label :workflow %><br>
-
-    <%= form.label :workflow_default do %>
-      <%= form.radio_button :workflow, "default" %> Publish immediately
+  <fieldset>
+    <legend><%= t('cho.form.workflow')%></legend>
+    <%= form.label :workflow_default, class: :no_bold do %>
+      <%= form.radio_button :workflow, "default", id: :workflow_default %> Publish immediately
     <% end %>
 
-    <%= form.label :workflow_mediated do %>
-      <%= form.radio_button :workflow, "mediated" %> Mediated
+    <%= form.label :workflow_mediated, class: :no_bold do %>
+      <%= form.radio_button :workflow, "mediated", id: :workflow_mediated %> Mediated
     <% end %>
-  </p>
+  </fieldset>
 
-
-  <p>
-    <%= form.label :visibility %><br>
-
-    <%= form.label :visibility_public do %>
-      <%= form.radio_button :visibility, "public" %> Public
+  <fieldset>
+    <legend><%= t('cho.form.visibility')%></legend>
+    <%= form.label :visibility_public, class: :no_bold do %>
+      <%= form.radio_button :visibility, "public", id: :visibility_public %> Public
     <% end %>
 
-    <%= form.label :visibility_authenticated do %>
-      <%= form.radio_button :visibility, "authenticated" %> Authenticated
+    <%= form.label :visibility_authenticated, class: :no_bold do %>
+      <%= form.radio_button :visibility, "authenticated", id: :visibility_authenticated %> Authenticated
     <% end %>
 
-    <%= form.label :visibility_private do %>
-      <%= form.radio_button :visibility, "private" %> Private
+    <%= form.label :visibility_private, class: :no_bold do %>
+      <%= form.radio_button :visibility, "private", id: :visibility_private %> Private
     <% end %>
-  </p>
+  </fieldset>
 
   <%= render '/work/submissions/errors', work: collection if collection.errors.any? %>
 

--- a/app/views/collection/curated_collections/new.html.erb
+++ b/app/views/collection/curated_collections/new.html.erb
@@ -1,4 +1,4 @@
-<h1>New Curated Collection</h1>
+<h1>New <%= t('cho.header_links.curated_collection') %></h1>
 
 <%= render 'collection/base/form', collection: @collection %>
 

--- a/app/views/collection/library_collections/new.html.erb
+++ b/app/views/collection/library_collections/new.html.erb
@@ -1,4 +1,4 @@
-<h1>New Library Collection</h1>
+<h1>New <%= t('cho.header_links.library_collection') %></h1>
 
 <%= render 'collection/base/form', collection: @collection %>
 

--- a/config/locales/cho.yml
+++ b/config/locales/cho.yml
@@ -1,0 +1,6 @@
+en:
+  cho:
+    form:
+      metadata: "Basic Metadata"
+      workflow: "Workflow"
+      visibility: "Visibility"

--- a/spec/views/archival_collections/edit.html.erb_spec.rb
+++ b/spec/views/archival_collections/edit.html.erb_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe 'collection/archival_collections/edit', type: :view do
       assert_select 'textarea[name=?]', 'archival_collection[description]'
       assert_select 'input[name=?]', 'archival_collection[workflow]'
       assert_select 'input[name=?]', 'archival_collection[visibility]'
+      # Added to make sure accessibility changes are in place
+      assert_select 'legend', 'Basic Metadata'
+      assert_select 'label', 'Title required'
+      assert_select 'legend', 'Workflow'
+      assert_select 'legend', 'Visibility'
     end
   end
 end

--- a/spec/views/archival_collections/new.html.erb_spec.rb
+++ b/spec/views/archival_collections/new.html.erb_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe 'collection/archival_collections/new', type: :view do
       assert_select 'textarea[name=?]', 'archival_collection[description]'
       assert_select 'input[name=?]', 'archival_collection[workflow]'
       assert_select 'input[name=?]', 'archival_collection[visibility]'
+      # Added to make sure accessibility changes are in place
+      assert_select 'legend', 'Basic Metadata'
+      assert_select 'label', 'Title required'
+      assert_select 'legend', 'Workflow'
+      assert_select 'legend', 'Visibility'
     end
   end
 end

--- a/spec/views/curated_collections/edit.html.erb_spec.rb
+++ b/spec/views/curated_collections/edit.html.erb_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe 'collection/curated_collections/edit', type: :view do
       assert_select 'textarea[name=?]', 'curated_collection[description]'
       assert_select 'input[name=?]', 'curated_collection[workflow]'
       assert_select 'input[name=?]', 'curated_collection[visibility]'
+      # Added to make sure accessibility changes are in place
+      assert_select 'legend', 'Basic Metadata'
+      assert_select 'label', 'Title required'
+      assert_select 'legend', 'Workflow'
+      assert_select 'legend', 'Visibility'
     end
   end
 end

--- a/spec/views/curated_collections/new.html.erb_spec.rb
+++ b/spec/views/curated_collections/new.html.erb_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe 'collection/curated_collections/new', type: :view do
       assert_select 'textarea[name=?]', 'curated_collection[description]'
       assert_select 'input[name=?]', 'curated_collection[workflow]'
       assert_select 'input[name=?]', 'curated_collection[visibility]'
+      # Added to make sure accessibility changes are in place
+      assert_select 'legend', 'Basic Metadata'
+      assert_select 'label', 'Title required'
+      assert_select 'legend', 'Workflow'
+      assert_select 'legend', 'Visibility'
     end
   end
 end

--- a/spec/views/library_collections/edit.html.erb_spec.rb
+++ b/spec/views/library_collections/edit.html.erb_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe 'collection/library_collections/edit', type: :view do
       assert_select 'textarea[name=?]', 'library_collection[description]'
       assert_select 'input[name=?]', 'library_collection[workflow]'
       assert_select 'input[name=?]', 'library_collection[visibility]'
+      # Added to make sure accessibility changes are in place
+      assert_select 'legend', 'Basic Metadata'
+      assert_select 'label', 'Title required'
+      assert_select 'legend', 'Workflow'
+      assert_select 'legend', 'Visibility'
     end
   end
 end

--- a/spec/views/library_collections/new.html.erb_spec.rb
+++ b/spec/views/library_collections/new.html.erb_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe 'collection/library_collections/new', type: :view do
       assert_select 'textarea[name=?]', 'library_collection[description]'
       assert_select 'input[name=?]', 'library_collection[workflow]'
       assert_select 'input[name=?]', 'library_collection[visibility]'
+      # Added to make sure accessibility changes are in place
+      assert_select 'legend', 'Basic Metadata'
+      assert_select 'label', 'Title required'
+      assert_select 'legend', 'Workflow'
+      assert_select 'legend', 'Visibility'
     end
   end
 end


### PR DESCRIPTION
Fixes #378 and #373 

## Description
Running through the interface to swap hard coded text with i18n translations and reworked the collection form for better accessibility. Refactors labels and inputs surrounded with paragraph tags and hard coded breaks with fieldset, legends for organizing form controls into a group for users of accessible technology. Also adds required to title for both the label and the input.

Why was this necessary?
In order to populate text changes in the UI throughout the system easily, we are converting things like titles, labels, buttons, etc. to i18n to have consistent text and easier updates.
Also to target some accessibility errors. We need to have at least one field required, so that librarians can find work in progress in the UI.

## Changes
Uses the existing i18n for the collections from the dropdown menu for the headers on the forms for collections. Updates the collection form to use better accessibility practices, adds i18n translation, and some form styles. Form fields are now grouped with fieldsets for better organization.

Are there any major changes in this PR that will change the release process?
Nope.

## Checklist

- [x] i18n enabled
- [x] adequate test coverage
- [x] accessible interface
