### PR TITLE
Adding core field flag to data dictionary

### DIFF
--- a/app/cho/data_dictionary/field.rb
+++ b/app/cho/data_dictionary/field.rb
@@ -16,6 +16,7 @@ module DataDictionary
     attribute :display_name, Valkyrie::Types::String
     attribute :multiple, Valkyrie::Types::Strict::Bool
     attribute :help_text, Valkyrie::Types::String
+    attribute :core_field, Valkyrie::Types::Strict::Bool
 
     def multiple?
       return false if multiple.nil?

--- a/app/cho/data_dictionary/field_change_set.rb
+++ b/app/cho/data_dictionary/field_change_set.rb
@@ -27,17 +27,21 @@ module DataDictionary
     property :index_type, multiple: false, default: 'no_facet'
     validates :index_type, inclusion: { in: Field::IndexTypes.values }
 
+    property :core_field, multiple: false, default: false
+    validates :core_field, with: :coerce_into_boolean
+
     # rubocop:disable Style/NumericPredicate
     # Rubocop wants to use {multiple.zero?} but that breaks things.
     # Need to find a better way to coerce booleans.
-    def coerce_into_boolean(_field)
-      return if multiple.is_a?(TrueClass) || multiple.is_a?(FalseClass)
-      if multiple == 'false' || multiple == '0' || multiple == 0
-        self.multiple = false
-      elsif multiple == 'true' || multiple == '1' || multiple == 1
-        self.multiple = true
+    def coerce_into_boolean(field)
+      field_value = self[field]
+      return if field_value.is_a?(TrueClass) || field_value.is_a?(FalseClass)
+      if ['false', '0', 0].include? field_value
+        send("#{field}=", false)
+      elsif ['true', '1', 1].include? field_value
+        send("#{field}=", true)
       else
-        errors.add(:multiple, 'is the wrong type')
+        errors.add(field, 'is the wrong type')
       end
     end
     # rubocop:enable Style/NumericPredicate

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,7 +11,8 @@ def title_field
     display_transformation: 'no_transformation',
     multiple: true,
     help_text: 'help me',
-    index_type: 'no_facet'
+    index_type: 'no_facet',
+    core_field: true
   )
 end
 
@@ -26,7 +27,8 @@ def subtitle_field
     display_transformation: 'no_transformation',
     multiple: true,
     help_text: 'help me',
-    index_type: 'no_facet'
+    index_type: 'no_facet',
+    core_field: true
   )
 end
 
@@ -41,7 +43,8 @@ def description_field
     display_transformation: 'no_transformation',
     multiple: true,
     help_text: 'help me',
-    index_type: 'no_facet'
+    index_type: 'no_facet',
+    core_field: true
   )
 end
 
@@ -72,8 +75,8 @@ def seed_resource(resource)
   Valkyrie.config.metadata_adapter.persister.save(resource: resource)
 end
 
-seed_resource(default_metadata_schema)
 seed_resource(title_field)
 seed_resource(subtitle_field)
 seed_resource(description_field)
+seed_resource(default_metadata_schema)
 load_work_types

--- a/spec/cho/data_dictionary/csv_importer_spec.rb
+++ b/spec/cho/data_dictionary/csv_importer_spec.rb
@@ -3,8 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe DataDictionary::CsvImporter do
-  let(:header) { "Label,Field Type,Requirement Designation,Validation,Multiple,Controlled Vocabulary,Default Value,Display Name,Display Transformation\n" }
-  let(:csv_field1) { "abc123_label,date,recommended,no_validation,false,no_vocabulary,abc123,My Abc123,no_transformation\n" }
+  let(:header) { "Label,Field Type,Requirement Designation,Validation,Multiple,Controlled Vocabulary,Default Value,Display Name,Display Transformation,Core Field\n" }
+  let(:csv_field1) { "abc123_label,date,recommended,no_validation,false,no_vocabulary,abc123,My Abc123,no_transformation,true\n" }
 
   let(:file) { StringIO.new(header + csv_field1) }
 

--- a/spec/cho/data_dictionary/field_spec.rb
+++ b/spec/cho/data_dictionary/field_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe DataDictionary::Field, type: :model do
   it { is_expected.to respond_to(:display_transformation) }
   it { is_expected.to respond_to(:help_text) }
   it { is_expected.to respond_to(:index_type) }
+  it { is_expected.to respond_to(:core_field) }
 
   it 'can be optional' do
     model.optional!
@@ -86,7 +87,8 @@ RSpec.describe DataDictionary::Field, type: :model do
                                 multiple: false,
                                 requirement_designation: 'recommended',
                                 updated_at: saved_model.updated_at,
-                                validation: 'no_validation' } }
+                                validation: 'no_validation',
+                                core_field: false } }
 
     its(:attributes) { is_expected.to eq(expected_metadata) }
   end

--- a/spec/cho/schema/metadata_field_spec.rb
+++ b/spec/cho/schema/metadata_field_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe Schema::MetadataField, type: :model do
                       default_value: 'abc123',
                       display_name: 'My Abc123',
                       display_transformation: 'no_transformation',
-                      multiple: false, validation: 'no_validation', order_index: 0 }
+                      multiple: false, validation: 'no_validation',
+                      core_field: false, order_index: 0 }
 
   it_behaves_like 'a Valkyrie::Resource'
 
@@ -49,6 +50,7 @@ RSpec.describe Schema::MetadataField, type: :model do
                                 requirement_designation: 'recommended',
                                 updated_at: saved_model.updated_at,
                                 validation: 'no_validation',
+                                core_field: false,
                                 order_index: 0 } }
 
     its(:attributes) { is_expected.to eq(expected_metadata) }

--- a/spec/factories/field.rb
+++ b/spec/factories/field.rb
@@ -14,6 +14,7 @@ FactoryGirl.define do
     validation 'no_validation'
     help_text 'help me'
     index_type 'no_facet'
+    core_field false
 
     to_create do |resource|
       Valkyrie.config.metadata_adapter.persister.save(resource: resource)

--- a/spec/factories/schema_metadata_field.rb
+++ b/spec/factories/schema_metadata_field.rb
@@ -14,6 +14,7 @@ FactoryGirl.define do
     validation 'no_validation'
     help_text 'help me'
     index_type 'no_facet'
+    core_field false
     order_index 0
 
     to_create do |resource|

--- a/spec/support/seed_map.rb
+++ b/spec/support/seed_map.rb
@@ -25,7 +25,8 @@ class SeedMAP
         display_transformation: 'no_transformation',
         multiple: true,
         help_text: 'help me',
-        index_type: 'no_facet'
+        index_type: 'no_facet',
+        core_field: true
       )
     end
 
@@ -39,7 +40,8 @@ class SeedMAP
         display_transformation: 'no_transformation',
         multiple: true,
         help_text: 'help me',
-        index_type: 'no_facet'
+        index_type: 'no_facet',
+        core_field: false
       )
     end
 
@@ -53,7 +55,8 @@ class SeedMAP
         display_transformation: 'no_transformation',
         multiple: true,
         help_text: 'help me',
-        index_type: 'no_facet'
+        index_type: 'no_facet',
+        core_field: true
       )
     end
 


### PR DESCRIPTION
refs #322.

## Description

Adding a flag to the data dictionary so that core fields can be define in the data dictionary.  I need this for #376 becuase the metadata schema needs to be able to get both core and additional fields from the data dictionary and we need a way to split them up.

## Changes

1. Adding a Flag to the Data Dictionary
2. Updating Tests to use the flag

Are there any major changes in this PR that will change the release process? No

## Checklist

- [x] i18n enabled
- [x] adequate test coverage
- [x] accessible interface
