### PR TITLE
Quick Accessibility Fix with Form For and ID

### DIFF
--- a/app/views/collection/base/_form.html.erb
+++ b/app/views/collection/base/_form.html.erb
@@ -1,39 +1,39 @@
-<%= form_with(model: collection) do |form| %>
+<%= form_for(@collection.model) do |form| %>
   <fieldset class="basic_metadata">
     <legend><%= t('cho.form.metadata')%></legend>
     <%= form.label :title do %>
       Title<span class="required no_bold"> required</span>
     <% end %>
-      <%= form.text_field :title, id: :title, :required => true %>
+      <%= form.text_field :title, :required => true %>
     <%= form.label :subtitle %>
-      <%= form.text_field :subtitle, id: :subtitle %>
+      <%= form.text_field :subtitle %>
     <%= form.label :description %>
-    <%= form.text_area :description, id: :description %>
+    <%= form.text_area :description %>
   </fieldset>
 
   <fieldset>
     <legend><%= t('cho.form.workflow')%></legend>
     <%= form.label :workflow_default, class: :no_bold do %>
-      <%= form.radio_button :workflow, "default", id: :workflow_default %> Publish immediately
+      <%= form.radio_button :workflow, "default" %> Publish immediately
     <% end %>
 
     <%= form.label :workflow_mediated, class: :no_bold do %>
-      <%= form.radio_button :workflow, "mediated", id: :workflow_mediated %> Mediated
+      <%= form.radio_button :workflow, "mediated" %> Mediated
     <% end %>
   </fieldset>
 
   <fieldset>
     <legend><%= t('cho.form.visibility')%></legend>
     <%= form.label :visibility_public, class: :no_bold do %>
-      <%= form.radio_button :visibility, "public", id: :visibility_public %> Public
+      <%= form.radio_button :visibility, "public" %> Public
     <% end %>
 
     <%= form.label :visibility_authenticated, class: :no_bold do %>
-      <%= form.radio_button :visibility, "authenticated", id: :visibility_authenticated %> Authenticated
+      <%= form.radio_button :visibility, "authenticated" %> Authenticated
     <% end %>
 
     <%= form.label :visibility_private, class: :no_bold do %>
-      <%= form.radio_button :visibility, "private", id: :visibility_private %> Private
+      <%= form.radio_button :visibility, "private" %> Private
     <% end %>
   </fieldset>
 


### PR DESCRIPTION
Swaps `form_with` back to `form_for` to get the label and input ids to match.

## Description

Using the new `form_with` does not automatically generate the ID for the input and when I use the same symbol from the `label` element to explicitly set the ID it doesn't prepend the value with the collection type.

References ticket: (if any)
#386 

Why was this necessary?
In order to gain greater accessibility with form controls and labels, the  value of the `for` attribute and the `id` need to match.

## Changes
Swaps `form_with` to be `form_for` instead

Are there any major changes in this PR that will change the release process?
No

## Checklist

- [x] i18n enabled
- [x] adequate test coverage
- [x] accessible interface
