### PR TITLE
Title is Required for Works

### DIFF
--- a/app/assets/stylesheets/form.scss
+++ b/app/assets/stylesheets/form.scss
@@ -5,7 +5,7 @@
 h1        { margin-bottom: 2rem; }
 fieldset  { margin-bottom: 3rem; }
 legend    { border: none; }
-.basic_metadata input { margin-bottom: 1rem; }
+input     { margin-bottom: 1rem; }
 .no_bold  { font-weight: normal; }
 .required {
   color: red;

--- a/app/cho/data_dictionary/fields_for_change_set.rb
+++ b/app/cho/data_dictionary/fields_for_change_set.rb
@@ -11,8 +11,8 @@ module DataDictionary::FieldsForChangeSet
     #   This statement makes sure the rails environment can be loaded even if the database has yet to be created.
     if ActiveRecord::Base.connection.table_exists? 'orm_resources'
       DataDictionary::Field.all.each do |field|
-        property field.label.parameterize.underscore.to_sym, multiple: field.multiple?, required: field.required_to_publish?
-        validates field.label.parameterize.underscore.to_sym, presence: field.required_to_publish?
+        property field.label.parameterize.underscore.to_sym, multiple: field.multiple?, required: field.required?
+        validates field.label.parameterize.underscore.to_sym, presence: field.required?
       end
     end
   end

--- a/app/cho/data_dictionary/with_requirement_designation.rb
+++ b/app/cho/data_dictionary/with_requirement_designation.rb
@@ -3,10 +3,18 @@
 module DataDictionary::WithRequirementDesignation
   extend ActiveSupport::Concern
 
-  RequirementDesignations = Valkyrie::Types::String.enum('required_to_publish', 'recommended', 'optional')
+  RequirementDesignations = Valkyrie::Types::String.enum('required', 'required_to_publish', 'recommended', 'optional')
 
   included do
     attribute :requirement_designation, RequirementDesignations
+  end
+
+  def required!
+    self.requirement_designation = 'required'
+  end
+
+  def required?
+    requirement_designation == 'required'
   end
 
   def required_to_publish!

--- a/app/views/collection/base/_form.html.erb
+++ b/app/views/collection/base/_form.html.erb
@@ -4,7 +4,7 @@
     <%= form.label :title do %>
       Title<span class="required no_bold"> required</span>
     <% end %>
-      <%= form.text_field :title, :required => true %>
+      <%= form.text_field :title, :required => true, 'aria-required' => true  %>
     <%= form.label :subtitle %>
       <%= form.text_field :subtitle %>
     <%= form.label :description %>

--- a/app/views/work/submissions/_form.html.erb
+++ b/app/views/work/submissions/_form.html.erb
@@ -1,10 +1,16 @@
 <%= form_for(work_form.model, url: work_form.form_path) do |form| %>
 
   <%- work_form.fields.each do |metadata_field| %>
-    <p>
-      <%= form.label metadata_field.label, metadata_field.display_name %><br>
+    <% if metadata_field.requirement_designation == 'required' %>
+      <%= form.label metadata_field.label, metadata_field.display_name do %>
+        <%= metadata_field.label.titleize %><span class="required no_bold"> required</span>
+      <% end %>
+      <%= form.text_field metadata_field.label, :required => true, 'aria-required' => true %>
+    <% else %>
+      <%= form.label metadata_field.label, metadata_field.display_name %>
       <%= form.text_field metadata_field.label %>
-    </p>
+    <% end %>
+
   <%- end  %>
 
   <%= form.hidden_field :work_type, value: work_form.work_type.id %>

--- a/data_dictionary.csv
+++ b/data_dictionary.csv
@@ -1,5 +1,5 @@
 Label,Field Type,Requirement Designation,Validation,Multiple,Controlled Vocabulary,Default Value,Display Name,Display Transformation,Index Type,Help Text,Core Field
-title,string,required_to_publish,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,true
+title,string,required,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,true
 subtitle,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,true
 description,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,true
 generic_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false

--- a/spec/cho/data_dictionary/fields_controller_spec.rb
+++ b/spec/cho/data_dictionary/fields_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe DataDictionary::FieldsController, type: :controller do
     {
       'label' => 'title',
       'field_type' => 'string',
-      'requirement_designation' => 'required_to_publish',
+      'requirement_designation' => 'required',
       'validation' => 'no_validation',
       'multiple' => true,
       'controlled_vocabulary' => 'no_vocabulary',
@@ -102,7 +102,7 @@ RSpec.describe DataDictionary::FieldsController, type: :controller do
         get :index, params: {}, session: valid_session, format: :csv
         expect(response.content_type).to eq('text/csv')
         expect(response.body).to include("Label,Field Type,Requirement Designation,Validation,Multiple,Controlled Vocabulary,Default Value,Display Name,Display Transformation,Index Type,Help Text,Core Field\n")
-        expect(response.body).to include("title,string,required_to_publish,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,true\n")
+        expect(response.body).to include("title,string,required,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,true\n")
         expect(response.body).to include("abc123_label,date,recommended,no_validation,false,no_vocabulary,abc123,My Abc123,no_transformation,no_facet,help me,false\n")
       end
     end

--- a/spec/cho/schema/metadata_field_spec.rb
+++ b/spec/cho/schema/metadata_field_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Schema::MetadataField, type: :model do
                                 internal_resource: 'Schema::MetadataField',
                                 label: 'title',
                                 multiple: true,
-                                requirement_designation: 'required_to_publish',
+                                requirement_designation: 'required',
                                 order_index: nil,
                                 validation: 'no_validation' } }
 


### PR DESCRIPTION
## Description

Title is required for the creation of works. Loops through the data dictionary and looks for the fields with the required attribute and adds the additional aria attribute and the span for the required text. Replaces `required_to_publish` with `required` where needed.

References ticket: (if any)
#373 

Why was this necessary?

We need at least one identifying field, so that librarians can find unfinished work in a listing of works.

## Changes

Adds aria required attributes for the title input. Adds the requireddesignation to the data dictionary ruby file and the csv.

Updates style sheet to add bottom margin to all inputs and make the submissions form look for a required designation and add CSS and required attributes to the field. Uses the label for the block, makes the lable titleized, and adds the critical required span. Updates some tests for the title field to be required and no longer just required to publish.

Switches required to publish to required in the fields for change set so that the other change set tests pass without modification. We still want to test for the absence of title.

Are there any major changes in this PR that will change the release process?

## Checklist

- [x] i18n enabled
- [x] adequate test coverage
- [x] accessible interface
