### PR TITLE
Adds Additional translations for the Interface

### DIFF
--- a/app/views/collection/base/_form.html.erb
+++ b/app/views/collection/base/_form.html.erb
@@ -2,7 +2,7 @@
   <fieldset class="basic_metadata">
     <legend><%= t('cho.form.metadata')%></legend>
     <%= form.label :title do %>
-      Title<span class="required no_bold"> required</span>
+      <%= t('cho.field_label.title') %><span class="required no_bold"> <%= t('cho.field_label.required') %></span>
     <% end %>
       <%= form.text_field :title, :required => true, 'aria-required' => true  %>
     <%= form.label :subtitle %>
@@ -14,26 +14,26 @@
   <fieldset>
     <legend><%= t('cho.form.workflow')%></legend>
     <%= form.label :workflow_default, class: :no_bold do %>
-      <%= form.radio_button :workflow, "default" %> Publish immediately
+      <%= form.radio_button :workflow, "default" %> <%= t('cho.field_label.default') %>
     <% end %>
 
     <%= form.label :workflow_mediated, class: :no_bold do %>
-      <%= form.radio_button :workflow, "mediated" %> Mediated
+      <%= form.radio_button :workflow, "mediated" %> <%= t('cho.field_label.mediated') %>
     <% end %>
   </fieldset>
 
   <fieldset>
     <legend><%= t('cho.form.visibility')%></legend>
     <%= form.label :visibility_public, class: :no_bold do %>
-      <%= form.radio_button :visibility, "public" %> Public
+      <%= form.radio_button :visibility, "public" %> <%= t('cho.field_label.public') %>
     <% end %>
 
     <%= form.label :visibility_authenticated, class: :no_bold do %>
-      <%= form.radio_button :visibility, "authenticated" %> Authenticated
+      <%= form.radio_button :visibility, "authenticated" %> <%= t('cho.field_label.authenticated') %>
     <% end %>
 
     <%= form.label :visibility_private, class: :no_bold do %>
-      <%= form.radio_button :visibility, "private" %> Private
+      <%= form.radio_button :visibility, "private" %> <%= t('cho.field_label.private') %>
     <% end %>
   </fieldset>
 

--- a/config/locales/cho.yml
+++ b/config/locales/cho.yml
@@ -9,7 +9,18 @@ en:
       collection_type: "Collection Type"
       work_type: "Work Type"
       workflow: "Workflow"
+      default: "Publish immediately"
+      mediated: "Mediated"
       visibility: "Visibility"
+      public: "Public"
+      authenticated: "Authenticated"
+      private: "Private"
+      title: "Title"
+      required: "required"
+    header_links:
+      create_collection: "Create Collection"
+      create_submission: "Create Work"
+      data_dictionary: "Data Dictionary"
     work:
       new:
         heading: "New %{type} Work"
@@ -24,4 +35,3 @@ en:
         delete_link: "Delete Work"
         delete_confirmation: "Are you sure?"
       error: "%{count} prohibited this work from being saved:"
-

--- a/spec/cho/home_page_spec.rb
+++ b/spec/cho/home_page_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Home Page', type: :feature do
     expect(page).to have_content('New Library Collection')
     click_link('Curated Collection')
     expect(page).to have_content('New Curated Collection')
-    expect(page).to have_link('Create Submission')
+    expect(page).to have_link('Create Work')
     click_link('Generic')
     expect(page).to have_content('New Generic Work')
     click_link('Document')

--- a/spec/cho/work/submissions/new_spec.rb
+++ b/spec/cho/work/submissions/new_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Work::Submission, type: :feature do
   context 'when filling in all the required fields' do
     it 'creates a new work object' do
       visit(root_path)
-      click_link('Create Submission')
+      click_link('Create Work')
       click_link('Generic')
       expect(page).to have_content('New Generic Work')
       fill_in('work_submission[title]', with: 'New Title')
@@ -27,7 +27,7 @@ RSpec.describe Work::Submission, type: :feature do
   context 'without providing a title' do
     it 'reports the errors' do
       visit(root_path)
-      click_link('Create Submission')
+      click_link('Create Work')
       click_link('Document')
       expect(page).to have_content('New Document Work')
       expect(page).to have_link('Back')


### PR DESCRIPTION
## Description

Swaps out hard coded text for the interface with translations in the cho yml.

References ticket: (if any)
#378 
Why was this necessary?
Hard coded text in the interface is hard to change in multiple places. Much better to write it once and reference it everywhere.

## Changes

Adds translation for the navigation links and the collection form until it is changed to pull from the data dictionary. Updates the tests to use work instead of submission.

Are there any major changes in this PR that will change the release process?

## Checklist

- [x] i18n enabled
- [x] adequate test coverage
- [x] accessible interface
