### PR TITLE
Add exists? method to CommonQueries

### DIFF
--- a/app/cho/shared/common_queries.rb
+++ b/app/cho/shared/common_queries.rb
@@ -19,5 +19,18 @@ module CommonQueries
       Valkyrie.config.metadata_adapter.query_service.custom_queries.find_using(query)
     end
     alias_method :where, :find_using
+
+    # @param [String, Valkyrie::ID]
+    def exists?(parameter)
+      id = parameter.is_a?(Valkyrie::ID) ? parameter : Valkyrie::ID.new(parameter)
+      result = Valkyrie.config.metadata_adapter.query_service.find_by(id: id)
+      if result.class == self
+        true
+      else
+        raise TypeError, "Expecting #{self}, but found #{result.class} instead"
+      end
+    rescue Valkyrie::Persistence::ObjectNotFoundError
+      false
+    end
   end
 end


### PR DESCRIPTION
## Description

Returns true if the record exists, false if it does not, and raises an error if it exists but as a different class than the one being queried.

Why was this necessary? This would be helpful in many different contexts.

## Changes

Are there any major changes in this PR that will change the release process? No

## Checklist

- [x] i18n enabled
- [x] adequate test coverage
- [x] accessible interface
