### PR TITLE
Add simple test coverage for rails application classes

### DIFF
--- a/spec/application/application_cable/channel_spec.rb
+++ b/spec/application/application_cable/channel_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationCable::Channel do
+  it { expect(described_class).to be < ActionCable::Channel::Base }
+end

--- a/spec/application/application_cable/connection_spec.rb
+++ b/spec/application/application_cable/connection_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationCable::Connection do
+  it { expect(described_class).to be < ActionCable::Connection::Base }
+end

--- a/spec/application/application_job_spec.rb
+++ b/spec/application/application_job_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationJob do
+  it { expect(described_class).to be < ActiveJob::Base }
+end

--- a/spec/application/application_mailer_spec.rb
+++ b/spec/application/application_mailer_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationMailer, type: :mailer do
+  describe 'default email from' do
+    subject { described_class.default[:from] }
+
+    it { is_expected.to eq('from@example.com') }
+  end
+end


### PR DESCRIPTION
## Description

Why was this necessary? Coveralls had some 0% tests for some of our Rails application classes.

## Changes

Are there any major changes in this PR that will change the release process? No

## Checklist

- [x] i18n enabled
- [x] adequate test coverage
- [x] accessible interface
