### PR TITLE
WAVE Report Errors and Warnings

### DIFF
--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -10,3 +10,13 @@
   text-indent: 2%;
   width: 500px;
 }
+
+// styles to address inconsistent usage of search widgets
+.catalog_startOverLink:hover,
+.search-widgets .btn:hover { color: #FFF; }
+
+// addresses insufficient color contrast
+.dl-invert dt { color: #686868; }
+
+// Button visited link color
+.btn-danger:visited { color: #FFF; }

--- a/app/assets/stylesheets/form.scss
+++ b/app/assets/stylesheets/form.scss
@@ -8,6 +8,6 @@ legend    { border: none; }
 input     { margin-bottom: 1rem; }
 .no_bold  { font-weight: normal; }
 .required {
-  color: red;
+  color: #df0000;
   vertical-align: super;
 }

--- a/app/blacklight/catalog_controller.rb
+++ b/app/blacklight/catalog_controller.rb
@@ -3,6 +3,8 @@
 class CatalogController < ApplicationController
   include Blacklight::Catalog
 
+  helper LayoutHelperBehavior
+
   configure_blacklight do |config|
     ## Class for sending and receiving requests from a search index
     # config.repository_class = Blacklight::Solr::Repository

--- a/app/blacklight/layout_helper_behavior.rb
+++ b/app/blacklight/layout_helper_behavior.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Overrides the methods in Blacklight::LayoutHelperBehavior
+module LayoutHelperBehavior
+  ##
+  # Classes added to a document's show content div
+  # @return [String]
+  def show_content_classes
+    'col-sm-8 col-md-9 show-document'
+  end
+
+  ##
+  # Classes added to a document's sidebar div
+  # @return [String]
+  def show_sidebar_classes
+    'col-sm-4 col-md-3'
+  end
+
+  ##
+  # Classes used for sizing the main content of a Blacklight page
+  # @return [String]
+  def main_content_classes
+    'col-sm-8 col-sm-push-4 col-md-9 col-md-push-3'
+  end
+
+  ##
+  # Classes used for sizing the sidebar content of a Blacklight page
+  # @return [String]
+  def sidebar_classes
+    'col-sm-4 col-sm-pull-8 col-md-3 col-md-pull-9'
+  end
+end

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -1,0 +1,25 @@
+<%# Overrides the view from Blacklight so that we have good heading structure for content %>
+<h1 class="sr-only top-content-title"><%= t('blacklight.search.search_results_header') %></h1>
+
+<% @page_title = t('blacklight.search.page_title.title', :constraints => render_search_to_page_title(params), :application_name => application_name) %>
+
+<% content_for(:head) do -%>
+  <%= render_opensearch_response_metadata %>
+  <%= rss_feed_link_tag %>
+  <%= atom_feed_link_tag %>
+  <%= json_api_link_tag %>
+<% end %>
+
+<%= render 'search_header' %>
+
+<h2 class="sr-only"><%= t('blacklight.search.search_results') %></h2>
+
+<%- if @response.empty? %>
+  <%= render "zero_results" %>
+<%- elsif render_grouped_response? %>
+  <%= render_grouped_document_index %>
+<%- else %>
+  <%= render_document_index %>
+<%- end %>
+
+<%= render 'results_pagination' %>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,0 +1,14 @@
+<%# Overrides the view from Blacklight so that the content comes before the sidebar for accessibility %>
+<div id="content" class="<%= main_content_classes %>">
+  <% unless has_search_parameters? %>
+    <%# if there are no input/search related params, display the "home" partial -%>
+    <%= render 'home' %>
+    <%= render 'shared/sitelinks_search_box' %>
+  <% else %>
+    <%= render 'search_results' %>
+  <% end %>
+</div>
+
+<div id="sidebar" class="<%= sidebar_classes %>">
+  <%= render 'search_sidebar' %>
+</div>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,3 +1,4 @@
+<%# Overrides Blacklight view so that we can put the content before the sidebar for accessibility %>
 <div id="content" class="<%= show_content_classes %>">
   <%= render_document_main_content_partial %>
 

--- a/app/views/data_dictionary/fields/index.html.erb
+++ b/app/views/data_dictionary/fields/index.html.erb
@@ -15,7 +15,7 @@
       <th>Default value</th>
       <th>Display name</th>
       <th>Display transformation</th>
-      <th colspan="3"></th>
+      <th>Actions</th>
     </tr>
   </thead>
 

--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -1,0 +1,44 @@
+<%# Overrides the layout from Blacklight because we don't want the application name as the first heading %>
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+
+  <!-- Mobile viewport optimization h5bp.com/ad -->
+  <meta name="HandheldFriendly" content="True">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+
+  <!-- Internet Explorer use the highest version available -->
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+  <!-- Mobile IE allows us to activate ClearType technology for smoothing fonts for easy reading -->
+  <!--[if IEMobile]>
+  <meta http-equiv="cleartype" content="on">
+  <![endif]-->
+
+  <title><%= render_page_title %></title>
+  <%= opensearch_description_tag application_name, opensearch_catalog_url(:format => 'xml') %>
+  <%= favicon_link_tag %>
+  <%= stylesheet_link_tag "application", media: "all" %>
+  <%= javascript_include_tag "application" %>
+  <%= csrf_meta_tags %>
+  <%= content_for(:head) %>
+</head>
+<body class="<%= render_body_class %>">
+<%= render :partial => 'shared/header_navbar' %>
+
+<%= render partial: 'shared/ajax_modal' %>
+
+<div id="main-container" class="<%= container_classes %>">
+
+  <%= render :partial=>'/flash_msg', layout: 'shared/flash_messages' %>
+
+  <div class="row">
+    <%= yield %>
+  </div>
+</div>
+
+<%= render :partial => 'shared/footer' %>
+</body>
+</html>

--- a/app/views/saved_searches/index.html.erb
+++ b/app/views/saved_searches/index.html.erb
@@ -1,0 +1,29 @@
+<%# Overrides the view for better accessibility, heading structure, and swapping table for an unordered list %>
+<% @page_title = t('blacklight.saved_searches.page_title', :application_name => application_name) %>
+
+<div id="content" class="col-md-9">
+  <h1 class='page-heading'><%= t('blacklight.saved_searches.title') %></h1>
+  <%- if current_or_guest_user.blank? -%>
+    <h2 class='section-heading'><%= t('blacklight.saved_searches.need_login') %></h2>
+  <%- elsif @searches.blank? -%>
+    <h2 class='section-heading'><%= t('blacklight.saved_searches.no_searches') %></h2>
+  <%- else -%>
+    <p>
+      <%= link_to t('blacklight.saved_searches.clear.action_title'), blacklight.clear_saved_searches_path, :method => :delete, :data => { :confirm => t('blacklight.saved_searches.clear.action_confirm') } %>
+    </p>
+
+    <h2 class='section-heading'><%= t('blacklight.saved_searches.list_title') %></h2>
+    <ul>
+      <%- @searches.each do |search| -%>
+      <li>
+        <span><%= link_to_previous_search(search.query_params) %></span>
+        <span>
+          &lsqb;
+          <%= link_to t('blacklight.saved_searches.delete'), blacklight.forget_search_path(search.id) %>
+          &rsqb;
+        </span>
+      </li>
+      <%- end -%>
+    </ul>
+  <%- end -%>
+</div>

--- a/app/views/search_history/index.html.erb
+++ b/app/views/search_history/index.html.erb
@@ -1,0 +1,30 @@
+<%# Overrides the view for better accessibility, heading structure, and swapping table for an unordered list %>
+<% @page_title = t('blacklight.search_history.page_title', :application_name => application_name) %>
+
+<div id="content" class="col-md-12">
+  <h1 class='page-heading'><%=t('blacklight.search_history.title')%></h1>
+  <%- if @searches.blank? -%>
+    <h2 class='section-heading'><%=t('blacklight.search_history.no_history')%></h2>
+  <%- else -%>
+    <p>
+      <%= link_to t('blacklight.search_history.clear.action_title'), blacklight.clear_search_history_path, :method => :delete, :data => { :confirm => t('blacklight.search_history.clear.action_confirm') }, :class => 'btn btn-danger pull-right' %>
+    </p>
+    <h2 class='section-heading'><%=t('blacklight.search_history.recent')%></h2>
+    <ul>
+      <%-  @searches.each_with_index do |search,index| -%>
+        <%= content_tag :li, :id => "document_#{index + 1}" do %>
+          <span><%= link_to_previous_search(search_state.reset(search.query_params).to_hash) %></span>
+          <span class="search_history_action">
+            &lsqb;
+            <%- if current_or_guest_user && search.saved? -%>
+              <%= link_to t('blacklight.search_history.forget'), blacklight.forget_search_path(search.id) %>
+            <%- else -%>
+              <%= link_to t('blacklight.search_history.save'), blacklight.save_search_path(search.id), :method => :put %>
+            <%- end -%>
+            &rsqb;
+          </span>
+        <% end #content_tag %>
+      <%- end -%>
+    </ul>
+  <%- end -%>
+</div>

--- a/app/views/work/submissions/_form.html.erb
+++ b/app/views/work/submissions/_form.html.erb
@@ -16,6 +16,8 @@
   <%= form.hidden_field :work_type, value: work_form.work_type.id %>
 
   <%= form.hidden_field :file, value: work_form.model.cached_file_data %>
+
+  <%= form.label :file, class: 'sr-only' %>
   <%= form.file_field :file %>
 
   <%= render 'errors', work: work_form if work_form.errors.any? %>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -4,3 +4,6 @@ en:
     catalog:
       files:
       heading: 'Files'
+    search:
+      search_results_header: 'Search Results'
+      search_results: 'Listing of Search Results'

--- a/spec/blacklight/search_history_spec.rb
+++ b/spec/blacklight/search_history_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Search History Page', type: :feature do
+  describe 'when I have done a search' do
+    before do
+      visit '/'
+      fill_in 'q', with: 'book'
+      click_button 'search'
+      click_link 'History'
+    end
+    it 'shows searches' do
+      expect(page).to have_content 'Your recent searches'
+      expect(page).to have_content 'book'
+      expect(page).not_to have_content 'dang'
+      visit '/'
+      fill_in 'q', with: 'dang'
+      click_button 'search'
+      click_link 'History'
+      expect(page).to have_selector('ul')
+      expect(page).to have_content 'book'
+      expect(page).to have_content 'dang'
+    end
+  end
+end


### PR DESCRIPTION
Refactors the default view so that the main h1 isn't hidden and isn't repeating the name of the application. Refactors the headings and layout for the search results page, so that we have a good document outline and that the content comes before the facets in the code.

Fixes insuficient color contrast and overrides the layout helper for column sizes.

Adds label for the file upload button and a table header for the data dictionary.

Replaces the search history table with an unorderd list.

Aligns HTML for search history and saved searches.

Rubocop fixes.

Fixes the layout helper from blacklight so that the show page doesn't have the pull class to keep the tools column on the right.

## Description

References ticket: (if any)

Why was this necessary?

## Changes

Are there any major changes in this PR that will change the release process?

## Checklist

- [x] i18n enabled
- [x] adequate test coverage
- [x] accessible interface
