### PR TITLE
Tab test Change

### DIFF
--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -20,3 +20,11 @@
 
 // Button visited link color
 .btn-danger:visited { color: #FFF; }
+
+// Adds the colored focus around the Bootstrap dropdown
+.dropdown-toggle:focus {
+  border-color: #66aFe9;
+  box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102,175,233,.6);
+  outline: 2px;
+  outline: -webkit-focus-ring-color auto 5px;
+}


### PR DESCRIPTION
## Description

Adds the outline to the Bootstrap dropdown when tabbing through the interface.

References ticket: (if any) #305 

Why was this necessary?
A visual focus indicator is import for those individuals who navigate through the interface using a keyboard.

## Changes
Updates the blacklight style sheet to target a specific class of a dropdown

Are there any major changes in this PR that will change the release process?

## Checklist

- [x] i18n enabled
- [ ] adequate test coverage
- [x] accessible interface
