### PR TITLE
Remove the Back Link from Forms

### DIFF
--- a/app/views/collection/archival_collections/new.html.erb
+++ b/app/views/collection/archival_collections/new.html.erb
@@ -1,5 +1,3 @@
 <h1>New <%= t('cho.header_links.archival_collection') %></h1>
 
 <%= render 'collection/base/form', collection: @collection %>
-
-<%= link_to 'Back', archival_collections_path %>

--- a/app/views/collection/curated_collections/new.html.erb
+++ b/app/views/collection/curated_collections/new.html.erb
@@ -1,5 +1,3 @@
 <h1>New <%= t('cho.header_links.curated_collection') %></h1>
 
 <%= render 'collection/base/form', collection: @collection %>
-
-<%= link_to 'Back', curated_collections_path %>

--- a/app/views/collection/library_collections/new.html.erb
+++ b/app/views/collection/library_collections/new.html.erb
@@ -1,5 +1,3 @@
 <h1>New <%= t('cho.header_links.library_collection') %></h1>
 
 <%= render 'collection/base/form', collection: @collection %>
-
-<%= link_to 'Back', library_collections_path %>

--- a/app/views/data_dictionary/fields/edit.html.erb
+++ b/app/views/data_dictionary/fields/edit.html.erb
@@ -3,4 +3,3 @@
 <%= render 'form', data_dictionary_field: @data_dictionary_field %>
 
 <%= link_to 'Show', @data_dictionary_field %> |
-<%= link_to 'Back', data_dictionary_fields_path %>

--- a/app/views/data_dictionary/fields/new.html.erb
+++ b/app/views/data_dictionary/fields/new.html.erb
@@ -1,5 +1,3 @@
 <h1>New Data Dictionary Field</h1>
 
 <%= render 'form', data_dictionary_field: @data_dictionary_field %>
-
-<%= link_to 'Back', data_dictionary_fields_path %>

--- a/app/views/data_dictionary/fields/show.html.erb
+++ b/app/views/data_dictionary/fields/show.html.erb
@@ -39,6 +39,3 @@
     <dd><%= @data_dictionary_field.index_type %></dd>
   </dl>
 </div>
-<div class="clearleft">
-  <%= link_to 'Back', data_dictionary_fields_path %>
-</div>

--- a/app/views/work/submissions/edit.html.erb
+++ b/app/views/work/submissions/edit.html.erb
@@ -4,6 +4,5 @@
 <%= render partial: 'form',  locals: { work_form: @work, with_collections: false } %>
 
 <%= link_to t('cho.work.edit.show_link'), work_path(@work.model) %> |
-<%= link_to t('cho.work.edit.back_link'), works_path %> |
 <%= link_to t('cho.work.edit.delete_link'), work_path(@work.model),
             data: {:confirm => t('cho.work.edit.delete_confirmation')}, :method => :delete %>

--- a/app/views/work/submissions/new.html.erb
+++ b/app/views/work/submissions/new.html.erb
@@ -8,5 +8,3 @@
 <p><%= t('cho.work.new.no_type') %></p>
 
 <% end %>
-
-<%= link_to t('cho.work.new.back_link'), works_path %>

--- a/config/locales/cho.yml
+++ b/config/locales/cho.yml
@@ -31,7 +31,6 @@ en:
       edit:
         heading: "Editing Work"
         submit: "Update Work"
-        back_link: "Back"
         show_link: "Show"
         delete_link: "Delete Work"
         delete_confirmation: "Are you sure?"

--- a/spec/cho/collection/archival_collections/show_spec.rb
+++ b/spec/cho/collection/archival_collections/show_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Collection::Archival, type: :feature do
       expect(page).to have_content('public')
       click_link('Edit')
       expect(page).to have_field('archival_collection[title]', with: 'Archival Collection')
+      expect(page).not_to have_link('Back')
     end
   end
 

--- a/spec/cho/collection/curated_collections/show_spec.rb
+++ b/spec/cho/collection/curated_collections/show_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Collection::Curated, type: :feature do
       expect(page).to have_content('public')
       click_link('Edit')
       expect(page).to have_field('curated_collection[title]', with: 'Curated Collection')
+      expect(page).not_to have_link('Back')
     end
   end
 

--- a/spec/cho/collection/library_collections/show_spec.rb
+++ b/spec/cho/collection/library_collections/show_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Collection::Library, type: :feature do
       expect(page).to have_content('public')
       click_link('Edit')
       expect(page).to have_field('library_collection[title]', with: 'Library Collection')
+      expect(page).not_to have_link('Back')
     end
   end
 

--- a/spec/cho/work/submissions/edit_spec.rb
+++ b/spec/cho/work/submissions/edit_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe 'Editing works', type: :feature do
       visit(edit_work_path(resource))
       expect(page).to have_content('Editing Work')
       expect(page).to have_selector('h2', text: 'Work to edit')
-      expect(page).to have_link('Back')
       expect(page).to have_link('Show')
       fill_in('work_submission[title]', with: 'Updated Work Title')
       click_button('Update Work')

--- a/spec/cho/work/submissions/new_spec.rb
+++ b/spec/cho/work/submissions/new_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe Work::Submission, type: :feature do
       click_link('Create Work')
       click_link('Document')
       expect(page).to have_content('New Document Work')
-      expect(page).to have_link('Back')
       click_button('Create Work')
       within('#error_explanation') do
         expect(page).to have_selector('h2', text: '2 errors prohibited this work from being saved:')


### PR DESCRIPTION
## Description
Removes the inconsistently working back link from the interface.

References ticket: (if any) #414 

Why was this necessary?
The back link wasn't working consistently and there are other ways in the interface to get around

## Changes
Deletes the back link from the works and collection views 
Are there any major changes in this PR that will change the release process?

## Checklist

- [ ] i18n enabled
- [ ] adequate test coverage
- [ ] accessible interface
