### PR TITLE
Accessibility for Tables and Screen Reader Adjustments

### DIFF
--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -28,3 +28,21 @@
   outline: 2px;
   outline: -webkit-focus-ring-color auto 5px;
 }
+
+// Adds a skip to content link for keyboard users, but only makes it visible when element receives focus
+.skip a
+{
+  position:absolute;
+  left:-10000px;
+  top:auto;
+  width:1px;
+  height:1px;
+  overflow:hidden;
+}
+
+.skip a:focus
+{
+  position:static;
+  width:auto;
+  height:auto;
+}

--- a/app/views/catalog/_document_members.html.erb
+++ b/app/views/catalog/_document_members.html.erb
@@ -2,8 +2,8 @@
   <table>
     <thead>
       <tr>
-        <td><%= t('cho.collection.members.title') %></td>
-        <td><%= t('cho.collection.members.date_created') %></td>
+        <td scope="col"><%= t('cho.collection.members.title') %></td>
+        <td scope="col"><%= t('cho.collection.members.date_created') %></td>
       </tr>
     </thead>
     <tbody>

--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -26,18 +26,21 @@
   <%= content_for(:head) %>
 </head>
 <body class="<%= render_body_class %>">
+<div class="skip">
+  <a href="#main-container">Skip to main content</a>
+</div>
 <%= render :partial => 'shared/header_navbar' %>
 
 <%= render partial: 'shared/ajax_modal' %>
 
-<div id="main-container" class="<%= container_classes %>">
+<main id="main-container" class="<%= container_classes %>">
 
   <%= render :partial=>'/flash_msg', layout: 'shared/flash_messages' %>
 
   <div class="row">
     <%= yield %>
   </div>
-</div>
+</main>
 
 <%= render :partial => 'shared/footer' %>
 </body>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -16,7 +16,7 @@
   </div>
 </div>
 
-<div id="search-navbar" class="navbar navbar-default navbar-static-top" role="navigation">
+<div id="search-navbar" class="navbar navbar-default navbar-static-top">
   <div class="<%= container_classes %>">
     <%= render_search_bar  %>
   </div>

--- a/spec/cho/home_page_spec.rb
+++ b/spec/cho/home_page_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe 'Home Page', type: :feature do
   it 'has all the navigation options' do
     visit('/')
     expect(page).to have_content('Cultural Heritage Objects')
+    expect(page).to have_link('Skip to main content')
+    expect(page).to have_selector('main')
     expect(page).to have_link('Data Dictionary')
     click_link('Data Dictionary')
     expect(page).to have_content('Data Dictionary Fields')


### PR DESCRIPTION
## Description

Adds a column scope to the header in the table for accessibility, skip to content link for keyboard users, removes an extra ARIA landmark, and switches the main-content div to an HTML5 main element.

References ticket: (if any) #305 

Why was this necessary?
Makes it better for screen reader and keyboard users.

## Changes
Adds the column attribute to the table headers. Removes extra landmark role. Adds skip link to main content. 

Are there any major changes in this PR that will change the release process?

## Checklist

- [x] i18n enabled
- [ ] adequate test coverage
- [x] accessible interface
