### PR TITLE
Updating Capistrano deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -58,18 +58,16 @@ set :linked_files, fetch(:linked_files, []).push(
   'config/role_map.yml',
   'config/secrets.yml',
   'config/solr.yml',
-  'public/robots.txt',
-  'public/sitemap.xml'
+  'public/robots.txt'
 )
 
 set :linked_dirs, fetch(:linked_dirs, []).push(
   'log',
-  'public/system',
-  'public/uploads',
   'tmp/cache',
   'tmp/pids',
   'tmp/sockets',
   'tmp/uploads',
+  'tmp/files',
   'vendor/bundle'
 )
 
@@ -95,10 +93,6 @@ namespace :deploy do
   desc 'set up the shared directory to have the symbolic links to the appropriate directories shared between servers'
   task :symlink_shared_directories do
     on roles(:web, :job) do
-      execute "ln -sf /#{fetch(:application)}/upload_#{fetch(:stage)}/uploads/ /home/deploy/cho/shared/tmp/"
-      execute "ln -sf /#{fetch(:application)}/upload_#{fetch(:stage)}/uploads /home/deploy/cho/shared/public/"
-      execute "ln -sf /#{fetch(:application)}/shared_#{fetch(:stage)}/public/robots.txt /home/deploy/cho/shared/public/robots.txt"
-      execute "ln -sf /#{fetch(:application)}/shared_#{fetch(:stage)}/public/sitemap.xml /home/deploy/cho/shared/public/sitemap.xml"
       execute "ln -sf /#{fetch(:application)}/config_#{fetch(:stage)}/cho/ /home/deploy/cho/shared/config"
     end
   end

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -16,7 +16,7 @@
 # server list. The second argument is a, or duck-types, Hash and is
 # used to set extended properties on the server.
 server 'choweb1qa.vmhost.psu.edu:1855', user: 'deploy', roles: %w(web app db), primary: true
-server 'chojobs1qa.vmhost.psu.edu:1855', user: 'deploy', roles: %w(app job)
+# server 'chojobs1qa.vmhost.psu.edu:1855', user: 'deploy', roles: %w(app job)
 # server 'example.com', user: 'deploy', roles: %w{web app}, my_property: :my_value
 
 # Custom SSH Options


### PR DESCRIPTION
## Description

The initial deploy configuration was copied over from Scholarsphere. Most of this doesn't apply to our current setup, so we're removing it in favor of a simpler configuration.

## Changes

Are there any major changes in this PR that will change the release process? Yes

There are new directories in the server's shared Capistrano directory. These directories must exist when the application is deployed.

## Checklist

- [x] i18n enabled
- [x] adequate test coverage
- [x] accessible interface
