### PR TITLE
Changing production to disk

### DIFF
--- a/config/valkyrie.yml
+++ b/config/valkyrie.yml
@@ -8,4 +8,4 @@ test:
 
 production:
   metadata_adapter: postgres
-  storage_adapter: fedora
+  storage_adapter: disk


### PR DESCRIPTION
Matches up with the configured storage adapter

## Description

References ticket: #359

Why was this necessary?  Is causing a null pointer exception when the storage adapter is used, since fedora is not configured.

## Changes

Are there any major changes in this PR that will change the release process?

## Checklist

- [ ] i18n enabled
- [ ] adequate test coverage
- [ ] accessible interface
