### PR TITLE
Use a metadata schema for collections

### DIFF
--- a/app/cho/collection/change_set_behaviors.rb
+++ b/app/cho/collection/change_set_behaviors.rb
@@ -2,15 +2,9 @@
 
 module Collection::ChangeSetBehaviors
   extend ActiveSupport::Concern
+  include DataDictionary::FieldsForChangeSet
 
   included do
-    property :title, multiple: false, required: true
-    validates :title, presence: true
-
-    property :subtitle, multiple: false, required: false
-
-    property :description, multiple: false, required: false
-
     property :workflow, multiple: false, required: true
     validates :workflow, inclusion: { in: ::Collection::CommonFields::WORKFLOW }
     validates :workflow, presence: true
@@ -19,4 +13,18 @@ module Collection::ChangeSetBehaviors
     validates :visibility, inclusion: { in: ::Collection::CommonFields::VISIBILITY }
     validates :visibility, presence: true
   end
+
+  # @return [Array<Schema::MetadataField>]
+  def form_fields
+    @form_fields ||= ordered_form_fields
+  end
+
+  private
+
+    def ordered_form_fields
+      metadata_schema = Schema::Metadata.find_using(label: 'Collection').first
+      field_ids = metadata_schema.core_fields + metadata_schema.fields
+      unordered_fields = field_ids.map { |id| Schema::MetadataField.find(id) }
+      unordered_fields.sort_by(&:order_index)
+    end
 end

--- a/app/cho/collection/common_fields.rb
+++ b/app/cho/collection/common_fields.rb
@@ -2,15 +2,13 @@
 
 module Collection::CommonFields
   extend ActiveSupport::Concern
+  include DataDictionary::FieldsForObject
 
   WORKFLOW = ['default', 'mediated'].freeze
   VISIBILITY = ['public', 'authenticated', 'private'].freeze
 
   included do
     attribute :id, Valkyrie::Types::ID.optional
-    attribute :title, Valkyrie::Types::String
-    attribute :subtitle, Valkyrie::Types::String
-    attribute :description, Valkyrie::Types::String
     attribute :workflow, Valkyrie::Types::Set.member(Valkyrie::Types::String.enum(*WORKFLOW))
     attribute :visibility, Valkyrie::Types::Set.member(Valkyrie::Types::String.enum(*VISIBILITY))
   end

--- a/app/cho/collection/controller_behaviors.rb
+++ b/app/cho/collection/controller_behaviors.rb
@@ -37,7 +37,7 @@ module Collection::ControllerBehaviors
     change_set_persister.buffer_into_index do |buffered_changeset_persister|
       buffered_changeset_persister.delete(resource: change_set)
     end
-    flash[:alert] = "#{change_set.title} has been deleted"
+    flash[:alert] = "#{change_set.title.first} has been deleted"
     redirect_to(root_path)
   end
 

--- a/app/cho/data_dictionary/fields_for_object.rb
+++ b/app/cho/data_dictionary/fields_for_object.rb
@@ -10,6 +10,11 @@ module DataDictionary::FieldsForObject
     #   Like when you run rake db:create
     #   This statement makes sure the rails environment can be loaded even if the database has yet to be created.
     if ActiveRecord::Base.connection.table_exists? 'orm_resources'
+
+      # During testing, another race condition exists where the database has not been seeded yet
+      # when this block executes, resulting in no fields being defined on the resource.
+      Rails.application.load_seed if DataDictionary::Field.all.empty? && Rails.env.test?
+
       DataDictionary::Field.all.each do |field|
         attribute field.label.parameterize.underscore.to_sym, Valkyrie::Types::Set
       end

--- a/app/views/collection/archival_collections/edit.html.erb
+++ b/app/views/collection/archival_collections/edit.html.erb
@@ -3,5 +3,5 @@
 <%= render 'collection/base/form', collection: @collection %>
 
 <%= link_to 'Show', @collection %> |
-<%= link_to "Delete #{@collection.title}", archival_collection_path(@collection),
+<%= link_to "Delete #{@collection.title.first}", archival_collection_path(@collection),
             data: { confirm: 'Are you sure?' }, method: :delete %>

--- a/app/views/collection/base/_form.html.erb
+++ b/app/views/collection/base/_form.html.erb
@@ -1,14 +1,8 @@
 <%= form_for(@collection.model) do |form| %>
+
   <fieldset class="basic_metadata">
     <legend><%= t('cho.form.metadata') %></legend>
-    <%= form.label :title do %>
-      <%= t('cho.field_label.title') %><span class="required no_bold"> <%= t('cho.field_label.required') %></span>
-    <% end %>
-      <%= form.text_field :title, :required => true, 'aria-required' => true %>
-    <%= form.label :subtitle %>
-      <%= form.text_field :subtitle %>
-    <%= form.label :description %>
-    <%= form.text_area :description %>
+    <%= render 'shared/form_fields', resource: @collection, form: form %>
   </fieldset>
 
   <fieldset>

--- a/app/views/collection/curated_collections/edit.html.erb
+++ b/app/views/collection/curated_collections/edit.html.erb
@@ -3,5 +3,5 @@
 <%= render 'collection/base/form', collection: @collection %>
 
 <%= link_to 'Show', @collection %> |
-<%= link_to "Delete #{@collection.title}", curated_collection_path(@collection),
+<%= link_to "Delete #{@collection.title.first}", curated_collection_path(@collection),
             data: { confirm: 'Are you sure?' }, method: :delete %>

--- a/app/views/collection/library_collections/edit.html.erb
+++ b/app/views/collection/library_collections/edit.html.erb
@@ -3,5 +3,5 @@
 <%= render 'collection/base/form', collection: @collection %>
 
 <%= link_to 'Show', @collection %> |
-<%= link_to "Delete #{@collection.title}", library_collection_path(@collection),
+<%= link_to "Delete #{@collection.title.first}", library_collection_path(@collection),
             data: { confirm: 'Are you sure?' }, method: :delete %>

--- a/app/views/shared/_form_fields.html.erb
+++ b/app/views/shared/_form_fields.html.erb
@@ -1,0 +1,12 @@
+<%- resource.form_fields.each do |metadata_field| %>
+  <% if metadata_field.requirement_designation == 'required' %>
+    <%= form.label metadata_field.label, metadata_field.display_name do %>
+      <%= metadata_field.label.titleize %><span class="required no_bold"> required</span>
+    <% end %>
+    <%= form.text_field metadata_field.label, :required => true, 'aria-required' => true %>
+  <% else %>
+    <%= form.label metadata_field.label, metadata_field.display_name %>
+    <%= form.text_field metadata_field.label %>
+  <% end %>
+
+<%- end %>

--- a/app/views/work/submissions/_form.html.erb
+++ b/app/views/work/submissions/_form.html.erb
@@ -1,17 +1,6 @@
 <%= form_for(work_form.model, url: work_form.form_path) do |form| %>
 
-  <%- work_form.form_fields.each do |metadata_field| %>
-    <% if metadata_field.requirement_designation == 'required' %>
-      <%= form.label metadata_field.label, metadata_field.display_name do %>
-        <%= metadata_field.label.titleize %><span class="required no_bold"> required</span>
-      <% end %>
-      <%= form.text_field metadata_field.label, :required => true, 'aria-required' => true %>
-    <% else %>
-      <%= form.label metadata_field.label, metadata_field.display_name %>
-      <%= form.text_field metadata_field.label %>
-    <% end %>
-
-  <%- end %>
+  <%= render 'shared/form_fields', resource: work_form, form: form %>
 
   <% if with_collections %>
     <%= form.label :member_of_collection_ids %>

--- a/config/data_dictionary/schema_fields.yml
+++ b/config/data_dictionary/schema_fields.yml
@@ -1,6 +1,8 @@
 development: &development
   - schema: 'Generic'
     fields: []
+  - schema: 'Collection'
+    fields: []
   - schema: 'Document'
     fields:
       contributor:
@@ -150,4 +152,6 @@ test:
     fields:
       audio_field:
         order_index: 1
+  - schema: 'Collection'
+    fields: []
 production: *development

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -44,7 +44,7 @@ class SeedMAP
     def load_work_types
       schema_config.map { |config| config.fetch("schema") }.each do |type|
         seed_resource(metadata_schema(type))
-        seed_resource(work_type(type))
+        seed_resource(work_type(type)) unless type == 'Collection'
       end
     end
 

--- a/spec/cho/collection/archival_collections/archival_spec.rb
+++ b/spec/cho/collection/archival_collections/archival_spec.rb
@@ -10,11 +10,6 @@ RSpec.describe Collection::Archival, type: :model do
     expect(resource_klass.model_name.param_key).to eq('archival_collection')
   end
 
-  describe '#members' do
-    subject { resource_klass.new }
-
-    its(:members) { is_expected.to be_empty }
-  end
-
+  it_behaves_like 'a collection'
   it_behaves_like 'a Valkyrie::Resource'
 end

--- a/spec/cho/collection/change_set_behaviors_spec.rb
+++ b/spec/cho/collection/change_set_behaviors_spec.rb
@@ -28,17 +28,13 @@ RSpec.describe Collection::ChangeSetBehaviors do
 
   describe '#multiple?' do
     it 'has one title and description' do
-      expect(change_set).not_to be_multiple(:title)
-      expect(change_set).not_to be_multiple(:subtitle)
-      expect(change_set).not_to be_multiple(:description)
       expect(change_set).not_to be_multiple(:workflow)
       expect(change_set).not_to be_multiple(:visibility)
     end
   end
 
   describe '#required?' do
-    it 'has a required title' do
-      expect(change_set).to be_required(:title)
+    it 'has required fields' do
       expect(change_set).to be_required(:workflow)
       expect(change_set).to be_required(:visibility)
     end
@@ -46,9 +42,6 @@ RSpec.describe Collection::ChangeSetBehaviors do
 
   describe '#fields=' do
     before { change_set.prepopulate! }
-    its(:title) { is_expected.to be_nil }
-    its(:description) { is_expected.to be_nil }
-    its(:subtitle) { is_expected.to be_nil }
     its(:workflow) { is_expected.to be_nil }
     its(:visibility) { is_expected.to be_nil }
   end
@@ -59,7 +52,7 @@ RSpec.describe Collection::ChangeSetBehaviors do
     before { change_set.validate(params) }
 
     context 'without a title' do
-      let(:params) { { description: 'description' } }
+      let(:params) { {} }
 
       its(:full_messages) { is_expected.to include("Title can't be blank") }
     end
@@ -80,6 +73,12 @@ RSpec.describe Collection::ChangeSetBehaviors do
       let(:params) { { title: 'Title', description: 'My collection', workflow: 'default', visibility: 'public' } }
 
       its(:full_messages) { is_expected.to be_empty }
+    end
+  end
+
+  describe '#form_fields' do
+    it 'contains all the fields from the collection schema' do
+      expect(change_set.form_fields.map(&:label)).to contain_exactly('subtitle', 'description', 'title')
     end
   end
 end

--- a/spec/cho/collection/common_fields_spec.rb
+++ b/spec/cho/collection/common_fields_spec.rb
@@ -16,9 +16,6 @@ RSpec.describe Collection::CommonFields, type: :model do
   subject { MyCollection.new }
 
   it { is_expected.to respond_to(:id) }
-  it { is_expected.to respond_to(:title) }
-  it { is_expected.to respond_to(:subtitle) }
-  it { is_expected.to respond_to(:description) }
   it { is_expected.to respond_to(:workflow) }
   it { is_expected.to respond_to(:visibility) }
 end

--- a/spec/cho/collection/curated_collections/curated_spec.rb
+++ b/spec/cho/collection/curated_collections/curated_spec.rb
@@ -10,11 +10,6 @@ RSpec.describe Collection::Curated, type: :model do
     expect(resource_klass.model_name.param_key).to eq('curated_collection')
   end
 
-  describe '#members' do
-    subject { resource_klass.new }
-
-    its(:members) { is_expected.to be_empty }
-  end
-
+  it_behaves_like 'a collection'
   it_behaves_like 'a Valkyrie::Resource'
 end

--- a/spec/cho/collection/library_collections/library_spec.rb
+++ b/spec/cho/collection/library_collections/library_spec.rb
@@ -10,11 +10,6 @@ RSpec.describe Collection::Library, type: :model do
     expect(resource_klass.model_name.param_key).to eq('library_collection')
   end
 
-  describe '#members' do
-    subject { resource_klass.new }
-
-    its(:members) { is_expected.to be_empty }
-  end
-
+  it_behaves_like 'a collection'
   it_behaves_like 'a Valkyrie::Resource'
 end

--- a/spec/support/shared/collections.rb
+++ b/spec/support/shared/collections.rb
@@ -24,3 +24,30 @@ RSpec.shared_examples 'a collection with works' do
     end
   end
 end
+
+RSpec.shared_examples 'a collection' do
+  describe '#title' do
+    it 'is nil when not set' do
+      expect(resource_klass.new.title).to be_empty
+    end
+
+    it 'can be set as an attribute' do
+      resource = resource_klass.new(title: 'test')
+      expect(resource.attributes[:title]).to contain_exactly('test')
+    end
+
+    it 'is included in the list of attributes' do
+      expect(resource_klass.new.has_attribute?(:title)).to eq true
+    end
+
+    it 'is included in the list of fields' do
+      expect(resource_klass.fields).to include(:title)
+    end
+  end
+
+  describe '#members' do
+    subject { resource_klass.new }
+
+    its(:members) { is_expected.to be_empty }
+  end
+end

--- a/spec/support/shared/controllers.rb
+++ b/spec/support/shared/controllers.rb
@@ -71,7 +71,7 @@ RSpec.shared_examples 'a collection controller' do
 
       it 'updates the requested collection' do
         put :update, params: { id: collection.to_param, resource_class.model_name.param_key.to_sym => new_attributes }, session: valid_session
-        expect(updated_collection.title).to eq('Updated collection')
+        expect(updated_collection.title).to contain_exactly('Updated collection')
       end
 
       it 'redirects to the collection' do

--- a/spec/views/archival_collections/edit.html.erb_spec.rb
+++ b/spec/views/archival_collections/edit.html.erb_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'collection/archival_collections/edit', type: :view do
     assert_select 'form[action=?][method=?]', archival_collection_path(@collection), 'post' do
       assert_select 'input[name=?]', 'archival_collection[title]'
       assert_select 'input[name=?]', 'archival_collection[subtitle]'
-      assert_select 'textarea[name=?]', 'archival_collection[description]'
+      assert_select 'input[name=?]', 'archival_collection[description]'
       assert_select 'input[name=?]', 'archival_collection[workflow]'
       assert_select 'input[name=?]', 'archival_collection[visibility]'
       # Added to make sure accessibility changes are in place

--- a/spec/views/archival_collections/new.html.erb_spec.rb
+++ b/spec/views/archival_collections/new.html.erb_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'collection/archival_collections/new', type: :view do
     assert_select 'form[action=?][method=?]', archival_collections_path, 'post' do
       assert_select 'input[name=?]', 'archival_collection[title]'
       assert_select 'input[name=?]', 'archival_collection[subtitle]'
-      assert_select 'textarea[name=?]', 'archival_collection[description]'
+      assert_select 'input[name=?]', 'archival_collection[description]'
       assert_select 'input[name=?]', 'archival_collection[workflow]'
       assert_select 'input[name=?]', 'archival_collection[visibility]'
       # Added to make sure accessibility changes are in place

--- a/spec/views/curated_collections/edit.html.erb_spec.rb
+++ b/spec/views/curated_collections/edit.html.erb_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'collection/curated_collections/edit', type: :view do
     assert_select 'form[action=?][method=?]', curated_collection_path(@collection), 'post' do
       assert_select 'input[name=?]', 'curated_collection[title]'
       assert_select 'input[name=?]', 'curated_collection[subtitle]'
-      assert_select 'textarea[name=?]', 'curated_collection[description]'
+      assert_select 'input[name=?]', 'curated_collection[description]'
       assert_select 'input[name=?]', 'curated_collection[workflow]'
       assert_select 'input[name=?]', 'curated_collection[visibility]'
       # Added to make sure accessibility changes are in place

--- a/spec/views/curated_collections/new.html.erb_spec.rb
+++ b/spec/views/curated_collections/new.html.erb_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'collection/curated_collections/new', type: :view do
     assert_select 'form[action=?][method=?]', curated_collections_path, 'post' do
       assert_select 'input[name=?]', 'curated_collection[title]'
       assert_select 'input[name=?]', 'curated_collection[subtitle]'
-      assert_select 'textarea[name=?]', 'curated_collection[description]'
+      assert_select 'input[name=?]', 'curated_collection[description]'
       assert_select 'input[name=?]', 'curated_collection[workflow]'
       assert_select 'input[name=?]', 'curated_collection[visibility]'
       # Added to make sure accessibility changes are in place

--- a/spec/views/library_collections/edit.html.erb_spec.rb
+++ b/spec/views/library_collections/edit.html.erb_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'collection/library_collections/edit', type: :view do
     assert_select 'form[action=?][method=?]', library_collection_path(@collection), 'post' do
       assert_select 'input[name=?]', 'library_collection[title]'
       assert_select 'input[name=?]', 'library_collection[subtitle]'
-      assert_select 'textarea[name=?]', 'library_collection[description]'
+      assert_select 'input[name=?]', 'library_collection[description]'
       assert_select 'input[name=?]', 'library_collection[workflow]'
       assert_select 'input[name=?]', 'library_collection[visibility]'
       # Added to make sure accessibility changes are in place

--- a/spec/views/library_collections/new.html.erb_spec.rb
+++ b/spec/views/library_collections/new.html.erb_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'collection/library_collections/new', type: :view do
     assert_select 'form[action=?][method=?]', library_collections_path, 'post' do
       assert_select 'input[name=?]', 'library_collection[title]'
       assert_select 'input[name=?]', 'library_collection[subtitle]'
-      assert_select 'textarea[name=?]', 'library_collection[description]'
+      assert_select 'input[name=?]', 'library_collection[description]'
       assert_select 'input[name=?]', 'library_collection[workflow]'
       assert_select 'input[name=?]', 'library_collection[visibility]'
       # Added to make sure accessibility changes are in place


### PR DESCRIPTION
## Description

Allows us to define the same set of core fields for collections that are
used for works. Additional configuration can later be added to expand
fields on collections and vary them by the collection class.

Fixes #407 

Why was this necessary?

Makes the process for defining fields on works and collections the same.

## Changes

Are there any major changes in this PR that will change the release process? No.

## Checklist

- [x] i18n enabled
- [x] adequate test coverage
- [x] accessible interface
