### PR TITLE
SCSS Linting for CHO

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -10,6 +10,6 @@
  * files in this directory. Styles in this file should be added after the last require_* statement.
  * It is generally better to create a new file per style scope.
  *
- *= require_tree .
  *= require_self
+ *= require cho
  */

--- a/app/assets/stylesheets/cho.scss
+++ b/app/assets/stylesheets/cho.scss
@@ -1,0 +1,3 @@
+@charset "UTF-8";
+
+@import 'cho/variables', 'cho/blacklight', 'cho/data_dictionary_fields', 'cho/form', 'cho/scaffolds';

--- a/app/assets/stylesheets/cho/blacklight.scss
+++ b/app/assets/stylesheets/cho/blacklight.scss
@@ -5,44 +5,42 @@
 @import 'blacklight/blacklight';
 
 #header-navbar .navbar-brand {
-  color: #fff;
-  background: none;
+  background: $header-black;
+  color: $primary-white;
   text-indent: 2%;
   width: 500px;
 }
 
 // styles to address inconsistent usage of search widgets
 .catalog_startOverLink:hover,
-.search-widgets .btn:hover { color: #FFF; }
+.search-widgets .btn:hover { color: $primary-white; }
 
 // addresses insufficient color contrast
-.dl-invert dt { color: #686868; }
+.dl-invert dt { color: $gray-middle; }
 
 // Button visited link color
-.btn-danger:visited { color: #FFF; }
+.btn-danger:visited { color: $primary-white; }
 
 // Adds the colored focus around the Bootstrap dropdown
 .dropdown-toggle:focus {
-  border-color: #66aFe9;
-  box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102,175,233,.6);
+  border-color: $blue-light;
+  box-shadow: inset 0 1px 1px $focus-shadow-color-inset, $focus-shadow-color;
   outline: 2px;
   outline: -webkit-focus-ring-color auto 5px;
 }
 
 // Adds a skip to content link for keyboard users, but only makes it visible when element receives focus
-.skip a
-{
-  position:absolute;
-  left:-10000px;
-  top:auto;
-  width:1px;
-  height:1px;
-  overflow:hidden;
+.skip a {
+  height: 1px;
+  left: -10000px;
+  overflow: hidden;
+  position: absolute;
+  top: auto;
+  width: 1px;
 }
 
-.skip a:focus
-{
-  position:static;
-  width:auto;
-  height:auto;
+.skip a:focus {
+  height: auto;
+  position: static;
+  width: auto;
 }

--- a/app/assets/stylesheets/cho/data_dictionary_fields.scss
+++ b/app/assets/stylesheets/cho/data_dictionary_fields.scss
@@ -8,15 +8,13 @@
 .data-dictionary dt {
   clear: left;
   float: left;
-}
-
-.data-dictionary dt {
   padding-right: 2em;
 }
+
 .data-dictionary dd {
   float: left;
 }
 
 .clearleft {
-  clear: left
+  clear: left;
 }

--- a/app/assets/stylesheets/cho/form.scss
+++ b/app/assets/stylesheets/cho/form.scss
@@ -2,12 +2,14 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-h1        { margin-bottom: 2rem; }
-fieldset  { margin-bottom: 3rem; }
-legend    { border: none; }
-input     { margin-bottom: 1rem; }
-.no_bold  { font-weight: normal; }
+h1 { margin-bottom: 2rem; }
+fieldset { margin-bottom: 3rem; }
+legend { border: 0; }
+input { margin-bottom: 1rem; }
+
+.no_bold { font-weight: normal; }
+
 .required {
-  color: #df0000;
+  color: $required-red;
   vertical-align: super;
 }

--- a/app/assets/stylesheets/cho/scaffolds.scss
+++ b/app/assets/stylesheets/cho/scaffolds.scss
@@ -1,7 +1,6 @@
 body {
-  background-color: #fff;
-  color: #333;
-  margin: 33px;
+  background-color: $primary-white;
+  color: $body-text-color;
   font-family: verdana, arial, helvetica, sans-serif;
   font-size: 13px;
   line-height: 18px;
@@ -14,21 +13,21 @@ p, ol, ul, td {
 }
 
 pre {
-  background-color: #eee;
-  padding: 10px;
+  background-color: $primary-white;
   font-size: 11px;
+  padding: 10px;
 }
 
 a {
-  color: #000;
+  color: $primary-black;
 
   &:visited {
-    color: #666;
+    color: $gray-middle;
   }
 
   &:hover {
-    color: #fff;
-    background-color: #000;
+    background-color: $primary-black;
+    color: $primary-white;
   }
 }
 
@@ -47,30 +46,30 @@ div {
 }
 
 #notice {
-  color: green;
+  color: $green-notice;
 }
 
 .field_with_errors {
-  padding: 2px;
-  background-color: red;
+  background-color: $required-red;
   display: table;
+  padding: 2px;
 }
 
 #error_explanation {
-  width: 450px;
-  border: 2px solid red;
-  padding: 7px 7px 0;
+  background-color: $primary-white;
+  border: 2px solid $required-red;
   margin-bottom: 20px;
-  background-color: #f0f0f0;
+  padding: 7px 7px 0;
+  width: 450px;
 
   h2 {
-    text-align: left;
-    font-weight: bold;
-    padding: 5px 5px 5px 15px;
+    background-color: $required-red;
+    color: $primary-white;
     font-size: 12px;
+    font-weight: bold;
     margin: -7px -7px 0;
-    background-color: #c00;
-    color: #fff;
+    padding: 5px 5px 5px 15px;
+    text-align: left;
   }
 
   ul li {

--- a/app/assets/stylesheets/cho/variables.scss
+++ b/app/assets/stylesheets/cho/variables.scss
@@ -1,0 +1,18 @@
+// Color variables to be used throughout ScholarSphere.
+
+$primary-white: #fff;
+$gray-middle: #686868;
+$primary-black: #000;
+
+$required-red: #d9534f;
+$green-notice: #008000;
+$blue-light: #66afe9;
+
+$body-text-color: #333;
+
+// Header
+$header-black: #222;
+
+// Browser focus ring for elements that require keyboard focus
+$focus-shadow-color: rgba(102, 175, 233, .6);
+$focus-shadow-color-inset: rgba(0, 0, 0, .075);


### PR DESCRIPTION
Adds a cho.scss file and imports the partials. Updates css for syntax errors.

## Description

Moves the CHO-specific and venodr overrides into a CHO folder and imports those CSS files into the application.css. Fixes all issues reported by the SCSS Linter.

Why was this necessary?

Updates CSS and SCSS styles according to current best practices.

## Changes

Are there any major changes in this PR that will change the release process?

Moved SCSS files into a CHO folder.

## Checklist

- [ ] i18n enabled
- [ ] adequate test coverage
- [ ] accessible interface
