### PR TITLE
Change work_type to work_type_id

### DIFF
--- a/app/cho/work/submission.rb
+++ b/app/cho/work/submission.rb
@@ -7,7 +7,7 @@ module Work
     include CommonQueries
 
     attribute :id, Valkyrie::Types::ID.optional
-    attribute :work_type, Valkyrie::Types::String
+    attribute :work_type_id, Valkyrie::Types::ID.optional
     attribute :member_of_collection_ids, Valkyrie::Types::Set
 
     # A list of Work::Files.

--- a/app/cho/work/submission_change_set.rb
+++ b/app/cho/work/submission_change_set.rb
@@ -2,8 +2,8 @@
 
 module Work
   class SubmissionChangeSet < Valkyrie::ChangeSet
-    validates :work_type, presence: true
-    property :work_type, multiple: false, required: true
+    validates :work_type_id, presence: true
+    property :work_type_id, multiple: false, required: true, type: Valkyrie::Types::ID
     property :file, multiple: false, required: false
     validates :member_of_collection_ids, with: :validate_members!
     property :member_of_collection_ids,
@@ -12,7 +12,6 @@ module Work
              type: Types::Strict::Array.member(Valkyrie::Types::ID)
 
     include DataDictionary::FieldsForChangeSet
-    alias :work_type_id :work_type
     delegate :url_helpers, to: 'Rails.application.routes'
 
     def initialize(*args)
@@ -35,7 +34,7 @@ module Work
       @form_fields = unordered_fields.sort_by(&:order_index)
     end
 
-    def work_type_model
+    def work_type
       @work_type ||= Work::Type.find(Valkyrie::ID.new(work_type_id))
     end
 
@@ -73,7 +72,7 @@ module Work
     private
 
       def metadata_schema
-        @metadata_schema ||= work_type_model.metadata_schema
+        @metadata_schema ||= work_type.metadata_schema
       end
   end
 end

--- a/app/cho/work/submission_indexer.rb
+++ b/app/cho/work/submission_indexer.rb
@@ -8,7 +8,7 @@ module Work
     end
 
     def to_solr
-      return {} unless resource.try(:work_type)
+      return {} unless resource.try(:work_type_id)
       {
         work_type_ssim: label_for_id
       }
@@ -17,8 +17,8 @@ module Work
     # @return [String]
     # @note returns the label associated with the work_type_id
     def label_for_id
-      work_type = Work::Type.find(Valkyrie::ID.new(resource.work_type))
-      return resource.work_type if work_type.nil?
+      work_type = Work::Type.find(Valkyrie::ID.new(resource.work_type_id))
+      return resource.work_type_id if work_type.nil?
       work_type.label
     end
   end

--- a/app/cho/work/submissions_controller.rb
+++ b/app/cho/work/submissions_controller.rb
@@ -9,9 +9,9 @@ module Work
 
     # GET /works/new
     def new
-      work_type = params.fetch(:work_type, nil)
-      if work_type
-        @work = initialize_change_set(work_type: work_type)
+      work_type_id = params.fetch(:work_type_id, nil)
+      if work_type_id
+        @work = initialize_change_set(work_type_id: work_type_id)
       else
         flash[:alert] = 'You must specify a work type'
         redirect_to(root_path)

--- a/app/views/work/submissions/_form.html.erb
+++ b/app/views/work/submissions/_form.html.erb
@@ -24,7 +24,7 @@
     </datalist>
   <% end %>
 
-  <%= form.hidden_field :work_type, value: work_form.work_type_model.id %>
+  <%= form.hidden_field :work_type_id, value: work_form.work_type_id %>
 
   <%= form.hidden_field :file, value: work_form.model.cached_file_data %>
 

--- a/app/views/work/submissions/_nav.html.erb
+++ b/app/views/work/submissions/_nav.html.erb
@@ -4,7 +4,7 @@
   </a>
   <ul class="dropdown-menu">
     <% Work::Type.all.each do |type| %>
-      <li><%= link_to type.label, new_work_path(work_type: type.id) %></li>
+      <li><%= link_to type.label, new_work_path(work_type_id: type.id) %></li>
     <% end %>
   </ul>
 </li>

--- a/app/views/work/submissions/new.html.erb
+++ b/app/views/work/submissions/new.html.erb
@@ -1,5 +1,5 @@
-<% if @work.work_type_model %>
-  <h1><%= t('cho.work.new.heading', type: @work.work_type_model.label) %></h1>
+<% if @work.work_type %>
+  <h1><%= t('cho.work.new.heading', type: @work.work_type.label) %></h1>
 
   <%= render partial: 'form', locals: { work_form: @work, with_collections: true } %>
 

--- a/spec/cho/work/submissions/change_set_spec.rb
+++ b/spec/cho/work/submissions/change_set_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Work::SubmissionChangeSet do
     end
 
     it 'has a single work type' do
-      expect(change_set).not_to be_multiple(:work_type)
+      expect(change_set).not_to be_multiple(:work_type_id)
     end
 
     it 'has multiple parents' do
@@ -33,15 +33,15 @@ RSpec.describe Work::SubmissionChangeSet do
     end
 
     it 'has a required work type' do
-      expect(change_set).to be_required(:work_type)
+      expect(change_set).to be_required(:work_type_id)
     end
   end
 
   describe '#fields=' do
     before { change_set.prepopulate! }
     its(:title) { is_expected.to be_empty }
+    its(:work_type_id) { is_expected.to eq(Valkyrie::ID.new(nil)) }
     its(:work_type) { is_expected.to be_nil }
-    its(:work_type_model) { is_expected.to be_nil }
     its(:file) { is_expected.to be_nil }
     its(:member_of_collection_ids) { is_expected.to be_empty }
   end
@@ -52,7 +52,7 @@ RSpec.describe Work::SubmissionChangeSet do
     before { change_set.validate(params) }
 
     context 'without a title' do
-      let(:params) { { work_type: 'work type' } }
+      let(:params) { { work_type_id: 'work type' } }
 
       its(:full_messages) { is_expected.to include("Title can't be blank") }
     end
@@ -64,20 +64,20 @@ RSpec.describe Work::SubmissionChangeSet do
     end
 
     context 'with all required fields' do
-      let(:params) { { work_type: 'work type', title: 'Title' } }
+      let(:params) { { work_type_id: 'work type', title: 'Title' } }
 
       its(:full_messages) { is_expected.to be_empty }
     end
 
     context 'with non-existent parents' do
-      let(:params) { { work_type: 'work type', title: 'Title', member_of_collection_ids: ['nothere'] } }
+      let(:params) { { work_type_id: 'work type', title: 'Title', member_of_collection_ids: ['nothere'] } }
 
       its(:full_messages) { is_expected.to include('Member of collection ids nothere does not exist') }
     end
 
     context 'with existing parents and all required fields' do
       let(:collection) { create_for_repository(:archival_collection) }
-      let(:params) { { work_type: 'work type', title: 'Title', member_of_collection_ids: [collection.id] } }
+      let(:params) { { work_type_id: 'work type', title: 'Title', member_of_collection_ids: [collection.id] } }
 
       its(:full_messages) { is_expected.to be_empty }
     end
@@ -114,12 +114,13 @@ RSpec.describe Work::SubmissionChangeSet do
   end
 
   context 'with a defined work type' do
-    let(:resource) { Work::Submission.new(work_type: work_type.id) }
+    let(:resource) { Work::Submission.new(work_type_id: work_type.id) }
     let(:work_type) { Work::Type.find_using(label: 'Generic').first }
 
     describe '#model' do
       its(:model) { is_expected.to eq(resource) }
-      its(:work_type_model) { is_expected.to eq(work_type) }
+      its(:work_type) { is_expected.to eq(work_type) }
+      its(:work_type_id) { is_expected.to eq(work_type.id) }
     end
 
     describe '#fields' do

--- a/spec/cho/work/submissions/edit_spec.rb
+++ b/spec/cho/work/submissions/edit_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Editing works', type: :feature do
-  let(:resource) { create_for_repository(:work, title: 'Work to edit', work_type: work_type.id) }
+  let(:resource) { create_for_repository(:work, title: 'Work to edit', work_type_id: work_type.id) }
   let(:work_type)  { Work::Type.where(label: 'Document').first }
   let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
 

--- a/spec/cho/work/submissions/indexer_spec.rb
+++ b/spec/cho/work/submissions/indexer_spec.rb
@@ -21,14 +21,14 @@ describe Work::SubmissionIndexer do
     end
 
     context "when the resource's work type isn't an id or doesn't exist" do
-      let(:resource) { instance_double('Resource', work_type: "I don't exist") }
+      let(:resource) { instance_double('Resource', work_type_id: "I don't exist") }
 
       it { is_expected.to eq(work_type_ssim: "I don't exist") }
     end
 
     context "when the resource's work type does exist" do
       let(:work_type) { create_for_repository(:work_type, label: 'Indexed Label') }
-      let(:resource) { instance_double('Resource', work_type: work_type.id) }
+      let(:resource) { instance_double('Resource', work_type_id: work_type.id) }
 
       it { is_expected.to eq(work_type_ssim: 'Indexed Label') }
     end

--- a/spec/cho/work/submissions/new_spec.rb
+++ b/spec/cho/work/submissions/new_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Work::Submission, type: :feature do
 
   context 'with a non-existent work type' do
     it 'reports the error in the form' do
-      visit(new_work_path(work_type: 'bogus-work-type-id'))
+      visit(new_work_path(work_type_id: 'bogus-work-type-id'))
       expect(page).to have_content('Unable to find work type')
     end
   end

--- a/spec/cho/work/submissions/show_spec.rb
+++ b/spec/cho/work/submissions/show_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Work::Submission, type: :feature do
     let(:work) do create_for_repository(:work,
       title: 'No files',
       member_of_collection_ids: [collection.id],
-      work_type: work_type.id)
+      work_type_id: work_type.id)
     end
 
     it 'displays only metadata' do
@@ -29,7 +29,7 @@ RSpec.describe Work::Submission, type: :feature do
   end
 
   context 'when the work has a file' do
-    let(:work) { create_for_repository(:work, :with_file, title: 'An editable file', work_type: work_type.id) }
+    let(:work) { create_for_repository(:work, :with_file, title: 'An editable file', work_type_id: work_type.id) }
 
     it 'displays metadata and files' do
       visit(polymorphic_path([:solr_document], id: work.id))

--- a/spec/cho/work/submissions/submission_spec.rb
+++ b/spec/cho/work/submissions/submission_spec.rb
@@ -27,22 +27,22 @@ RSpec.describe Work::Submission do
     end
   end
 
-  describe '#work_type' do
+  describe '#work_type_id' do
     it 'is nil when not set' do
-      expect(resource_klass.new.work_type).to be_nil
+      expect(resource_klass.new.work_type_id).to be_nil
     end
 
     it 'can be set as an attribute' do
-      resource = resource_klass.new(work_type: 'test')
-      expect(resource.attributes[:work_type]).to eq('test')
+      resource = resource_klass.new(work_type_id: Valkyrie::ID.new('123'))
+      expect(resource.attributes[:work_type_id].to_s).to eq('123')
     end
 
     it 'is included in the list of attributes' do
-      expect(resource_klass.new.has_attribute?(:work_type)).to eq true
+      expect(resource_klass.new.has_attribute?(:work_type_id)).to eq true
     end
 
     it 'is included in the list of fields' do
-      expect(resource_klass.fields).to include(:work_type)
+      expect(resource_klass.fields).to include(:work_type_id)
     end
   end
 

--- a/spec/cho/work/submissions/submissions_controller_spec.rb
+++ b/spec/cho/work/submissions/submissions_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Work::SubmissionsController, type: :controller do
   describe 'GET #new' do
     context 'with a work type' do
       it 'returns a success response' do
-        get :new, params: { work_type: 'type' }
+        get :new, params: { work_type_id: 'type' }
         expect(response).to be_success
         expect(assigns(:work)).to be_a(Work::SubmissionChangeSet)
       end
@@ -33,7 +33,8 @@ RSpec.describe Work::SubmissionsController, type: :controller do
   end
 
   describe 'POST #create' do
-    let(:valid_attributes) { { title: 'New Title', work_type: 'type' } }
+    let(:work_type_id) { Work::Type.find_using(label: 'Generic') }
+    let(:valid_attributes) { { title: 'New Title', work_type_id: work_type_id } }
     let(:resource) { Work::Submission.all.last }
 
     context 'with valid params' do

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -7,7 +7,7 @@ require Rails.root.join('spec', 'support', 'seed_map')
 FactoryGirl.define do
   factory :work_submission, aliases: [:work], class: Work::Submission do
     title 'Sample Generic Work'
-    work_type 'Generic'
+    work_type_id { Work::Type.find_using(label: 'Generic').first.id }
 
     to_create do |resource|
       Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: resource)

--- a/spec/views/work_submissions/edit.html.erb_spec.rb
+++ b/spec/views/work_submissions/edit.html.erb_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'work/submissions/edit', type: :view do
-  let(:work) { build(:work, title: ['Editable title'], id: 'id', work_type: work_type.id) }
+  let(:work) { build(:work, title: ['Editable title'], id: 'id', work_type_id: work_type.id) }
   let(:work_type)  { Work::Type.where(label: 'Document').first }
   let(:change_set) { Work::SubmissionChangeSet.new(work) }
   let(:form) { change_set }

--- a/spec/views/work_submissions/new.html.erb_spec.rb
+++ b/spec/views/work_submissions/new.html.erb_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'work/submissions/new', type: :view do
   let(:work_type)  { Work::Type.where(label: 'Document').first }
-  let(:change_set) { Work::SubmissionChangeSet.new(Work::Submission.new(work_type: work_type.id)) }
+  let(:change_set) { Work::SubmissionChangeSet.new(Work::Submission.new(work_type_id: work_type.id)) }
   let(:form) { change_set }
 
   before do


### PR DESCRIPTION
Co-authored-by: Michael Tribone mtribone@psu.edu

## Description

Changed the work_type attribute for Work::Submission and
Work::SubmissionChangeSet to work_type_id, using the Valkyrie ID instead
of just a string.

Fixes: #419

Why was this necessary?

We needed to be more consistent about attributes names and remove confusion over object properties and id properties.

## Changes

Are there any major changes in this PR that will change the release process? No

## Checklist

- [x] i18n enabled
- [x] adequate test coverage
- [x] accessible interface
