### PR TITLE
Configuring Travis for stage build with Niftany

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,5 @@
+--color
+--tty
+--format progress
+--profile
 --require spec_helper

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,16 +14,11 @@ jdk:
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
-  matrix:
-    - TEST_SUITE=rspec
-    - TEST_SUITE=rubocop
-before_install:
-  - mkdir -p dep_cache
-before_script:
-  - cp config/travis/hydra-ldap.yml config/hydra-ldap.yml
-  - cp config/travis/database.yml config/database.yml
-  - psql -c 'create database travis_ci_test;' -U postgres
-  - bundle exec solr_wrapper --config config/travis/solr_wrapper_test.yml &
-  - bin/jetty_wait
-script:
-  - bundle exec rake cho:travis:$TEST_SUITE
+stages:
+  - niftany
+  - test
+jobs:
+  include:
+    - script: ./travis/test.sh
+    - stage: niftany
+      script: bundle exec niftany

--- a/config/travis/solr_wrapper_test.yml
+++ b/config/travis/solr_wrapper_test.yml
@@ -1,5 +1,5 @@
 # config/travis/solr_wrapper_test.yml
-version: 5.3.1
+version: 7.1.0
 port: 8985
 instance_dir: solr-test
 download_dir: dep_cache

--- a/travis/test.sh
+++ b/travis/test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+echo -e "\n\n\033[0;32mTravis test.sh script\033[0m"
+
+echo -e "\n\n\033[1;33mMaking dependency cache directory\033[0m"
+mkdir -p dep_cache
+echo "Listing directory contents:"
+ls -l dep_cache
+
+echo -e "\n\n\033[1;33mPreparing...\033[0m"
+cp config/travis/hydra-ldap.yml config/hydra-ldap.yml
+cp config/travis/database.yml config/database.yml
+psql -c 'create database travis_ci_test;' -U postgres
+bundle exec solr_wrapper --config config/travis/solr_wrapper_test.yml &
+bin/jetty_wait
+
+echo -e "\n\n\033[1;33mRunning RSpec test suite\033[0m"
+bundle exec rake cho:travis:rspec
+RSPEC_EXIT_CODE=$?
+
+exit $RSPEC_EXIT_CODE


### PR DESCRIPTION
## Description

Configures Travis to use stage builds with a separate check for linters, using Niftany, to run first. The second stage is the rspec test.

This also corrects an error with the solr version of the Travis configuration.

Why was this necessary?

Allows Travis to check to linter errors prior to running the test suite.

## Changes

Are there any major changes in this PR that will change the release process? No

## Checklist

- [x] i18n enabled
- [x] adequate test coverage
- [x] accessible interface
