### PR TITLE
Registering CreateForRepository as create

### DIFF
--- a/spec/blacklight/catalog_spec.rb
+++ b/spec/blacklight/catalog_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Catalog page', type: :feature do
   context 'with an existing work' do
     let(:query) { 'exceptional' }
 
-    before { create_for_repository(:work, title: 'Some exceptional content') }
+    before { create(:work, title: 'Some exceptional content') }
 
     it 'searches and facets on the item' do
       visit('/catalog')

--- a/spec/blacklight/solr_document_spec.rb
+++ b/spec/blacklight/solr_document_spec.rb
@@ -22,18 +22,18 @@ RSpec.describe SolrDocument, type: :model do
   describe '#files' do
     subject { SolrDocument.new(document).files.first }
 
-    let(:work_file) { create_for_repository :work_file }
+    let(:work_file) { create :work_file }
     let(:document) { { 'internal_resource_tsim' => 'MyResource', files_ssim: [work_file.id.to_s] } }
 
     its(:to_h) { is_expected.to include(original_filename: 'original_name',
                                         internal_resource: 'Work::File',
-                                        id: work_file.id) }
+                                        id: Valkyrie::ID.new(work_file.id)) }
   end
 
   describe '#member_of_collections' do
     subject { SolrDocument.new(document).member_of_collections.first }
 
-    let(:collection) { create_for_repository(:archival_collection) }
+    let(:collection) { create(:archival_collection) }
     let(:document) { { 'internal_resource_tsim' => 'MyResource', member_of_collection_ids_ssim: [collection.id.to_s] } }
 
     its(:to_h) { is_expected.to include('title_tesim' => ['Archival Collection'],

--- a/spec/cho/collection/archival_collections/archival_collections_controller_spec.rb
+++ b/spec/cho/collection/archival_collections/archival_collections_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Collection::ArchivalCollectionsController, type: :controller do
-  let(:collection) { create_for_repository(:archival_collection) }
+  let(:collection) { create(:archival_collection) }
   let(:resource_class) { Collection::Archival }
 
   it_behaves_like 'a collection controller'

--- a/spec/cho/collection/archival_collections/edit_spec.rb
+++ b/spec/cho/collection/archival_collections/edit_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Collection::Archival, type: :feature do
-  let(:resource) { create_for_repository(:archival_collection, title: 'Archival collection to edit') }
+  let(:resource) { create(:archival_collection, title: 'Archival collection to edit') }
   let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
 
   context 'with all the required metadata' do

--- a/spec/cho/collection/archival_collections/index_spec.rb
+++ b/spec/cho/collection/archival_collections/index_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Collection::Archival, type: :feature do
-  before { create_for_repository(:archival_collection, title: 'Archival collection index view') }
+  before { create(:archival_collection, title: 'Archival collection index view') }
 
   it 'displays facets and the collection in an index view' do
     visit(root_path)

--- a/spec/cho/collection/archival_collections/show_spec.rb
+++ b/spec/cho/collection/archival_collections/show_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Collection::Archival, type: :feature do
-  let(:collection) { create_for_repository(:archival_collection) }
+  let(:collection) { create :archival_collection }
 
   context 'when the collection has no member works' do
     it 'displays its show page and links to the edit form' do

--- a/spec/cho/collection/curated_collections/curated_collections_controller_spec.rb
+++ b/spec/cho/collection/curated_collections/curated_collections_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Collection::CuratedCollectionsController, type: :controller do
-  let(:collection) { create_for_repository(:curated_collection) }
+  let(:collection) { create(:curated_collection) }
   let(:resource_class) { Collection::Curated }
 
   it_behaves_like 'a collection controller'

--- a/spec/cho/collection/curated_collections/edit_spec.rb
+++ b/spec/cho/collection/curated_collections/edit_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Collection::Curated, type: :feature do
-  let(:resource) { create_for_repository(:curated_collection, title: 'Curated collection to edit') }
+  let(:resource) { create(:curated_collection, title: 'Curated collection to edit') }
   let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
 
   context 'with all the required metadata' do

--- a/spec/cho/collection/curated_collections/index_spec.rb
+++ b/spec/cho/collection/curated_collections/index_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Collection::Curated, type: :feature do
-  before { create_for_repository(:curated_collection, title: 'Curated collection index view') }
+  before { create(:curated_collection, title: 'Curated collection index view') }
 
   it 'displays facets and the collection in an index view' do
     visit(root_path)

--- a/spec/cho/collection/curated_collections/show_spec.rb
+++ b/spec/cho/collection/curated_collections/show_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Collection::Curated, type: :feature do
-  let(:collection) { create_for_repository(:curated_collection) }
+  let(:collection) { create(:curated_collection) }
 
   context 'when the collection has no member works' do
     it 'displays its show page and links to the edit form' do

--- a/spec/cho/collection/library_collections/edit_spec.rb
+++ b/spec/cho/collection/library_collections/edit_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Collection::Library, type: :feature do
-  let(:resource) { create_for_repository(:library_collection, title: 'Library collection to edit') }
+  let(:resource) { create(:library_collection, title: 'Library collection to edit') }
   let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
 
   context 'with all the required metadata' do

--- a/spec/cho/collection/library_collections/index_spec.rb
+++ b/spec/cho/collection/library_collections/index_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Collection::Library, type: :feature do
-  before { create_for_repository(:library_collection, title: 'Library collection index view') }
+  before { create(:library_collection, title: 'Library collection index view') }
 
   it 'displays facets and the collection in an index view' do
     visit(root_path)

--- a/spec/cho/collection/library_collections/library_collections_controller_spec.rb
+++ b/spec/cho/collection/library_collections/library_collections_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Collection::LibraryCollectionsController, type: :controller do
-  let(:collection) { create_for_repository(:library_collection) }
+  let(:collection) { create :library_collection }
   let(:resource_class) { Collection::Library }
 
   it_behaves_like 'a collection controller'

--- a/spec/cho/collection/library_collections/show_spec.rb
+++ b/spec/cho/collection/library_collections/show_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Collection::Library, type: :feature do
-  let(:collection) { create_for_repository(:library_collection) }
+  let(:collection) { create :library_collection }
 
   context 'when the collection has no member works' do
     it 'displays its show page and links to the edit form' do

--- a/spec/cho/collection/with_members_spec.rb
+++ b/spec/cho/collection/with_members_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Collection::WithMembers do
       it 'returns the members associated with the resource' do
         change_set = Valkyrie::ChangeSet.new(ParentResource.new)
         parent = Valkyrie.config.metadata_adapter.persister.save(resource: change_set)
-        member = create_for_repository(:work, member_of_collection_ids: [parent.id])
+        member = create(:work, member_of_collection_ids: [parent.id])
         reloaded_parent = Valkyrie.config.metadata_adapter.query_service.find_by(id: parent.id)
         expect(reloaded_parent.members.map(&:id)).to contain_exactly(member.id)
       end

--- a/spec/cho/data_dictionary/csv_importer_spec.rb
+++ b/spec/cho/data_dictionary/csv_importer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe DataDictionary::CsvImporter do
   end
 
   context 'record exists' do
-    before { create_for_repository(:data_dictionary_field) }
+    before { create(:data_dictionary_field) }
 
     it 'will update records' do
       expect {

--- a/spec/cho/data_dictionary/fields_controller_spec.rb
+++ b/spec/cho/data_dictionary/fields_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe DataDictionary::FieldsController, type: :controller do
   let(:valid_session) { {} }
 
   context 'valid object created' do
-    let!(:dictionary_field) { create_for_repository(:data_dictionary_field) }
+    let!(:dictionary_field) { create(:data_dictionary_field) }
     let(:title_field) { DataDictionary::Field.all.to_a.keep_if { |f| f.label == 'title' }.first }
     let(:reloaded_dictionary_field) { Valkyrie.config.metadata_adapter.query_service.find_by(id: dictionary_field.id) }
 

--- a/spec/cho/schema/metadata_spec.rb
+++ b/spec/cho/schema/metadata_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe Schema::Metadata, type: :model do
   context 'loading template' do
     subject { reloaded_model }
 
-    let(:core_fields) { [create_for_repository(:schema_metadata_field, label: 'core1')] }
-    let(:fields) { [create_for_repository(:schema_metadata_field, label: 'field1')] }
+    let(:core_fields) { [create(:schema_metadata_field, label: 'core1')] }
+    let(:fields) { [create(:schema_metadata_field, label: 'field1')] }
 
     let(:saved_model) { Valkyrie.config.metadata_adapter.persister.save(resource: model) }
     let(:reloaded_model) { Schema::Metadata.find(saved_model.id) }

--- a/spec/cho/work/submissions/change_set_spec.rb
+++ b/spec/cho/work/submissions/change_set_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Work::SubmissionChangeSet do
     end
 
     context 'with existing parents and all required fields' do
-      let(:collection) { create_for_repository(:archival_collection) }
+      let(:collection) { create :archival_collection }
       let(:params) { { work_type_id: 'work type', title: 'Title', member_of_collection_ids: [collection.id] } }
 
       its(:full_messages) { is_expected.to be_empty }

--- a/spec/cho/work/submissions/edit_spec.rb
+++ b/spec/cho/work/submissions/edit_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Editing works', type: :feature do
-  let(:resource) { create_for_repository(:work, title: 'Work to edit', work_type_id: work_type.id) }
+  let(:resource) { create(:work, title: 'Work to edit', work_type_id: work_type.id) }
   let(:work_type)  { Work::Type.where(label: 'Document').first }
   let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
 

--- a/spec/cho/work/submissions/index_spec.rb
+++ b/spec/cho/work/submissions/index_spec.rb
@@ -3,10 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe Work::Submission, type: :feature do
-  let(:collection) { create_for_repository(:library_collection) }
+  let(:collection) { create :library_collection }
 
   before do
-    create_for_repository(:work, title: 'Work Index View', member_of_collection_ids: [collection.id])
+    create :work, title: 'Work Index View', member_of_collection_ids: [collection.id]
   end
 
   it 'displays a list of fields in the search result view' do

--- a/spec/cho/work/submissions/indexer_spec.rb
+++ b/spec/cho/work/submissions/indexer_spec.rb
@@ -27,7 +27,7 @@ describe Work::SubmissionIndexer do
     end
 
     context "when the resource's work type does exist" do
-      let(:work_type) { create_for_repository(:work_type, label: 'Indexed Label') }
+      let(:work_type) { create :work_type, label: 'Indexed Label' }
       let(:resource) { instance_double('Resource', work_type_id: work_type.id) }
 
       it { is_expected.to eq(work_type_ssim: 'Indexed Label') }

--- a/spec/cho/work/submissions/new_spec.rb
+++ b/spec/cho/work/submissions/new_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Work::Submission, type: :feature do
   end
 
   context 'when filling in all the required fields' do
-    let!(:archival_collection) { create_for_repository(:archival_collection, title: 'Sample Collection') }
+    let!(:archival_collection) { create(:archival_collection, title: 'Sample Collection') }
 
     it 'creates a new work object' do
       visit(root_path)
@@ -28,7 +28,7 @@ RSpec.describe Work::Submission, type: :feature do
   end
 
   context 'without providing a title' do
-    let!(:archival_collection) { create_for_repository(:archival_collection, title: 'Sample Collection') }
+    let!(:archival_collection) { create(:archival_collection, title: 'Sample Collection') }
 
     it 'reports the errors' do
       visit(root_path)

--- a/spec/cho/work/submissions/show_spec.rb
+++ b/spec/cho/work/submissions/show_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Work::Submission, type: :feature do
   let(:work_type) { Work::Type.where(label: 'Document').first }
 
   context 'when the work has no files' do
-    let(:collection) { create_for_repository(:library_collection) }
-    let(:work) do create_for_repository(:work,
+    let(:collection) { create(:library_collection) }
+    let(:work) do create(:work,
       title: 'No files',
       member_of_collection_ids: [collection.id],
       work_type_id: work_type.id)
@@ -29,7 +29,7 @@ RSpec.describe Work::Submission, type: :feature do
   end
 
   context 'when the work has a file' do
-    let(:work) { create_for_repository(:work, :with_file, title: 'An editable file', work_type_id: work_type.id) }
+    let(:work) { create(:work, :with_file, title: 'An editable file', work_type_id: work_type.id) }
 
     it 'displays metadata and files' do
       visit(polymorphic_path([:solr_document], id: work.id))

--- a/spec/cho/work/submissions/submissions_controller_spec.rb
+++ b/spec/cho/work/submissions/submissions_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Work::SubmissionsController, type: :controller do
   let(:metadata_adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
-  let(:resource) { create_for_repository(:work) }
+  let(:resource) { create :work }
   let(:index_solr)    { Valkyrie::MetadataAdapter.find(:index_solr) }
 
   describe 'GET #new' do

--- a/spec/factories/archival_collections.rb
+++ b/spec/factories/archival_collections.rb
@@ -7,9 +7,5 @@ FactoryGirl.define do
     description 'Sample archival collection'
     workflow 'default'
     visibility 'public'
-
-    to_create do |resource|
-      Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: resource)
-    end
   end
 end

--- a/spec/factories/curated_collections.rb
+++ b/spec/factories/curated_collections.rb
@@ -7,9 +7,5 @@ FactoryGirl.define do
     subtitle 'subtitle for a curated collection'
     workflow 'default'
     visibility 'public'
-
-    to_create do |resource|
-      Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: resource)
-    end
   end
 end

--- a/spec/factories/library_collections.rb
+++ b/spec/factories/library_collections.rb
@@ -7,9 +7,5 @@ FactoryGirl.define do
     subtitle 'subtitle for a library collection'
     workflow 'default'
     visibility 'public'
-
-    to_create do |resource|
-      Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: resource)
-    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -13,6 +13,11 @@ FactoryGirl.define do
     login
     email
 
+    to_create do |user|
+      user.save!
+      user
+    end
+
     factory :admin do
       group_list 'umg/up.libraries.cho-admin'
       groups_last_update { Time.now }

--- a/spec/support/create_for_repository.rb
+++ b/spec/support/create_for_repository.rb
@@ -23,4 +23,4 @@ class CreateStategyForRepositoryPattern
     result
   end
 end
-FactoryGirl.register_strategy(:create_for_repository, CreateStategyForRepositoryPattern)
+FactoryGirl.register_strategy(:create, CreateStategyForRepositoryPattern)

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -3,3 +3,9 @@
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
 end
+
+FactoryGirl.define do
+  to_create do |resource|
+    Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: resource)
+  end
+end

--- a/spec/support/shared/collections.rb
+++ b/spec/support/shared/collections.rb
@@ -3,7 +3,7 @@
 RSpec.shared_examples 'a collection with works' do
   before do
     (1..20).each do |count|
-      create_for_repository(:work, title: "Work #{count}", member_of_collection_ids: [collection.id])
+      create(:work, title: "Work #{count}", member_of_collection_ids: [collection.id])
     end
   end
 


### PR DESCRIPTION
This way we do not need to remember to do something differently to get the saved objects as the result from create

## Description
Create for Valkyrie objects was not working as expected (you were getting the un saved resource back.  You needed to remember to use create_for_repository.  Since almost all of our resources are Valkyrie resources this seemed backwards to me.

References ticket: (if any)

Why was this necessary?

## Changes

* CreateForReporitory is registered as create instead of create_for_repository
* A generic to_create for valkyrie index resources was defined in the rails helper
* Tests were changes to use create instead of create_for_repository
* Any factory that used the indexing persister no longer needed the to_create so that was removed
* The User factory now needed a specialized to_create so that was added

Are there any major changes in this PR that will change the release process?

## Checklist

- [ ] i18n enabled
- [ ] adequate test coverage
- [ ] accessible interface
