### PR TITLE
Full loop from file to repo

### DIFF
--- a/app/cho/work/import/csv_controller.rb
+++ b/app/cho/work/import/csv_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Work
+  module Import
+    class CsvController < ApplicationController
+      # GET /csv_file/new
+      def new
+        @csv_file = CsvFile.new
+      end
+
+      # POST /csv_file
+      def create
+        file = params[:work_import_csv_file][:file]
+        @results = CsvDryRun.run(file.path)
+        @file_name = file.path
+        render :dry_run_results
+      end
+
+      def run_import
+        file_name = params[:file_name]
+        results =  CsvDryRun.run(file_name)
+        importer = CsvImporter.new(results)
+        if importer.run
+          @created = importer.created
+          render :import_success
+        else
+          @errors = importer.errors
+          render :import_failure
+        end
+      end
+    end
+  end
+end

--- a/app/cho/work/import/csv_file.rb
+++ b/app/cho/work/import/csv_file.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Work
+  module Import
+    class CsvFile
+      extend ActiveModel::Naming
+      include ActiveModel::Conversion
+      def persisted?
+        false
+      end
+      # Accessors needed for shrine to send the temporary uploaded file
+      #  to the controller
+      # For the moment we are uploading a single file.
+      attr_accessor :id, :file_data, :cached_file_data, :file
+
+      # def model_name
+      #   "CsvFile"
+      # end
+    end
+  end
+end

--- a/app/cho/work/import/csv_importer.rb
+++ b/app/cho/work/import/csv_importer.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Work
+  module Import
+    # Runs the import process assuming each item in the list is valid
+    #  Each item in the list is a change set that can be persisted
+    #
+    # importer = CSVRunImport.new(change_set_list)
+    # if importer.run
+    #   puts "The import was successful"
+    # else
+    #   puts there import failed
+    #   importer.errors.each {|error| puts error }
+    # end
+    #
+    class CsvImporter
+      attr_reader :change_set_list, :errors, :created
+
+      def initialize(change_set_list, change_set_persister = nil)
+        @change_set_list = change_set_list
+        @change_set_persister = change_set_persister
+        @errors = []
+        @created = []
+      end
+
+      def run
+        return false unless valid_list?
+        change_set_list.each do |change_set|
+          result = change_set_persister.validate_and_save(change_set: change_set, resource_params: {})
+          if result.errors.blank?
+            created << result
+          else
+            errors << result
+          end
+        end
+        errors.empty?
+      end
+
+      private
+
+        def valid_list?
+          state = change_set_list.map(&:valid?).reduce(:'&')
+          errors << 'Invalid items in list' unless state
+          state
+        end
+
+        def persist_changeset(change_set); end
+
+        def change_set_persister
+          @change_set_persister ||= ChangeSetPersister.new(
+            metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister),
+            storage_adapter: Valkyrie.config.storage_adapter
+          )
+        end
+    end
+  end
+end

--- a/app/cho/work/import/csv_reader.rb
+++ b/app/cho/work/import/csv_reader.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'csv'
+
 module Work
   module Import
     class CsvReader
@@ -8,7 +10,7 @@ module Work
       delegate :each, :map, to: :csv_hashes
 
       def initialize(csv_file)
-        csv_data = CSV.parse(csv_file)
+        csv_data = ::CSV.parse(csv_file)
         @headers = csv_data.shift
         @csv_hashes = csv_data.map { |a| Hash[@headers.zip(a)] }
       end

--- a/app/cho/work/import/work_hash_validator.rb
+++ b/app/cho/work/import/work_hash_validator.rb
@@ -10,11 +10,47 @@ module Work
       attr_reader :change_set
 
       def initialize(work_hash)
-        @change_set = SubmissionChangeSet.new(Submission.new)
-        collection_id = work_hash['member_of_collection_ids']
-        work_hash['member_of_collection_ids'] = [collection_id] unless collection_id.is_a?(Array)
-        @change_set.validate(work_hash)
+        validate_change_set(work_hash)
       end
+
+      private
+
+        def validate_change_set(work_hash)
+          @change_set = SubmissionChangeSet.new(Submission.new)
+          @change_set.validate(clean_hash(work_hash))
+        end
+
+        def clean_hash(work_hash)
+          work_hash['member_of_collection_ids'] = translate_collection_ids(work_hash['member_of_collection_ids'])
+          work_hash['work_type_id'] = translate_work_type(work_hash['work_type']) if work_hash['work_type_id'].blank?
+          work_hash['file'] = translate_file_name(work_hash['file_name'])
+          work_hash
+        end
+
+        def translate_work_type(work_type)
+          return nil if work_type.blank?
+
+          work_type_model = Work::Type.find_using(label: work_type).first
+          return nil if work_type_model.blank?
+
+          work_type_model.id
+        end
+
+        def translate_collection_ids(member_of_collection_ids)
+          if member_of_collection_ids.is_a?(Array)
+            member_of_collection_ids
+          else
+            [member_of_collection_ids]
+          end
+        end
+
+        def translate_file_name(file_name)
+          return nil if file_name.blank?
+
+          FileUtils.cp(file_name, Rails.root.join('tmp'))
+          file = ::File.new(Rails.root.join('tmp', ::File.basename(file_name)))
+          ActionDispatch::Http::UploadedFile.new(tempfile: file, filename: ::File.basename(file_name))
+        end
     end
   end
 end

--- a/app/views/work/import/csv/dry_run_results.html.erb
+++ b/app/views/work/import/csv/dry_run_results.html.erb
@@ -1,0 +1,13 @@
+<ol>
+  <% @results.each do |result| %>
+    <li>
+      <%= result.title %>
+      <%= result.errors %>
+    </li>
+  <% end %>
+</ol>
+
+<%= form_tag(controller: 'csv', action: 'run_import') do |form| %>
+ <%= hidden_field_tag(:file_name, @file_name) %>
+ <%= submit_tag(t('cho.csv.import.submit')) %>
+<% end %>

--- a/app/views/work/import/csv/import_failure.html.erb
+++ b/app/views/work/import/csv/import_failure.html.erb
@@ -1,0 +1,8 @@
+<h1><%= t('cho.csv.import.failure.header') %></h1>
+<ol>
+  <% @errors.each do |result| %>
+    <li>
+      <%= result.inspect %>
+    </li>
+  <% end %>
+</ol>

--- a/app/views/work/import/csv/import_success.html.erb
+++ b/app/views/work/import/csv/import_success.html.erb
@@ -1,0 +1,13 @@
+<h1><%= t('cho.csv.import.success.header') %></h1>
+<ol>
+  <% @created.each do |result| %>
+    <li>
+      <%= link_to result.title, solr_document_path(result.id) %>
+    </li>
+  <% end %>
+</ol>
+
+<%= form_tag(controller: 'csv', action: 'run_import') do |form| %>
+ <%= hidden_field_tag(:results, value: @results) %>
+ <%= submit_tag('Perform Import') %>
+<% end %>

--- a/app/views/work/import/csv/new.html.erb
+++ b/app/views/work/import/csv/new.html.erb
@@ -1,0 +1,9 @@
+<%= form_for(@csv_file, url: csv_file_index_path) do |form| %>
+
+  <%= form.hidden_field :file, value: @csv_file.cached_file_data %>
+  <%= form.file_field :file %>
+
+  <div class="actions">
+    <%= form.submit t('cho.csv.dry_run.submit') %>
+  </div>
+<% end %>

--- a/config/locales/cho.yml
+++ b/config/locales/cho.yml
@@ -42,3 +42,12 @@ en:
         title: "Title"
         date_created: "Date Created"
         heading: "Items in this Collection"
+    csv:
+      dry_run:
+        submit: "Dry Run"
+      import:
+        submit: "Perform Import"
+        failure:
+          header: "Failed Import"
+        success:
+          header: "Successful Import"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,4 +30,7 @@ Rails.application.routes.draw do
   resources :library_collections, except: [:show, :index], controller: 'collection/library_collections'
   resources :curated_collections, except: [:show, :index], controller: 'collection/curated_collections'
   resources :data_dictionary_fields, controller: 'data_dictionary/fields'
+  resources :work_import_csvfile, as: 'csv_file', path: '/csv_file', only: [:new, :create], controller: 'work/import/csv'
+
+  post '/csv_file/run_import', to: 'work/import/csv#run_import'
 end

--- a/spec/cho/work/import/csv_controller_spec.rb
+++ b/spec/cho/work/import/csv_controller_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Work::Import::CsvController, type: :controller do
+  let(:collection) { create :library_collection, title: 'my collection' }
+  let(:work_1_file_name) { Rails.root.join('spec', 'fixtures', 'hello_world.txt') }
+  let(:work_2_file_name) { Rails.root.join('spec', 'fixtures', 'hello_world2.txt') }
+  let(:work_3_file_name) { Rails.root.join('spec', 'fixtures', 'hello_world3.txt') }
+  let(:csv_file) do
+    csv_file = Tempfile.new('csv_file.csv')
+
+    csv_file.write("member_of_collection_ids,work_type,title,file_name\n")
+    csv_file.write("#{collection.id},Generic,My Work 1,#{work_1_file_name}\n")
+    csv_file.write("#{collection.id},Generic,My Work 2,#{work_2_file_name}\n")
+    csv_file.write("#{collection.id},Generic,My Work 3,#{work_3_file_name}\n")
+    csv_file.close
+
+    csv_file
+  end
+
+  describe 'GET #new' do
+    subject(:new_call) { get :new }
+
+    it 'returns a success response' do
+      expect(new_call).to render_template('new')
+      expect(response).to be_success
+    end
+  end
+
+  describe 'POST #create' do
+    subject(:create_call) { post :create, params: { 'work_import_csv_file': { file: file } } }
+
+    let(:file) { Rack::Test::UploadedFile.new(csv_file.path) }
+
+    it 'runs a dry run on the file' do
+      expect(create_call).to render_template('dry_run_results')
+      expect(response).to be_success
+      expect(assigns(:results)).to be_a(Array)
+      expect(assigns(:results).map(&:valid?)).to eq([true, true, true])
+      expect(File).to be_exist(assigns(:file_name))
+    end
+
+    context 'invalid csv' do
+      let(:csv_file) do
+        csv_file = Tempfile.new('csv_file.csv')
+
+        csv_file.write("member_of_collection_ids,work_type,title,file_name\n")
+        csv_file.write(",Generic,My Work 1,#{work_1_file_name}\n")
+        csv_file.write("#{collection.id},Bad,My Work 2,#{work_2_file_name}\n")
+        csv_file.write("bad,Generic,,#{work_3_file_name}\n")
+        csv_file.close
+
+        csv_file
+      end
+
+      it 'runs a dry run on the file' do
+        expect(create_call).to render_template('dry_run_results')
+        expect(response).to be_success
+        expect(assigns(:results)).to be_a(Array)
+        expect(assigns(:results).map(&:valid?)).to eq([false, false, false])
+        expect(assigns(:results).map(&:errors).map(&:messages)).to eq([{ member_of_collection_ids: [' does not exist'] }, { work_type_id: ["can't be blank"] }, { member_of_collection_ids: ['bad does not exist'], title: ["can't be blank"] }])
+        expect(File).to be_exist(assigns(:file_name))
+      end
+    end
+  end
+
+  describe 'POST #run_import' do
+    subject(:import_call) { post :run_import, params: { file_name: csv_file.path } }
+
+    it 'runs an import on the file' do
+      expect(import_call).to render_template('import_success')
+      expect(response).to be_success
+      expect(assigns(:created)).to be_a(Array)
+      expect(assigns(:created).map(&:valid?)).to eq([true, true, true])
+      expect(assigns(:created).map(&:title)).to eq([['My Work 1'], ['My Work 2'], ['My Work 3']])
+    end
+  end
+end

--- a/spec/cho/work/import/csv_dry_run_spec.rb
+++ b/spec/cho/work/import/csv_dry_run_spec.rb
@@ -51,5 +51,28 @@ RSpec.describe Work::Import::CsvDryRun do
         expect(dry_run_results[2]).not_to be_valid
       end
     end
+
+    context 'Work Type string included ' do
+      let(:csv_data) { "member_of_collection_ids,work_type,title\n#{collection.id},Generic,\"My Stuff\"\n#{collection.id},Generic,\"My Awsome work\",\n#{collection.id},Generic,\"My Awsome work\"" }
+
+      it 'returns a list of change sets' do
+        is_expected.to be_a Array
+        expect(dry_run_results.count).to eq(3)
+        expect(dry_run_results[0]).to be_valid
+        expect(dry_run_results[1]).to be_valid
+        expect(dry_run_results[2]).to be_valid
+      end
+    end
+    context 'Work Type string included ' do
+      let(:file_name) { Rails.root.join('spec', 'fixtures', 'hello_world.txt') }
+      let(:csv_data) { "member_of_collection_ids,work_type,title,file_name\n#{collection.id},Generic,\"My Stuff\",#{file_name}" }
+
+      it 'returns a list of change sets' do
+        is_expected.to be_a Array
+        expect(dry_run_results.count).to eq(1)
+        expect(dry_run_results[0]).to be_valid
+        expect(dry_run_results[0].file).to be_a(ActionDispatch::Http::UploadedFile)
+      end
+    end
   end
 end

--- a/spec/cho/work/import/csv_importer_spec.rb
+++ b/spec/cho/work/import/csv_importer_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Work::Import::CsvImporter do
+  let(:collection) { create :library_collection }
+  let(:work_type_id) { Work::Type.find_using(label: 'Generic').first.id }
+  let(:work_hash_1) { { member_of_collection_ids: [collection.id], work_type_id: [work_type_id], title: 'My first work' } }
+  let(:work_hash_2) { { member_of_collection_ids: [collection.id], work_type_id: [work_type_id], title: 'My second work' } }
+  let(:change_set_list) { [Work::SubmissionChangeSet.new(Work::Submission.new(work_hash_1)),
+                           Work::SubmissionChangeSet.new(Work::Submission.new(work_hash_2))] }
+  let(:importer) { described_class.new(change_set_list) }
+
+  it 'creates the works' do
+    status = false
+    expect { status = importer.run }.to change(Work::Submission, :count).by(2)
+    expect(status).to be_truthy
+  end
+
+  context 'invalid work hash' do
+    let(:work_hash_2) { { member_of_collection_ids: [collection.id], work_type_id: [work_type_id], title: nil } }
+
+    it 'does not create the works' do
+      status = false
+      expect { status = importer.run }.to change(Work::Submission, :count).by(0)
+      expect(status).to be_falsey
+      expect(importer.errors).to eq(['Invalid items in list'])
+    end
+  end
+
+  context 'error during save' do
+    let(:bad_persister) { ChangeSetPersister.new(metadata_adapter: nil, storage_adapter: nil) }
+    let(:importer) { described_class.new(change_set_list, bad_persister) }
+
+    it 'does not create the works' do
+      status = false
+      expect { status = importer.run }.to change(Work::Submission, :count).by(0)
+      expect(status).to be_falsey
+      expect(importer.errors.count).to eq(2)
+      expect(importer.errors.map(&:class)).to eq([Work::SubmissionChangeSet, Work::SubmissionChangeSet])
+      expect(importer.errors.map(&:errors).map(&:full_messages)).to eq([["Save ChangeSetPersister#persister delegated to metadata_adapter.persister, but metadata_adapter is nil: #{bad_persister.inspect}"],
+                                                                        ["Save ChangeSetPersister#persister delegated to metadata_adapter.persister, but metadata_adapter is nil: #{bad_persister.inspect}"]])
+    end
+  end
+
+  context 'with a file' do
+    let(:file_name) { Rails.root.join('spec', 'fixtures', 'hello_world.txt') }
+    let(:work_hash_1) { { member_of_collection_ids: [collection.id], work_type_id: [work_type_id], title: 'My first work', file_name: file_name } }
+    let(:change_set_list) { [Work::SubmissionChangeSet.new(Work::Submission.new(work_hash_1))] }
+
+    it 'creates the works' do
+      status = false
+      expect { status = importer.run }.to change(Work::Submission, :count).by(1)
+      expect(status).to be_truthy
+    end
+  end
+end

--- a/spec/fixtures/hello_world2.txt
+++ b/spec/fixtures/hello_world2.txt
@@ -1,0 +1,1 @@
+Hello World!

--- a/spec/fixtures/hello_world3.txt
+++ b/spec/fixtures/hello_world3.txt
@@ -1,0 +1,1 @@
+Hello World!


### PR DESCRIPTION
## Description

Creates works by importing a csv file in the UI, running a dry run, and import.

Running this brings up some issues.
1. How are we getting the files attached to the work?
1. Should this really be a UI element based on question 1?
1. When the same file gets uploaded twice the upload process errors (files are stored on disk with their original file name)


References ticket: (if any) #238 

Why was this necessary?

## Changes

* Adds a Importer for the CSV Dry Run Results
* Adds files to the DRY Run
* Adds UI elements for running the entire process (very basic)


Are there any major changes in this PR that will change the release process? No

## Checklist

- [x] i18n enabled
- [x] adequate test coverage
- [ ] accessible interface
