### PR TITLE
Adding csv export 

### DIFF
--- a/app/blacklight/document/csv.rb
+++ b/app/blacklight/document/csv.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+# This module provide CSV export for works and collections
+#  @note the collection export is a list of works in CSV format, not the collection metadata
+#
+module Document::Csv
+  include CsvParsing
+
+  def self.extended(document)
+    # Register our exportable formats
+    Document::Csv.register_export_formats(document)
+  end
+
+  def self.register_export_formats(document)
+    document.will_export_as(:csv)
+  end
+
+  # Export the currect solr document in csv format
+  def export_as_csv
+    if collection?
+      export_collection
+    else
+      export_model
+    end
+  end
+
+  # needed to use the solr document as a scope for a search builder
+  def resource
+    self
+  end
+
+  # needed to use the solr document as a scope for a search builder
+  def blacklight_config
+    CatalogController.blacklight_config
+  end
+
+  private
+
+    def export_collection
+      ::CSV.generate do |csv|
+        csv << ['id', 'members_of_collection_id'] + fields.map(&:label)
+        export_members(csv)
+      end
+    end
+
+    def export_model
+      ::CSV.generate { |csv| csv << export_fields(self) }
+    end
+
+    def export_members(csv)
+      page = 1
+      more_members = true
+      while more_members
+        members = document_facade(page).members
+        members.each do |member|
+          csv << export_fields(member)
+        end
+        page += 1
+        more_members = members.count >= rows
+      end
+    end
+
+    def export_fields(solr_document)
+      values = fields.map do |field|
+        to_csv_field(solr_document.send(field.method_name))
+      end
+      [solr_document.id, to_csv_field(solr_document['member_of_collection_ids_ssim'])].concat(values)
+    end
+
+    def fields
+      @fields ||= DataDictionary::Field.all
+    end
+
+    # cleans up ids and converts arrays to a single string
+    def to_csv_field(field_value)
+      return field_value if field_value.blank?
+      remove_id_marker(Array.wrap(field_value)).join(VALUE_SEPARATOR)
+    end
+
+    # removes id- that gets added to the id fields in solr documents
+    def remove_id_marker(field_value)
+      field_value.map { |value| value.sub(/^id-/, '') }
+    end
+
+    def document_facade(current_page = 1)
+      SolrFacade.new(
+        repository: CatalogController.new.repository,
+        query: CollectionMemberSearchBuilder.new(self).page(current_page).rows(rows).query
+      )
+    end
+
+    def rows
+      100
+    end
+end

--- a/app/blacklight/solr_document.rb
+++ b/app/blacklight/solr_document.rb
@@ -19,8 +19,15 @@ class SolrDocument
   # Recommendation: Use field names from Dublin Core
   use_extension(Blacklight::Document::DublinCore)
 
+  # csv extension
+  use_extension(Document::Csv)
+
   def internal_resource
-    Array.wrap(self['internal_resource_tsim']).first.constantize
+    internal_resource_name.constantize
+  end
+
+  def internal_resource_name
+    Array.wrap(self['internal_resource_tsim']).first
   end
 
   # @return [Array<Work::File>]
@@ -35,5 +42,9 @@ class SolrDocument
     Array.wrap(self['member_of_collection_ids_ssim']).map do |id|
       SolrDocument.find(id.sub(/^id-/, ''))
     end
+  end
+
+  def collection?
+    internal_resource_name.include?('Collection')
   end
 end

--- a/app/cho/data_dictionary/field.rb
+++ b/app/cho/data_dictionary/field.rb
@@ -26,5 +26,13 @@ module DataDictionary
     def self.core_fields
       @core_fields ||= where(core_field: true)
     end
+
+    # this defined how the field should be addressed when creating dynamic methods for access
+    #  in other classes such as the SolrDocument
+    # @note Just the plain label is not necissarily unique enough to be used so we are adding a suffix to avoid collisions
+    #       with other methods
+    def method_name
+      "#{label}_data_dictionary_field"
+    end
   end
 end

--- a/app/cho/data_dictionary/fields_for_solr_document.rb
+++ b/app/cho/data_dictionary/fields_for_solr_document.rb
@@ -11,10 +11,14 @@ module DataDictionary::FieldsForSolrDocument
     #   This statement makes sure the rails environment can be loaded even if the database has yet to be created.
     if ActiveRecord::Base.connection.table_exists? 'orm_resources'
       DataDictionary::Field.all.each do |field|
-        next if field.field_type != 'string'
-
-        define_method(field.label) do
-          self["#{field.label}_tesim"]
+        if field.field_type == 'string' || field.field_type == 'text'
+          define_method(field.method_name) do
+            self["#{field.label}_tesim"]
+          end
+        else field.field_type == 'date'
+             define_method(field.method_name) do
+               self["#{field.label}_dtsi"]
+             end
         end
       end
     end

--- a/app/cho/shared/csv_parsing.rb
+++ b/app/cho/shared/csv_parsing.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module CsvParsing
+  VALUE_SEPARATOR = '|'
+end

--- a/app/cho/work/import/csv_reader.rb
+++ b/app/cho/work/import/csv_reader.rb
@@ -5,6 +5,8 @@ require 'csv'
 module Work
   module Import
     class CsvReader
+      include ::CsvParsing
+
       attr_reader :headers, :csv_hashes
 
       delegate :each, :map, to: :csv_hashes
@@ -12,8 +14,20 @@ module Work
       def initialize(csv_file)
         csv_data = ::CSV.parse(csv_file)
         @headers = csv_data.shift
-        @csv_hashes = csv_data.map { |a| Hash[@headers.zip(a)] }
+        @csv_hashes = csv_data.map { |a| Hash[@headers.zip(format_csv_data(a))] }
       end
+
+      private
+
+        def format_csv_data(data_array)
+          data_array.map do |value|
+            if value.present? && value.include?(VALUE_SEPARATOR)
+              value.split(VALUE_SEPARATOR)
+            else
+              value
+            end
+          end
+        end
     end
   end
 end

--- a/app/cho/work/submission_indexer.rb
+++ b/app/cho/work/submission_indexer.rb
@@ -27,7 +27,11 @@ module Work
 
       def collection_labels_for_ids
         return unless resource.respond_to?(:member_of_collection_ids)
-        resource.member_of_collection_ids.map { |id| SolrDocument.find(id).title }.flatten
+        resource.member_of_collection_ids.map { |id| SolrDocument.find(id).send(title_field_method) }.flatten
+      end
+
+      def title_field_method
+        @title_field ||= DataDictionary::Field.find_using(label: 'title').first.method_name
       end
   end
 end

--- a/config/data_dictionary/data_dictionary_test.csv
+++ b/config/data_dictionary/data_dictionary_test.csv
@@ -2,6 +2,7 @@ Label,Field Type,Requirement Designation,Validation,Multiple,Controlled Vocabula
 title,string,required,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,true
 subtitle,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,true
 description,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,true
+created,date,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false
 generic_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false
 document_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false
 still_image_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false

--- a/spec/blacklight/solr_document_spec.rb
+++ b/spec/blacklight/solr_document_spec.rb
@@ -11,16 +11,16 @@ RSpec.describe SolrDocument, type: :model do
     ActiveSupport::Dependencies.remove_constant('MyResource')
   end
 
-  describe '#internal_resource' do
-    subject { SolrDocument.new(document) }
+  subject(:solr_document) { SolrDocument.new(document) }
 
+  describe '#internal_resource' do
     let(:document) { { 'internal_resource_tsim' => 'MyResource' } }
 
     its(:internal_resource) { is_expected.to be(MyResource) }
   end
 
   describe '#files' do
-    subject { SolrDocument.new(document).files.first }
+    subject { solr_document.files.first }
 
     let(:work_file) { create :work_file }
     let(:document) { { 'internal_resource_tsim' => 'MyResource', files_ssim: [work_file.id.to_s] } }
@@ -31,7 +31,7 @@ RSpec.describe SolrDocument, type: :model do
   end
 
   describe '#member_of_collections' do
-    subject { SolrDocument.new(document).member_of_collections.first }
+    subject { solr_document.member_of_collections.first }
 
     let(:collection) { create(:archival_collection) }
     let(:document) { { 'internal_resource_tsim' => 'MyResource', member_of_collection_ids_ssim: [collection.id.to_s] } }
@@ -42,10 +42,61 @@ RSpec.describe SolrDocument, type: :model do
   end
 
   describe 'data dictionary field accessors' do
-    subject { SolrDocument.new(document) }
+    let(:document) { { 'internal_resource_tsim' => 'MyResource', title_tesim: ['my_title'], created_dtsi: ['2018-04-19T15:46:46Z'] } }
 
-    let(:document) { { 'internal_resource_tsim' => 'MyResource', title_tesim: ['my_title'] } }
+    its(:title_data_dictionary_field) { is_expected.to eq ['my_title'] }
+    its(:created_data_dictionary_field) { is_expected.to eq ['2018-04-19T15:46:46Z'] }
+  end
 
-    its(:title) { is_expected.to eq ['my_title'] }
+  describe 'exports_as? csv' do
+    subject { solr_document.exports_as?(:csv) }
+
+    let(:document) { { 'internal_resource_tsim' => 'MyResource' } }
+
+    it { is_expected.to be_truthy }
+  end
+
+  describe 'export_as_csv' do
+    subject { solr_document.export_as_csv }
+
+    let(:document) { { 'internal_resource_tsim' => 'MyResource', id: 'abc123', title_tesim: ['my_title'], generic_field_tesim: ['value1', 'value2'] } }
+
+    it { is_expected.to eq("abc123,,my_title,,,,value1|value2,,,,,\n") }
+
+    context 'a collection' do
+      let(:collection) { create :library_collection }
+      let(:work) { create :work, member_of_collection_ids: [collection.id], title: 'Work One' }
+      let(:work1_csv) { "#{work.id},#{collection.id},Work One,,,,,,,,," }
+      let(:work2) { create :work, member_of_collection_ids: [collection.id], title: 'Work Two' }
+      let(:work2_csv) { "#{work2.id},#{collection.id},Work Two,,,,,,,,," }
+      let(:csv_header) { 'id,members_of_collection_id,title,subtitle,description,created,generic_field,document_field,still_image_field,moving_image_field,map_field,audio_field' }
+      let(:document) { { 'internal_resource_tsim' => 'MyCollection', id: collection.id, title_tesim: ['my_collection'] } }
+
+      before do
+        work
+        work2
+      end
+
+      it { is_expected.to eq("#{csv_header}\n#{work1_csv}\n#{work2_csv}\n") }
+
+      it 'can use multiple pages' do
+        expect(solr_document).to receive(:rows).at_least(:once).and_return(1)
+        expect(solr_document.export_as_csv).to eq("#{csv_header}\n#{work1_csv}\n#{work2_csv}\n")
+      end
+    end
+  end
+
+  describe 'is_collection?' do
+    subject { solr_document.collection? }
+
+    let(:document) { { 'internal_resource_tsim' => 'MyResource' } }
+
+    it { is_expected.to be_falsey }
+
+    context 'collection document' do
+      let(:document) { { 'internal_resource_tsim' => 'MyCollection' } }
+
+      it { is_expected.to be_truthy }
+    end
   end
 end

--- a/spec/cho/work/import/csv_reader_spec.rb
+++ b/spec/cho/work/import/csv_reader_spec.rb
@@ -36,5 +36,12 @@ RSpec.describe Work::Import::CsvReader do
     subject { reader.csv_hashes }
 
     it { is_expected.to eq(csv_hash) }
+
+    context 'value has multiple items' do
+      let(:csv_file) { StringIO.new("header1,header2\ndata1,data2\ndataA1|dataA2,dataB") }
+      let(:csv_hash) { [{ 'header1' => 'data1', 'header2' => 'data2' }, { 'header1' => ['dataA1', 'dataA2'], 'header2' => 'dataB' }] }
+
+      it { is_expected.to eq(csv_hash) }
+    end
   end
 end


### PR DESCRIPTION
 * Adds .csv format to show for work and collection
 * Adds method name to field
 * Changed field methods defined on SolrDocument to not conflict with existing methods. resource field vs resource method existing on solr document
 * Changes indexer to use new method name

## Description

References ticket: (if any) refs #17

Why was this necessary? Adding export as requested by users

## Changes

Are there any major changes in this PR that will change the release process? no

## Checklist

- [x] adequate test coverage
