### PR TITLE
Upgrade to FactoryBot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'uglifier', '>= 1.3.0'
 
 group :development, :test do
   gem 'byebug', platform: :mri
+  gem 'factory_bot_rails'
   gem 'niftany'
   gem 'pry-byebug'
   gem 'pry-rails'
@@ -61,7 +62,6 @@ group :test do
   gem 'capybara'
   gem 'coveralls', require: false
   gem 'database_cleaner'
-  gem 'factory_girl_rails'
   gem 'launchy'
   gem 'rails-controller-testing'
   gem 'rspec-its'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,10 +255,10 @@ GEM
     et-orbi (1.0.5)
       tzinfo
     execjs (2.7.0)
-    factory_girl (4.8.0)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.8.0)
-      factory_girl (~> 4.8.0)
+    factory_bot_rails (4.8.2)
+      factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
@@ -623,7 +623,7 @@ DEPENDENCIES
   database_cleaner
   devise_remote
   execjs
-  factory_girl_rails
+  factory_bot_rails
   faker!
   figaro
   hydra-ldap

--- a/spec/factories/archival_collections.rb
+++ b/spec/factories/archival_collections.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :archival_collection, class: Collection::Archival do
     title 'Archival Collection'
     subtitle 'subtitle for an archival collection'

--- a/spec/factories/curated_collections.rb
+++ b/spec/factories/curated_collections.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :curated_collection, class: Collection::Curated do
     title 'Curated Collection'
     description 'Sample curated collection'

--- a/spec/factories/field.rb
+++ b/spec/factories/field.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :data_dictionary_field, class: DataDictionary::Field do
     sequence(:id)
     label 'abc123_label'

--- a/spec/factories/library_collections.rb
+++ b/spec/factories/library_collections.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :library_collection, class: Collection::Library do
     title 'Library Collection'
     description 'Sample library collection'

--- a/spec/factories/schema_metadata.rb
+++ b/spec/factories/schema_metadata.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :schema_metadata, class: Schema::Metadata do
     sequence(:id)
     label 'abc123_label'

--- a/spec/factories/schema_metadata_field.rb
+++ b/spec/factories/schema_metadata_field.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :schema_metadata_field, class: Schema::MetadataField do
     sequence(:id)
     label 'abc123_label'

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   sequence :login do |n|
     "user#{n}"
   end

--- a/spec/factories/work_file.rb
+++ b/spec/factories/work_file.rb
@@ -4,7 +4,7 @@
 #   work object gets autoloaded.  This supports the title field being defined on the object
 require Rails.root.join('spec', 'support', 'seed_map')
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :work_file, class: Work::File do
     original_filename 'original_name'
     use [Valkyrie::Vocab::PCDMUse.OriginalFile]

--- a/spec/factories/work_types.rb
+++ b/spec/factories/work_types.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :work_type, class: Work::Type do
     label 'Sample Work Type'
 

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -4,7 +4,7 @@
 #   work object gets autoloaded.  This supports the title field being defined on the object
 require Rails.root.join('spec', 'support', 'seed_map')
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :work_submission, aliases: [:work], class: Work::Submission do
     title 'Sample Generic Work'
     work_type_id { Work::Type.find_using(label: 'Generic').first.id }

--- a/spec/support/create_for_repository.rb
+++ b/spec/support/create_for_repository.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
-# Factories in Factory Girl don't return the value returned via `to_create`.
-# This custom strategy is necessary to enable data mapper patterns in Factory
-# Girl.
+# Factories in FactoryBot don't return the value returned via `to_create`.
+# This custom strategy is necessary to enable data mapper patterns in FactoryBot
 #
 # Copied from:
-#   https://github.com/thoughtbot/factory_girl/issues/565
+#   https://github.com/thoughtbot/factory_bot/issues/565
 class CreateStategyForRepositoryPattern
   def association(runner)
     runner.run
@@ -23,4 +22,4 @@ class CreateStategyForRepositoryPattern
     result
   end
 end
-FactoryGirl.register_strategy(:create, CreateStategyForRepositoryPattern)
+FactoryBot.register_strategy(:create, CreateStategyForRepositoryPattern)

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 end
 
-FactoryGirl.define do
+FactoryBot.define do
   to_create do |resource|
     Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: resource)
   end


### PR DESCRIPTION
## Description

Replaces the FactoryGirl gem with FactoryBot. Same functionality, just a
better name.

Fixes: #400 

Why was this necessary? The old gem name was problematic. The new gem name is less controversial.

## Changes

Are there any major changes in this PR that will change the release process? No

## Checklist

- [x] i18n enabled
- [x] adequate test coverage
- [x] accessible interface
