### PR TITLE
Changing Set.member to Set.of

### DIFF
--- a/app/cho/collection/common_fields.rb
+++ b/app/cho/collection/common_fields.rb
@@ -9,7 +9,7 @@ module Collection::CommonFields
 
   included do
     attribute :id, Valkyrie::Types::ID.optional
-    attribute :workflow, Valkyrie::Types::Set.member(Valkyrie::Types::String.enum(*WORKFLOW))
-    attribute :visibility, Valkyrie::Types::Set.member(Valkyrie::Types::String.enum(*VISIBILITY))
+    attribute :workflow, Valkyrie::Types::Set.of(Valkyrie::Types::String.enum(*WORKFLOW))
+    attribute :visibility, Valkyrie::Types::Set.of(Valkyrie::Types::String.enum(*VISIBILITY))
   end
 end

--- a/app/cho/work/submission_change_set.rb
+++ b/app/cho/work/submission_change_set.rb
@@ -10,7 +10,7 @@ module Work
     property :member_of_collection_ids,
              multiple: true,
              required: false,
-             type: Types::Strict::Array.member(Valkyrie::Types::ID)
+             type: Types::Strict::Array.of(Valkyrie::Types::ID)
 
     include DataDictionary::FieldsForChangeSet
     delegate :url_helpers, to: 'Rails.application.routes'

--- a/spec/cho/collection/common_fields_spec.rb
+++ b/spec/cho/collection/common_fields_spec.rb
@@ -13,9 +13,26 @@ RSpec.describe Collection::CommonFields, type: :model do
     ActiveSupport::Dependencies.remove_constant('MyCollection')
   end
 
-  subject { MyCollection.new }
+  subject(:collection) { MyCollection.new }
 
   it { is_expected.to respond_to(:id) }
   it { is_expected.to respond_to(:workflow) }
   it { is_expected.to respond_to(:visibility) }
+
+  describe '#visibility=' do
+    it 'can be set' do
+      expect { collection.visibility = 'public' }.not_to raise_error
+      expect { collection.visibility = 'authenticated' }.not_to raise_error
+      expect { collection.visibility = 'private' }.not_to raise_error
+      expect { collection.visibility = 'bogus' }.to raise_error(Dry::Types::ConstraintError)
+    end
+  end
+
+  describe '#workflow' do
+    it 'can be set' do
+      expect { collection.workflow = 'default' }.not_to raise_error
+      expect { collection.workflow = 'mediated' }.not_to raise_error
+      expect { collection.workflow = 'bogus' }.to raise_error(Dry::Types::ConstraintError)
+    end
+  end
 end


### PR DESCRIPTION
refs #415
.member is being depricated

## Description

References ticket: (if any)

Why was this necessary?

## Changes

Are there any major changes in this PR that will change the release process?

## Checklist

- [ ] i18n enabled
- [ ] adequate test coverage
- [ ] accessible interface
