### PR TITLE
Changing Submission to define it should have a Set of Ids for member_of_collections_id

### DIFF
--- a/app/cho/work/submission.rb
+++ b/app/cho/work/submission.rb
@@ -8,7 +8,9 @@ module Work
 
     attribute :id, Valkyrie::Types::ID.optional
     attribute :work_type_id, Valkyrie::Types::ID.optional
-    attribute :member_of_collection_ids, Valkyrie::Types::Set
+
+    # TODO  The default canbe removed after we upgrade to Valkyrie 1.0
+    attribute :member_of_collection_ids, Valkyrie::Types::Set.of(Valkyrie::Types::ID).default([])
 
     # A list of Work::Files.
     #  The stored valkyrie resource for files attached to a submission

--- a/spec/cho/work/submissions/submission_spec.rb
+++ b/spec/cho/work/submissions/submission_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Work::Submission do
 
     it 'can be set as an attribute' do
       resource = resource_klass.new(member_of_collection_ids: ['1', '2'])
-      expect(resource.attributes[:member_of_collection_ids]).to contain_exactly('1', '2')
+      expect(resource.attributes[:member_of_collection_ids].map(&:id)).to contain_exactly('1', '2')
     end
 
     it 'is included in the list of attributes' do


### PR DESCRIPTION
## Description

This changes the type of the values in the list to ids.
This does not really enforce that an id must be used, since Valkyrie::Types:ID take any value in it's constructor and does a to_s on it.
In addition we needed to add a default to the definition becuase of a bug in Dry::Types.  Valkyrie 1.0 works around this bug, so upgrading will allow us to remove our default.

References ticket: (if any) #415

Why was this necessary? For consistency and documentation to enforce that member_of_collections_ids will actually be Ids.

## Changes

Are there any major changes in this PR that will change the release process?

## Checklist

- [ ] i18n enabled
- [ ] adequate test coverage
- [ ] accessible interface
