### PR TITLE
Adding sync to change set so model is populated for work & Collectin edit and new

### DIFF
--- a/app/cho/collection/controller_behaviors.rb
+++ b/app/cho/collection/controller_behaviors.rb
@@ -63,6 +63,7 @@ module Collection::ControllerBehaviors
     end
 
     def respond_error(change_set, error_view)
+      change_set.sync
       @collection = change_set
       render error_view
     end

--- a/app/cho/work/submissions_controller.rb
+++ b/app/cho/work/submissions_controller.rb
@@ -53,6 +53,7 @@ module Work
       end
 
       def respond_error(change_set, error_view)
+        change_set.sync
         @work = change_set
         render error_view
       end

--- a/spec/cho/work/submissions/submissions_controller_spec.rb
+++ b/spec/cho/work/submissions/submissions_controller_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe Work::SubmissionsController, type: :controller do
       it "returns a success response (i.e. to display the 'new' template)" do
         post :create, params: { 'work_submission': invalid_attributes }
         expect(response).to be_success
+        expect(assigns(:work).model.title).to eq(['Missing a work type'])
       end
     end
   end
@@ -80,11 +81,12 @@ RSpec.describe Work::SubmissionsController, type: :controller do
     end
 
     context 'with an invalid change set' do
-      let(:invalid_attributes) { { title: '' } }
+      let(:invalid_attributes) { { title: '', description: 'my new description' } }
 
       it "returns a success response (i.e. to display the 'edit' template)" do
         put :update, params: { id: resource.to_param, 'work_submission': invalid_attributes }
         expect(response).to be_success
+        expect(assigns(:work).model.description).to eq(['my new description'])
       end
     end
   end

--- a/spec/support/shared/controllers.rb
+++ b/spec/support/shared/controllers.rb
@@ -51,6 +51,7 @@ RSpec.shared_examples 'a collection controller' do
       it "returns a success response (i.e. to display the 'new' template)" do
         post :create, params: { resource_class.model_name.param_key.to_sym => invalid_attributes }, session: valid_session
         expect(response).to be_success
+        expect(assigns[:collection].model.description).to eq(['A sample collection'])
       end
     end
   end
@@ -81,11 +82,12 @@ RSpec.shared_examples 'a collection controller' do
     end
 
     context 'with invalid params' do
-      let(:invalid_attributes) { { title: '' } }
+      let(:invalid_attributes) { { title: '', description: 'My Updated description' } }
 
       it "returns a success response (i.e. to display the 'edit' template)" do
         put :update, params: { id: collection.to_param, resource_class.model_name.param_key.to_sym => invalid_attributes }, session: valid_session
         expect(response).to be_success
+        expect(assigns[:collection].model.description).to eq(['My Updated description'])
       end
     end
   end


### PR DESCRIPTION
This makes sure that when there is an error with the model you will see the changes in the form and not just an empty form or the work's\collection's original values.

## Description

References ticket: (if any)  #425

Why was this necessary?  The form was coming back either empty or with the original values, not the values the user had typed in before the error.

## Changes

* Sync is now called on error to make sure the change set is showing the values entered by the user

Are there any major changes in this PR that will change the release process? No

## Checklist

- [ ] i18n enabled
- [x] adequate test coverage
- [ ] accessible interface
