### PR TITLE
Rename sample database names

### DIFF
--- a/config/samples/database.yml
+++ b/config/samples/database.yml
@@ -9,15 +9,15 @@ default: &default
 
 development:
   <<: *default
-  database: choish_dev
+  database: cho_dev
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: choish_test
+  database: cho_test
 
 production:
   <<: *default
-  database: choish_prod
+  database: cho_prod


### PR DESCRIPTION
## Description

This is purely cosmetic since all the database configuration is local
only.

Why was this necessary? "choish" was a previous name and shouldn't be used anymore.

## Changes

Are there any major changes in this PR that will change the release process? No, however, if you rebuild your local environment, you may need to create new databases with these names.

## Checklist

- [ ] i18n enabled
- [ ] adequate test coverage
- [ ] accessible interface
