### PR TITLE
Chose this PR to enforce the text type in data dictionary for description

### DIFF
--- a/app/cho/schema/metadata_field.rb
+++ b/app/cho/schema/metadata_field.rb
@@ -10,5 +10,13 @@ module Schema
       field.data_dictionary_field_id = data_dictionary_field.id
       field
     end
+
+    def input_type
+      if text?
+        :text_area
+      else
+        :text_field
+      end
+    end
   end
 end

--- a/app/views/shared/_form_fields.html.erb
+++ b/app/views/shared/_form_fields.html.erb
@@ -1,12 +1,16 @@
 <%- resource.form_fields.each do |metadata_field| %>
-  <% if metadata_field.requirement_designation == 'required' %>
+  <% if metadata_field.required? %>
     <%= form.label metadata_field.label, metadata_field.display_name do %>
       <%= metadata_field.label.titleize %><span class="required no_bold"> required</span>
     <% end %>
-    <%= form.text_field metadata_field.label, :required => true, 'aria-required' => true %>
+    <%= form.send(metadata_field.input_type, metadata_field.label, :required => true, 'aria-required' => true) %>
   <% else %>
-    <%= form.label metadata_field.label, metadata_field.display_name %>
-    <%= form.text_field metadata_field.label %>
+    <% if metadata_field.text? %>
+      <%= form.label metadata_field.label, metadata_field.display_name %>
+      <%= form.text_area metadata_field.label, value: resource.send(metadata_field.label).first %>
+    <% else %>
+      <%= form.label metadata_field.label, metadata_field.display_name %>
+      <%= form.send(metadata_field.input_type, metadata_field.label) %>
+    <% end %>
   <% end %>
-
 <%- end %>

--- a/config/data_dictionary/data_dictionary_test.csv
+++ b/config/data_dictionary/data_dictionary_test.csv
@@ -1,7 +1,7 @@
 Label,Field Type,Requirement Designation,Validation,Multiple,Controlled Vocabulary,Default Value,Display Name,Display Transformation,Index Type,Help Text,Core Field
 title,string,required,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,true
 subtitle,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,true
-description,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,true
+description,text,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,true
 created,date,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false
 generic_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false
 document_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false

--- a/spec/cho/collection/archival_collections/edit_spec.rb
+++ b/spec/cho/collection/archival_collections/edit_spec.rb
@@ -9,9 +9,12 @@ RSpec.describe Collection::Archival, type: :feature do
   context 'with all the required metadata' do
     it 'updates an existing work with new metadata' do
       visit(edit_archival_collection_path(resource))
+      expect(page).to have_field('Description', type: 'textarea', with: 'Sample archival collection')
       fill_in('archival_collection[title]', with: 'Updated Archival Collection Title')
+      fill_in('archival_collection[description]', with: 'Updated archival collection description')
       click_button('Update Archival collection')
       expect(page).to have_content('Updated Archival Collection Title')
+      expect(page).to have_content('Updated archival collection description')
     end
   end
 

--- a/spec/cho/collection/curated_collections/edit_spec.rb
+++ b/spec/cho/collection/curated_collections/edit_spec.rb
@@ -9,9 +9,12 @@ RSpec.describe Collection::Curated, type: :feature do
   context 'with all the required metadata' do
     it 'updates an existing work with new metadata' do
       visit(edit_curated_collection_path(resource))
+      expect(page).to have_field('Description', type: 'textarea', with: 'Sample curated collection')
       fill_in('curated_collection[title]', with: 'Updated Curated Collection Title')
+      fill_in('curated_collection[description]', with: 'Updated curated collection description')
       click_button('Update Curated collection')
       expect(page).to have_content('Updated Curated Collection Title')
+      expect(page).to have_content('Updated curated collection description')
     end
   end
 

--- a/spec/cho/collection/library_collections/edit_spec.rb
+++ b/spec/cho/collection/library_collections/edit_spec.rb
@@ -9,9 +9,12 @@ RSpec.describe Collection::Library, type: :feature do
   context 'with all the required metadata' do
     it 'updates an existing work with new metadata' do
       visit(edit_library_collection_path(resource))
+      expect(page).to have_field('Description', type: 'textarea', with: 'Sample library collection')
       fill_in('library_collection[title]', with: 'Updated Library Collection Title')
+      fill_in('library_collection[description]', with: 'Updated library collection description')
       click_button('Update Library collection')
       expect(page).to have_content('Updated Library Collection Title')
+      expect(page).to have_content('Updated library collection description')
     end
   end
 

--- a/spec/cho/schema/metadata_field_spec.rb
+++ b/spec/cho/schema/metadata_field_spec.rb
@@ -82,4 +82,18 @@ RSpec.describe Schema::MetadataField, type: :model do
       expect(schema_field.data_dictionary_field_id.to_s).to eq(data_dictionary_field.id.to_s)
     end
   end
+
+  describe '#input_type' do
+    subject { model.input_type }
+
+    context 'by default' do
+      it { is_expected.to eq(:text_field) }
+    end
+
+    context 'by default' do
+      let(:model) { described_class.new(field_type: 'text') }
+
+      it { is_expected.to eq(:text_area) }
+    end
+  end
 end

--- a/spec/cho/work/submissions/edit_spec.rb
+++ b/spec/cho/work/submissions/edit_spec.rb
@@ -13,9 +13,12 @@ RSpec.describe 'Editing works', type: :feature do
       expect(page).to have_content('Editing Work')
       expect(page).to have_selector('h2', text: 'Work to edit')
       expect(page).to have_link('Show')
+      expect(page).to have_field('Description', type: 'textarea', with: nil)
       fill_in('work_submission[title]', with: 'Updated Work Title')
+      fill_in('work_submission[description]', with: 'Updated description')
       click_button('Update Work')
       expect(page).to have_content('Updated Work Title')
+      expect(page).to have_content('Updated description')
     end
   end
 

--- a/spec/views/archival_collections/edit.html.erb_spec.rb
+++ b/spec/views/archival_collections/edit.html.erb_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'collection/archival_collections/edit', type: :view do
     assert_select 'form[action=?][method=?]', archival_collection_path(@collection), 'post' do
       assert_select 'input[name=?]', 'archival_collection[title]'
       assert_select 'input[name=?]', 'archival_collection[subtitle]'
-      assert_select 'input[name=?]', 'archival_collection[description]'
+      assert_select 'textarea[name=?]', 'archival_collection[description]'
       assert_select 'input[name=?]', 'archival_collection[workflow]'
       assert_select 'input[name=?]', 'archival_collection[visibility]'
       # Added to make sure accessibility changes are in place

--- a/spec/views/archival_collections/new.html.erb_spec.rb
+++ b/spec/views/archival_collections/new.html.erb_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'collection/archival_collections/new', type: :view do
     assert_select 'form[action=?][method=?]', archival_collections_path, 'post' do
       assert_select 'input[name=?]', 'archival_collection[title]'
       assert_select 'input[name=?]', 'archival_collection[subtitle]'
-      assert_select 'input[name=?]', 'archival_collection[description]'
+      assert_select 'textarea[name=?]', 'archival_collection[description]'
       assert_select 'input[name=?]', 'archival_collection[workflow]'
       assert_select 'input[name=?]', 'archival_collection[visibility]'
       # Added to make sure accessibility changes are in place

--- a/spec/views/curated_collections/edit.html.erb_spec.rb
+++ b/spec/views/curated_collections/edit.html.erb_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'collection/curated_collections/edit', type: :view do
     assert_select 'form[action=?][method=?]', curated_collection_path(@collection), 'post' do
       assert_select 'input[name=?]', 'curated_collection[title]'
       assert_select 'input[name=?]', 'curated_collection[subtitle]'
-      assert_select 'input[name=?]', 'curated_collection[description]'
+      assert_select 'textarea[name=?]', 'curated_collection[description]'
       assert_select 'input[name=?]', 'curated_collection[workflow]'
       assert_select 'input[name=?]', 'curated_collection[visibility]'
       # Added to make sure accessibility changes are in place

--- a/spec/views/curated_collections/new.html.erb_spec.rb
+++ b/spec/views/curated_collections/new.html.erb_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'collection/curated_collections/new', type: :view do
     assert_select 'form[action=?][method=?]', curated_collections_path, 'post' do
       assert_select 'input[name=?]', 'curated_collection[title]'
       assert_select 'input[name=?]', 'curated_collection[subtitle]'
-      assert_select 'input[name=?]', 'curated_collection[description]'
+      assert_select 'textarea[name=?]', 'curated_collection[description]'
       assert_select 'input[name=?]', 'curated_collection[workflow]'
       assert_select 'input[name=?]', 'curated_collection[visibility]'
       # Added to make sure accessibility changes are in place

--- a/spec/views/library_collections/edit.html.erb_spec.rb
+++ b/spec/views/library_collections/edit.html.erb_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'collection/library_collections/edit', type: :view do
     assert_select 'form[action=?][method=?]', library_collection_path(@collection), 'post' do
       assert_select 'input[name=?]', 'library_collection[title]'
       assert_select 'input[name=?]', 'library_collection[subtitle]'
-      assert_select 'input[name=?]', 'library_collection[description]'
+      assert_select 'textarea[name=?]', 'library_collection[description]'
       assert_select 'input[name=?]', 'library_collection[workflow]'
       assert_select 'input[name=?]', 'library_collection[visibility]'
       # Added to make sure accessibility changes are in place

--- a/spec/views/library_collections/new.html.erb_spec.rb
+++ b/spec/views/library_collections/new.html.erb_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'collection/library_collections/new', type: :view do
     assert_select 'form[action=?][method=?]', library_collections_path, 'post' do
       assert_select 'input[name=?]', 'library_collection[title]'
       assert_select 'input[name=?]', 'library_collection[subtitle]'
-      assert_select 'input[name=?]', 'library_collection[description]'
+      assert_select 'textarea[name=?]', 'library_collection[description]'
       assert_select 'input[name=?]', 'library_collection[workflow]'
       assert_select 'input[name=?]', 'library_collection[visibility]'
       # Added to make sure accessibility changes are in place

--- a/spec/views/work_submissions/edit.html.erb_spec.rb
+++ b/spec/views/work_submissions/edit.html.erb_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'work/submissions/edit', type: :view do
     assert_select 'form[action=?][method=?]', work_path(@work.model), 'post' do
       assert_select 'input[name=?]', 'work_submission[title]'
       assert_select 'input[name=?]', 'work_submission[subtitle]'
-      assert_select 'input[name=?]', 'work_submission[description]'
+      assert_select 'textarea[name=?]', 'work_submission[description]'
       assert_select 'input[name=?]', "work_submission[#{specific_field}]"
     end
   end


### PR DESCRIPTION
# Option A

## Description

Renders a text area when the data dictionary field type is 'text.' By
default, everything else is still a text input.

Fixes: #475 

Why was this necessary? The description field was not rendered as a text area.

## Changes

Are there any major changes in this PR that will change the release process? No

## Checklist

- [ ] i18n enabled
- [ ] adequate test coverage
- [ ] accessible interface
