### PR TITLE
Allow repository resets in selected service environments

### DIFF
--- a/app/cho/metrics/repository.rb
+++ b/app/cho/metrics/repository.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Metrics
+  class Repository
+    WHITELIST = ['localhost', 'qa'].freeze
+
+    class ResetError < StandardError; end
+
+    def self.reset
+      raise ResetError, "Reset not allowed for #{ENV['service_name']}" unless WHITELIST.include?(ENV['service_name'])
+      Valkyrie.config.metadata_adapter.resource_factory.orm_class.connection.truncate('orm_resources')
+      Blacklight.default_index.connection.delete_by_query('*:*')
+      Blacklight.default_index.connection.commit
+      FileUtils.rm_rf(Rails.root.join('tmp', 'files').to_s)
+      FileUtils.mkdir(Rails.root.join('tmp', 'files').to_s)
+      Rails.application.load_seed
+    end
+  end
+end

--- a/config/application.yml
+++ b/config/application.yml
@@ -2,9 +2,11 @@
 # For further instructions see: http://sites.psu.edu/dltdocs/?p=4073
 
 development:
+  service_name: "localhost"
   service_instance: "localhost"
   virtual_host: "http://localhost:3000/"
 test:
+  service_name: "example-test"
   service_instance: "example-test"
   virtual_host: "http://test.com/"
 production:

--- a/lib/tasks/benchmark.rake
+++ b/lib/tasks/benchmark.rake
@@ -15,5 +15,10 @@ namespace :cho do
       metric.file_size = file_size
       metric.run
     end
+
+    desc 'Clean out the application and re-seed the database'
+    task reset: :environment do
+      Metrics::Repository.reset
+    end
   end
 end

--- a/spec/cho/metrics/repository_spec.rb
+++ b/spec/cho/metrics/repository_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Metrics::Repository do
+  describe '::reset' do
+    context 'when the service instance is not white-listed' do
+      it 'prevents you from resetting the repository' do
+        expect { described_class.reset }.to raise_error(Metrics::Repository::ResetError)
+      end
+    end
+
+    context 'when the service instance is white-listed' do
+      it 'resets the repository' do
+        current = ENV['service_name']
+        ENV['service_name'] = 'qa'
+        described_class.reset
+        ENV['service_name'] = current
+      end
+    end
+  end
+
+  describe '::WHITELIST' do
+    subject { Metrics::Repository::WHITELIST }
+
+    it { is_expected.to contain_exactly('localhost', 'qa') }
+  end
+end

--- a/tasks/dev.rake
+++ b/tasks/dev.rake
@@ -3,11 +3,6 @@
 namespace :cho do
   desc 'Clean out the dev environment and re-seed the database'
   task clean: :environment do
-    Valkyrie.config.metadata_adapter.resource_factory.orm_class.connection.truncate('orm_resources')
-    Blacklight.default_index.connection.delete_by_query('*:*')
-    Blacklight.default_index.connection.commit
-    FileUtils.rm_rf(Rails.root.join('tmp', 'files').to_s)
-    FileUtils.mkdir(Rails.root.join('tmp', 'files').to_s)
-    Rake::Task['db:seed'].invoke
+    Rake::Task['cho:benchmark:reset'].invoke
   end
 end


### PR DESCRIPTION
## Description

Cleaning out the repository and running benchmarks is a common task for specific environments. However, it should only be allowed in specific ones, for example, only in QA or local and not in production.

Why was this necessary?

This makes running benchmarks and resetting the QA environment an easier process.

## Changes

Are there any major changes in this PR that will change the release process? Yes, we need to add a new key to the server's application.yml file.

## Checklist

- [ ] i18n enabled
- [ ] adequate test coverage
- [ ] accessible interface
