### PR TITLE
Re-enabling New Relic in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,6 @@ group :test do
   gem 'selenium-webdriver'
 end
 
-# @todo https://github.com/psu-libraries/cho-req/issues/225
 group :production do
-  # gem 'newrelic_rpm'
+  gem 'newrelic_rpm'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -359,6 +359,7 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (4.2.0)
     netrc (0.11.0)
+    newrelic_rpm (5.1.0.344)
     niftany (0.0.2)
       erb_lint (~> 0.0.22)
       rubocop (~> 0.51, <= 0.52.1)
@@ -632,6 +633,7 @@ DEPENDENCIES
   json
   launchy
   listen (~> 3.0.5)
+  newrelic_rpm
   niftany
   pg
   pry-byebug


### PR DESCRIPTION
## Description

Re-enable New Relic. The error with rake tasks seems to have resolved itself.

Fixes: #225 

## Changes

Are there any major changes in this PR that will change the release process? No

## Checklist

- [ ] i18n enabled
- [ ] adequate test coverage
- [ ] accessible interface
