### PR TITLE
Adding New Relic tracer to Metrics::Collection

### DIFF
--- a/app/cho/metrics/collection.rb
+++ b/app/cho/metrics/collection.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+require 'newrelic_rpm'
+
 module Metrics
   class Collection
+    include ::NewRelic::Agent::Instrumentation::ControllerInstrumentation
+
     attr_reader :length
 
     # @param [Integer] length how many times the metric will be run
@@ -18,6 +22,7 @@ module Metrics
       benchmark
       $stdout = current_stdout
     end
+    add_transaction_tracer :run, category: :task
 
     def benchmark
       Benchmark.benchmark("#{I18n.t('cho.metrics.benchmark_heading')}\n", 0, "%u,%y,%t,%r\n") do |bench|


### PR DESCRIPTION
## Description

Capture statistics from New Relic when we run our benchmark metrics.

Why was this necessary?

New Relic was not capturing any data when benchmarks were run. Adding
the tracer to the process solves the issue.

This was based on documentation from New Relic:
https://docs.newrelic.com/docs/agents/ruby-agent/background-jobs/monitor-ruby-background-processes

## Changes

Are there any major changes in this PR that will change the release process? No.

## Checklist

- [ ] i18n enabled
- [ ] adequate test coverage
- [ ] accessible interface
