### PR TITLE
Creating persisters that allow for singular, since it works for us

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,9 @@ git_source(:github) do |repo_name|
 end
 
 # Main gems
+gem 'blacklight'
 gem 'rails', '~> 5.1.3'
-gem 'valkyrie', github: 'samvera-labs/valkyrie'
+gem 'valkyrie', '~> 1.0'
 
 # Supporting gems
 gem 'coffee-rails', '~> 4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,27 +1,4 @@
 GIT
-  remote: https://github.com/samvera-labs/valkyrie.git
-  revision: cccdf6631905e5a5ccec2adf89d4230845890d20
-  specs:
-    valkyrie (0.1.0)
-      active-fedora
-      active-triples
-      activemodel
-      activerecord
-      activesupport
-      draper
-      dry-struct
-      dry-types
-      hydra-access-controls
-      hydra-derivatives
-      json
-      json-ld
-      pg
-      rdf
-      reform
-      reform-rails
-      ruby_tika_app
-
-GIT
   remote: https://github.com/stympy/faker.git
   revision: f8e1b81f8da82ea9eb88c4939a3a6801f97e5ac1
   branch: master
@@ -55,7 +32,7 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    active-fedora (11.5.2)
+    active-fedora (12.0.1)
       active-triples (>= 0.11.0, < 2.0.0)
       activemodel (>= 4.2, < 6)
       activesupport (>= 4.2.4, < 6)
@@ -71,8 +48,6 @@ GEM
       activesupport (>= 3.0.0)
       rdf (~> 2.0, >= 2.0.2)
       rdf-vocab (~> 2.0)
-    active_encode (0.1.1)
-      activesupport
     activejob (5.1.4)
       activesupport (= 5.1.4)
       globalid (>= 0.3.6)
@@ -97,7 +72,7 @@ GEM
       sshkit (>= 1.6.1, != 1.7.0)
     arel (8.0.0)
     ast (2.4.0)
-    autoprefixer-rails (7.2.3)
+    autoprefixer-rails (8.3.0)
       execjs
     bcrypt (3.1.11)
     better_errors (2.4.0)
@@ -115,7 +90,7 @@ GEM
     bindex (0.5.0)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
-    blacklight (6.13.0)
+    blacklight (6.14.1)
       bootstrap-sass (~> 3.2)
       deprecation
       globalid
@@ -125,16 +100,11 @@ GEM
       rails (>= 4.2, < 6)
       rsolr (>= 1.0.6, < 3)
       twitter-typeahead-rails (= 0.11.1.pre.corejavascript)
-    blacklight-access_controls (0.6.2)
-      blacklight (~> 6.0)
-      cancancan (~> 1.8)
-      deprecation (~> 1.0)
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
     builder (3.2.3)
     byebug (9.1.0)
-    cancancan (1.17.0)
     capistrano (3.9.1)
       airbrussh (>= 1.0.0)
       i18n
@@ -221,9 +191,9 @@ GEM
     dry-container (0.6.0)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.1, >= 0.1.3)
-    dry-core (0.4.2)
+    dry-core (0.4.5)
       concurrent-ruby (~> 1.0)
-    dry-equalizer (0.2.0)
+    dry-equalizer (0.2.1)
     dry-logic (0.4.2)
       dry-container (~> 0.2, >= 0.2.6)
       dry-core (~> 0.2)
@@ -275,21 +245,6 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     http_logger (0.5.1)
-    hydra-access-controls (10.5.0)
-      active-fedora (>= 10.0.0, < 12)
-      activesupport (>= 4, < 6)
-      blacklight (>= 5.16)
-      blacklight-access_controls (~> 0.6)
-      cancancan (~> 1.8)
-      deprecation (~> 1.0)
-    hydra-derivatives (3.3.2)
-      active-fedora (>= 11.3.1, < 12)
-      active_encode (~> 0.1)
-      activesupport (>= 4.0, < 6)
-      addressable (~> 2.5)
-      deprecation
-      mime-types (> 2.0, < 4.0)
-      mini_magick (>= 3.2, < 5)
     hydra-ldap (0.1.0)
       net-ldap
       rails
@@ -322,7 +277,7 @@ GEM
     kaminari-core (1.1.1)
     launchy (2.4.3)
       addressable (~> 2.3)
-    ldp (0.7.0)
+    ldp (0.7.2)
       deprecation
       faraday
       http_logger
@@ -346,7 +301,6 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_magick (4.8.0)
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
@@ -367,7 +321,6 @@ GEM
     nio4r (2.1.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
-    open4 (1.3.4)
     orm_adapter (0.5.0)
     parallel (1.12.1)
     parser (2.5.0.5)
@@ -445,7 +398,8 @@ GEM
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
       uber (< 0.2.0)
-    request_store (1.3.2)
+    request_store (1.4.1)
+      rack (>= 1.4)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -498,8 +452,6 @@ GEM
     rubocop-rspec (1.22.2)
       rubocop (>= 0.52.1)
     ruby-progressbar (1.9.0)
-    ruby_tika_app (1.5.0)
-      open4
     rubyzip (1.2.1)
     rufus-scheduler (3.4.2)
       et-orbi (~> 1.0)
@@ -532,7 +484,7 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.1)
       tilt (~> 2.0)
-    slop (4.6.1)
+    slop (4.6.2)
     smart_properties (1.13.1)
     solr_wrapper (1.1.0)
       faraday
@@ -586,6 +538,22 @@ GEM
       unf_ext
     unf_ext (0.0.7.4)
     unicode-display_width (1.3.0)
+    valkyrie (1.0.0)
+      active-fedora
+      active-triples
+      activemodel
+      activerecord
+      activesupport
+      draper
+      dry-struct
+      dry-types
+      json
+      json-ld
+      pg (< 1.0)
+      railties
+      rdf
+      reform
+      reform-rails
     vegas (0.1.11)
       rack (>= 1.0.0)
     warden (1.2.7)
@@ -610,6 +578,7 @@ PLATFORMS
 DEPENDENCIES
   better_errors
   binding_of_caller
+  blacklight
   byebug
   capistrano (~> 3.7)
   capistrano-bundler (~> 1.2)
@@ -652,7 +621,7 @@ DEPENDENCIES
   therubyracer
   turbolinks (~> 5)
   uglifier (>= 1.3.0)
-  valkyrie!
+  valkyrie (~> 1.0)
   web-console (>= 3.3.0)
   xray-rails
 

--- a/app/cho/work/submission.rb
+++ b/app/cho/work/submission.rb
@@ -31,5 +31,9 @@ module Work
         'work'
       end
     end
+
+    def attributes
+      super
+    end
   end
 end

--- a/app/valkyrie/indexing_adapter.rb
+++ b/app/valkyrie/indexing_adapter.rb
@@ -92,7 +92,7 @@ class IndexingAdapter
     end
 
     def buffered_persister
-      @buffered_persister ||= Valkyrie::Persistence::BufferedPersister.new(persister)
+      @buffered_persister ||= Valkyrie::Persistence::BufferedPersister.new(persister, buffer_class: Memory::SingularDeleteTrackingBuffer)
     end
   end
 end

--- a/app/valkyrie/memory/singular_delete_tracking_buffer.rb
+++ b/app/valkyrie/memory/singular_delete_tracking_buffer.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Memory::SingularDeleteTrackingBuffer < Valkyrie::Persistence::DeleteTrackingBuffer
+  def persister
+    @persister ||= Persister.new(self)
+  end
+
+  class Persister < Memory::SingularPersister
+    attr_reader :deletes
+    def initialize(*args)
+      @deletes = []
+      super
+    end
+
+    def delete(resource:)
+      @deletes << resource
+      super
+    end
+  end
+end

--- a/app/valkyrie/memory/singular_metadata_adapter.rb
+++ b/app/valkyrie/memory/singular_metadata_adapter.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Memory
+  class SingularMetadataAdapter < Valkyrie::Persistence::Memory::MetadataAdapter
+    # @return [Valkyrie::Persistence::Memory::Persister] A memory persister for
+    #   this adapter.
+    def persister
+      Memory::SingularPersister.new(self)
+    end
+  end
+end

--- a/app/valkyrie/memory/singular_persister.rb
+++ b/app/valkyrie/memory/singular_persister.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Memory::SingularPersister < Valkyrie::Persistence::Memory::Persister
+  # overriding ensure_multiple_values! to do nothing since we are allowing singular values
+  def ensure_multiple_values!(resource); end
+end

--- a/app/valkyrie/postgres/singular_metadata_adapter.rb
+++ b/app/valkyrie/postgres/singular_metadata_adapter.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Postgres
+  class SingularMetadataAdapter
+    # @return [Class] {Valkyrie::Persistence::Postgres::Persister}
+    def persister
+      SingularPersister.new(adapter: self)
+    end
+
+    # @return [Class] {Valkyrie::Persistence::Postgres::QueryService}
+    def query_service
+      @query_service ||= Valkyrie::Persistence::Postgres::QueryService.new(adapter: self)
+    end
+
+    # @return [Class] {Valkyrie::Persistence::Postgres::ResourceFactory}
+    def resource_factory
+      Valkyrie::Persistence::Postgres::ResourceFactory
+    end
+  end
+end

--- a/app/valkyrie/postgres/singular_persister.rb
+++ b/app/valkyrie/postgres/singular_persister.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Postgres
+  class SingularPersister < Valkyrie::Persistence::Postgres::Persister
+    private
+
+      # overriding ensure_multiple_values! to do nothing since we are allowing singular values
+      def ensure_multiple_values!(resource); end
+  end
+end

--- a/app/valkyrie/solr/singular_metadata_adapter.rb
+++ b/app/valkyrie/solr/singular_metadata_adapter.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Solr
+  class SingularMetadataAdapter < Valkyrie::Persistence::Solr::MetadataAdapter
+    def persister
+      Solr::SingularPersister.new(adapter: self)
+    end
+  end
+end

--- a/app/valkyrie/solr/singular_persister.rb
+++ b/app/valkyrie/solr/singular_persister.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Solr::SingularPersister < Valkyrie::Persistence::Solr::Persister
+  def repository(resources)
+    Solr::SingularRepository.new(resources: resources, connection: connection, resource_factory: resource_factory)
+  end
+end

--- a/app/valkyrie/solr/singular_repository.rb
+++ b/app/valkyrie/solr/singular_repository.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Solr::SingularRepository < Valkyrie::Persistence::Solr::Repository
+  # overriding ensure_multiple_values! to do nothing since we are allowing singular values
+  def ensure_multiple_values!(resource); end
+end

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -5,17 +5,17 @@ Rails.application.config.to_prepare do
   # Metadata Adapters
 
   Valkyrie::MetadataAdapter.register(
-    Valkyrie::Persistence::Postgres::MetadataAdapter.new,
+    Postgres::SingularMetadataAdapter.new,
     :postgres
   )
 
   Valkyrie::MetadataAdapter.register(
-    Valkyrie::Persistence::Memory::MetadataAdapter.new,
+    Memory::SingularMetadataAdapter.new,
     :memory
   )
 
   Valkyrie::MetadataAdapter.register(
-    Valkyrie::Persistence::Solr::MetadataAdapter.new(
+    Solr::SingularMetadataAdapter.new(
       connection: Blacklight.default_index.connection,
       resource_indexer: Valkyrie::Persistence::Solr::CompositeIndexer.new(
         Valkyrie::Indexers::AccessControlsIndexer,

--- a/spec/cho/data_dictionary/field_spec.rb
+++ b/spec/cho/data_dictionary/field_spec.rb
@@ -92,6 +92,7 @@ RSpec.describe DataDictionary::Field, type: :model do
                                 internal_resource: 'DataDictionary::Field',
                                 label: 'abc123_label',
                                 multiple: false,
+                                new_record: false,
                                 requirement_designation: 'recommended',
                                 updated_at: saved_model.updated_at,
                                 validation: 'no_validation',

--- a/spec/cho/schema/metadata_field_spec.rb
+++ b/spec/cho/schema/metadata_field_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe Schema::MetadataField, type: :model do
                                 internal_resource: 'Schema::MetadataField',
                                 label: 'abc123_label',
                                 multiple: false,
+                                new_record: false,
                                 requirement_designation: 'recommended',
                                 updated_at: saved_model.updated_at,
                                 validation: 'no_validation',

--- a/spec/cho/schema/metadata_spec.rb
+++ b/spec/cho/schema/metadata_spec.rb
@@ -23,15 +23,18 @@ RSpec.describe Schema::Metadata, type: :model do
     subject { saved_model }
 
     let(:saved_model) { Valkyrie.config.metadata_adapter.persister.save(resource: model) }
-    let(:expected_metadata) { { core_fields: core_fields.map(&:id),
-                                created_at: saved_model.created_at,
-                                fields: fields.map(&:id),
+    let(:expected_metadata) { { created_at: saved_model.created_at,
                                 id: saved_model.id,
                                 internal_resource: 'Schema::Metadata',
                                 label: 'abc123_label',
+                                new_record: false,
                                 updated_at: saved_model.updated_at } }
 
-    its(:attributes) { is_expected.to eq(expected_metadata) }
+    it 'has the correct attributes' do
+      expect(saved_model.attributes[:core_fields].map(&:id)).to eq(core_fields.map(&:id).map(&:id))
+      expect(saved_model.attributes[:fields].map(&:id)).to eq(fields.map(&:id).map(&:id))
+      expect(saved_model.attributes).to include(expected_metadata)
+    end
   end
 
   context 'loading template' do

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -8,4 +8,8 @@ FactoryBot.define do
   to_create do |resource|
     Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: resource)
   end
+
+  after :build do |record|
+    record.new_record = false if record.id.present?
+  end
 end

--- a/spec/support/shared/collections.rb
+++ b/spec/support/shared/collections.rb
@@ -46,7 +46,7 @@ RSpec.shared_examples 'a collection' do
   end
 
   describe '#members' do
-    subject { resource_klass.new }
+    subject { resource_klass.new(new_record: false) }
 
     its(:members) { is_expected.to be_empty }
   end

--- a/spec/valkyrie/indexing_adapter_spec.rb
+++ b/spec/valkyrie/indexing_adapter_spec.rb
@@ -5,14 +5,23 @@ require 'valkyrie/specs/shared_specs'
 
 RSpec.describe IndexingAdapter do
   let(:adapter) do
-    described_class.new(metadata_adapter: Valkyrie::Persistence::Memory::MetadataAdapter.new,
+    described_class.new(metadata_adapter: Memory::SingularMetadataAdapter.new,
                         index_adapter: index_solr)
   end
   let(:query_service) { adapter.query_service }
   let(:persister)     { adapter.persister }
   let(:index_solr)    { Valkyrie::MetadataAdapter.find(:index_solr) }
 
-  it_behaves_like 'a Valkyrie::Persister'
+  context 'shared examples allowing singular values' do
+    before do |example|
+      # We are skipping the check for 'does not save non-array properties' since we are allowing singular values
+      if example.description == 'does not save non-array properties'
+        skip 'We are allowing Non Array Properties'
+      end
+    end
+
+    it_behaves_like 'a Valkyrie::Persister'
+  end
 
   it 'updates Solr after saving to the metadata adapter' do
     persister.buffer_into_index do |buffered_adapter|

--- a/spec/valkyrie/memory/singular_adapter_spec.rb
+++ b/spec/valkyrie/memory/singular_adapter_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'valkyrie/specs/shared_specs'
+
+RSpec.describe Memory::SingularMetadataAdapter do
+  let(:adapter) do
+    described_class.new
+  end
+
+  it_behaves_like 'a Valkyrie::MetadataAdapter'
+
+  its(:persister) { is_expected.to be_a Memory::SingularPersister }
+end

--- a/spec/valkyrie/memory/singular_delete_tracking_buffer_spec.rb
+++ b/spec/valkyrie/memory/singular_delete_tracking_buffer_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'valkyrie/specs/shared_specs'
+
+RSpec.describe Memory::SingularDeleteTrackingBuffer do
+  let(:adapter) { described_class.new }
+  let(:query_service) { adapter.query_service }
+  let(:persister) do
+    adapter.persister
+  end
+
+  context 'shared examples allowing singular values' do
+    before do |example|
+      # We are skipping the check for 'does not save non-array properties' since we are allowing sigular values
+      if example.description == 'does not save non-array properties'
+        skip 'We are allowing Non Array Properties'
+      end
+    end
+
+    it_behaves_like 'a Valkyrie::Persister'
+  end
+  before do
+    class Resource < Valkyrie::Resource
+      include Valkyrie::Resource::AccessControls
+      attribute :id, Valkyrie::Types::ID.optional
+      attribute :title
+      attribute :member_ids
+      attribute :nested_resource
+    end
+  end
+  after do
+    Object.send(:remove_const, :Resource)
+  end
+  it 'tracks deletes' do
+    obj = persister.save(resource: Resource.new)
+    persister.delete(resource: obj)
+
+    expect(persister.deletes).to eq [obj]
+  end
+end

--- a/spec/valkyrie/memory/singular_persister_spec.rb
+++ b/spec/valkyrie/memory/singular_persister_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'valkyrie/specs/shared_specs'
+
+RSpec.describe Memory::SingularPersister do
+  let(:persister) { described_class.new(adapter) }
+  let(:adapter) { Memory::SingularMetadataAdapter.new }
+  let(:query_service) { adapter.query_service }
+
+  context 'shared examples allowing singular values' do
+    before do |example|
+      # We are skipping the check for 'does not save non-array properties' since we are allowing singular values
+      if example.description == 'does not save non-array properties'
+        skip 'We are allowing Non Array Properties'
+      end
+    end
+
+    it_behaves_like 'a Valkyrie::Persister'
+  end
+end

--- a/spec/valkyrie/postgres/singular_adapter_spec.rb
+++ b/spec/valkyrie/postgres/singular_adapter_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'valkyrie/specs/shared_specs'
+
+RSpec.describe Postgres::SingularMetadataAdapter do
+  let(:adapter) do
+    described_class.new
+  end
+
+  it_behaves_like 'a Valkyrie::MetadataAdapter'
+
+  its(:persister) { is_expected.to be_a Postgres::SingularPersister }
+end

--- a/spec/valkyrie/postgres/singular_persister_spec.rb
+++ b/spec/valkyrie/postgres/singular_persister_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'valkyrie/specs/shared_specs'
+
+RSpec.describe Postgres::SingularPersister do
+  let(:persister) { described_class.new(adapter: adapter) }
+  let(:adapter) { Postgres::SingularMetadataAdapter.new }
+  let(:query_service) { adapter.query_service }
+
+  context 'shared examples allowing singular values' do
+    before do |example|
+      # We are skipping the check for 'does not save non-array properties' since we are allowing singular values
+      if example.description == 'does not save non-array properties'
+        skip 'We are allowing Non Array Properties'
+      end
+    end
+
+    it_behaves_like 'a Valkyrie::Persister'
+  end
+end

--- a/spec/valkyrie/solr/singular_adapter_spec.rb
+++ b/spec/valkyrie/solr/singular_adapter_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'valkyrie/specs/shared_specs'
+
+RSpec.describe Solr::SingularMetadataAdapter do
+  subject { adapter }
+
+  let(:adapter) do
+    described_class.new(connection: Blacklight.default_index.connection)
+  end
+
+  it_behaves_like 'a Valkyrie::MetadataAdapter'
+
+  its(:persister) { is_expected.to be_a Solr::SingularPersister }
+end

--- a/spec/valkyrie/solr/singular_persister_spec.rb
+++ b/spec/valkyrie/solr/singular_persister_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'valkyrie/specs/shared_specs'
+
+RSpec.describe Solr::SingularPersister do
+  subject { persister }
+
+  let(:persister) { described_class.new(adapter: adapter) }
+  let(:adapter) { Solr::SingularMetadataAdapter.new(connection: Blacklight.default_index.connection) }
+  let(:query_service) { adapter.query_service }
+
+  context 'shared examples allowing singular values' do
+    before do |example|
+      # We are skipping the check for 'does not save non-array properties' since we are allowing singular values
+      if example.description == 'does not save non-array properties'
+        skip 'We are allowing Non Array Properties'
+      end
+    end
+
+    it_behaves_like 'a Valkyrie::Persister'
+  end
+
+  it 'creates a Solr::SingularRepository' do
+    expect(persister.repository([])).to be_a Solr::SingularRepository
+  end
+end


### PR DESCRIPTION
## Description

I was walking down the path of making everything plural and then I got to the part where we were outputting our data and realized it really needed to be singular there.  That meant we would need to translate from plural to singular.  That got me thinking why translate at the outside of the system.  Why not do the translation at the persistence layer?

I brought that thought to refactoring and we took it a step further.  What would happen if we just allowed Singular to  work.  The result is a set of persister that do not check for multiple.

This made almost every test pass, except for the few that relied on the new parameter new_record.

I'm not entirely positive this is what we want to do, or if we want to create an "Saveable" object that translates any singular property into multiple before it is saved.

References ticket: #466

Why was this necessary?  Upgrade to Valkyrie 1.0 to upgrade to blacklight 7

## Changes

* Upgrade to Valkyrie 1.0
* Add Singular Adapters & Persisters to allow for singular values
* Add new_record where needed in the tests

Are there any major changes in this PR that will change the release process?

## Checklist

- [ ] i18n enabled
- [x] adequate test coverage
- [ ] accessible interface
