### PR TITLE
Submission change sets should require a collection

### DIFF
--- a/app/cho/work/submission_change_set.rb
+++ b/app/cho/work/submission_change_set.rb
@@ -7,6 +7,7 @@ module Work
     property :work_type_id, multiple: false, required: true, type: Valkyrie::Types::ID
     property :file, multiple: false, required: false
     validates :member_of_collection_ids, with: :validate_members!
+    validates :member_of_collection_ids, presence: true
     property :member_of_collection_ids,
              multiple: true,
              required: false,

--- a/spec/cho/work/submissions/change_set_spec.rb
+++ b/spec/cho/work/submissions/change_set_spec.rb
@@ -69,16 +69,17 @@ RSpec.describe Work::SubmissionChangeSet do
 
       its(:full_messages) { is_expected.to include('Work type bad one does not exist') }
     end
-    context 'with all required fields' do
-      let(:params) { { work_type_id: work_type_id, title: 'Title' } }
-
-      its(:full_messages) { is_expected.to be_empty }
-    end
 
     context 'with non-existent parents' do
       let(:params) { { work_type_id: work_type_id, title: 'Title', member_of_collection_ids: ['nothere'] } }
 
       its(:full_messages) { is_expected.to include('Member of collection ids nothere does not exist') }
+    end
+
+    context 'without collection membership' do
+      let(:params) { { work_type_id: work_type_id, title: 'Title', member_of_collection_ids: [] } }
+
+      its(:full_messages) { is_expected.to include("Member of collection ids can't be blank") }
     end
 
     context 'with existing parents and all required fields' do

--- a/spec/cho/work/submissions/delete_spec.rb
+++ b/spec/cho/work/submissions/delete_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Deleting works', type: :feature do
   let(:resource) { create(:work, :with_file, title: 'Work to delete') }
   let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
 
-  it 'removes the work and file from the system' do
+  it 'removes the work and file from the system but retains its parent collection' do
     visit(polymorphic_path([:solr_document], id: resource.id))
     expect(page).to have_selector('li', text: 'hello_world.txt')
     click_link('Edit')
@@ -18,7 +18,8 @@ RSpec.describe 'Deleting works', type: :feature do
     expect(page).to have_content(resource.title.first)
     expect(Work::Submission.all.count).to eq(0)
     expect(Work::File.all.count).to eq(0)
-    expect(adapter.index_adapter.query_service.find_all.count).to eq(0)
+    expect(Collection::Archival.all.count).to eq(1)
+    expect(adapter.index_adapter.query_service.find_all.count).to eq(1)
     expect(File.exists?('tmp/files/hello_world.txt')).to be(false)
   end
 end

--- a/spec/cho/work/submissions/submissions_controller_spec.rb
+++ b/spec/cho/work/submissions/submissions_controller_spec.rb
@@ -33,17 +33,25 @@ RSpec.describe Work::SubmissionsController, type: :controller do
   end
 
   describe 'POST #create' do
+    let!(:collection) { create(:collection) }
     let(:work_type_id) { Work::Type.find_using(label: 'Generic').first }
-    let(:valid_attributes) { { title: 'New Title', work_type_id: work_type_id } }
     let(:resource) { Work::Submission.all.last }
 
     context 'with valid params' do
+      let(:valid_attributes) do
+        {
+          title: 'New Title',
+          work_type_id: work_type_id,
+          member_of_collection_ids: [collection.id]
+        }
+      end
+
       it 'creates a new Work' do
-        expect(index_solr.query_service.find_all.to_a.length).to eq 0
+        expect(index_solr.query_service.find_all.to_a.length).to eq 1
         expect {
           post :create, params: { 'work_submission': valid_attributes }
         }.to change { Work::Submission.count }.by(1)
-        expect(index_solr.query_service.find_all.to_a.length).to eq 1
+        expect(index_solr.query_service.find_all.to_a.length).to eq 2
       end
 
       it 'redirects to the created work' do

--- a/spec/factories/archival_collections.rb
+++ b/spec/factories/archival_collections.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :archival_collection, class: Collection::Archival do
+  factory :archival_collection, aliases: [:collection], class: Collection::Archival do
     title 'Archival Collection'
     subtitle 'subtitle for an archival collection'
     description 'Sample archival collection'

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -9,6 +9,14 @@ FactoryBot.define do
     title 'Sample Generic Work'
     work_type_id { Work::Type.find_using(label: 'Generic').first.id }
 
+    member_of_collection_ids do
+      if @build_strategy.is_a? FactoryBot::Strategy::Build
+        [build(:collection).id]
+      else
+        [create(:collection).id]
+      end
+    end
+
     to_create do |resource|
       Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: resource)
     end


### PR DESCRIPTION
## Description

A submission change change with an empty array of member collections will still be valid. This seems wrong. If works are supposed to always be in a collection, then the submission change set should not be valid if there is not at least one id in the array of member collections.

Why was this necessary?

This should prevent the occurrence of works without a parent collection.

## Changes

Are there any major changes in this PR that will change the release process? No.

## Checklist

- [ ] i18n enabled
- [ ] adequate test coverage
- [ ] accessible interface
