### PR TITLE
Implement the User Interface for CSV Import

### DIFF
--- a/app/blacklight/catalog_controller.rb
+++ b/app/blacklight/catalog_controller.rb
@@ -172,5 +172,6 @@ class CatalogController < ApplicationController
 
     config.add_nav_action :data_dictionary
     config.add_nav_action :select
+    config.add_nav_action :csv_import
   end
 end

--- a/app/cho/work/import/csv_controller.rb
+++ b/app/cho/work/import/csv_controller.rb
@@ -11,7 +11,7 @@ module Work
       # POST /csv_file
       def create
         file = params[:work_import_csv_file][:file]
-        @results = CsvDryRun.run(file.path)
+        @presenter = CsvDryRunResultsPresenter.new(CsvDryRun.run(file.path))
         @file_name = file.path
         render :dry_run_results
       end

--- a/app/cho/work/import/csv_dry_run_results_presenter.rb
+++ b/app/cho/work/import/csv_dry_run_results_presenter.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Work
+  module Import
+    # Presents the results of the dry run in a nice way for display
+    class CsvDryRunResultsPresenter
+      delegate :each, :to_a, to: :change_set_list
+      attr_reader :change_set_list
+
+      def initialize(change_set_list)
+        @change_set_list = change_set_list
+      end
+
+      def invalid_rows
+        @invalid ||= change_set_list.reject(&:valid?)
+      end
+
+      def valid_rows
+        @valid ||= change_set_list.select(&:valid?)
+      end
+
+      def invalid?
+        invalid_rows.present?
+      end
+
+      def valid?
+        valid_rows.present?
+      end
+
+      def error_count
+        invalid_rows.count
+      end
+    end
+  end
+end

--- a/app/views/application/_csv_import.erb
+++ b/app/views/application/_csv_import.erb
@@ -1,0 +1,1 @@
+<%= link_to t('cho.header_links.csv_import'), new_csv_file_path, class: 'nav-link' %>

--- a/app/views/work/import/csv/_dry_run_error_list.html.erb
+++ b/app/views/work/import/csv/_dry_run_error_list.html.erb
@@ -1,0 +1,5 @@
+<ul>
+  <% errors.each do |message| %>
+    <li><%= message %></li>
+  <% end %>
+</ul>

--- a/app/views/work/import/csv/_dry_run_result.html.erb
+++ b/app/views/work/import/csv/_dry_run_result.html.erb
@@ -1,0 +1,10 @@
+<tr>
+  <td><%= dry_run_result.title || 'Title is Missing' %></td>
+  <td>
+    <% if dry_run_result.errors.present? %>
+      <%= render 'dry_run_error_list', errors: dry_run_result.errors.full_messages %>
+    <% else %>
+      Success
+    <% end %>
+  </td>
+</tr>

--- a/app/views/work/import/csv/dry_run_results.html.erb
+++ b/app/views/work/import/csv/dry_run_results.html.erb
@@ -1,13 +1,20 @@
-<ol>
-  <% @results.each do |result| %>
-    <li>
-      <%= result.title %>
-      <%= result.errors %>
-    </li>
-  <% end %>
-</ol>
+<h1>Import Preview</h1>
+<p><%= t('cho.csv.dry_run.error_count_message', count: @presenter.error_count) %></p>
 
-<%= form_tag(controller: 'csv', action: 'run_import') do |form| %>
+<table class="table table-responsive table-striped">
+  <thead>
+  <tr>
+    <th><%= t('cho.csv.dry_run.preview_table.title') %></th>
+    <th><%= t('cho.csv.dry_run.preview_table.status') %></th>
+  </tr>
+  </thead>
+  <tbody>
+    <%= render partial: 'dry_run_result', collection: @presenter %>
+  </tbody>
+</table>
+
+<%= form_tag({ controller: 'csv', action: 'run_import' }, class: 'form-inline') do %>
  <%= hidden_field_tag(:file_name, @file_name) %>
- <%= submit_tag(t('cho.csv.import.submit')) %>
+  <%= submit_tag(t('cho.csv.import.submit'), disabled: @presenter.invalid?) %>
+  <%= link_to t('cho.csv.import.cancel'), :back, class: 'btn btn-link' %>
 <% end %>

--- a/app/views/work/import/csv/import_success.html.erb
+++ b/app/views/work/import/csv/import_success.html.erb
@@ -1,13 +1,10 @@
 <h1><%= t('cho.csv.import.success.header') %></h1>
-<ol>
+<ul class="result-list">
   <% @created.each do |result| %>
     <li>
-      <%= link_to result.title, solr_document_path(result.id) %>
+      <%= link_to result.title.join(', '), solr_document_path(result.id) %>
     </li>
   <% end %>
-</ol>
+</ul>
 
-<%= form_tag(controller: 'csv', action: 'run_import') do |form| %>
- <%= hidden_field_tag(:results, value: @results) %>
- <%= submit_tag('Perform Import') %>
-<% end %>
+<%= link_to t('cho.csv.import.success.new_import'), :new_csv_file, class: 'btn btn-link' %>

--- a/app/views/work/import/csv/new.html.erb
+++ b/app/views/work/import/csv/new.html.erb
@@ -1,3 +1,5 @@
+<h1>CSV Import</h1>
+
 <%= form_for(@csv_file, url: csv_file_index_path) do |form| %>
 
   <%= form.hidden_field :file, value: @csv_file.cached_file_data %>

--- a/config/locales/cho.yml
+++ b/config/locales/cho.yml
@@ -23,6 +23,7 @@ en:
       create_submission: "Create Work"
       data_dictionary: "Data Dictionary"
       select: "Select Resources"
+      csv_import: "Import CSV"
     work:
       new:
         heading: "New %{type} Work"
@@ -54,13 +55,19 @@ en:
         delete_link: "Delete Curated collection"
     csv:
       dry_run:
-        submit: "Dry Run"
+        submit: "Preview Import"
+        error_count_message: "Total Number of Works with Errors %{count}"
+        preview_table:
+          title: "Title"
+          status: "Status"
       import:
         submit: "Perform Import"
+        cancel: "Cancel"
         failure:
           header: "Failed Import"
         success:
           header: "Successful Import"
+          new_import: "Perform Additional Import"
     metrics:
       benchmark_heading: "User,System,Total,Real"
       collection:

--- a/spec/cho/work/import/csv_controller_spec.rb
+++ b/spec/cho/work/import/csv_controller_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe Work::Import::CsvController, type: :controller do
     it 'runs a dry run on the file' do
       expect(create_call).to render_template('dry_run_results')
       expect(response).to be_success
-      expect(assigns(:results)).to be_a(Array)
-      expect(assigns(:results).map(&:valid?)).to eq([true, true, true])
+      expect(assigns(:presenter)).to be_a(Work::Import::CsvDryRunResultsPresenter)
+      expect(assigns(:presenter).change_set_list.map(&:valid?)).to eq([true, true, true])
       expect(File).to be_exist(assigns(:file_name))
     end
 
@@ -57,9 +57,9 @@ RSpec.describe Work::Import::CsvController, type: :controller do
       it 'runs a dry run on the file' do
         expect(create_call).to render_template('dry_run_results')
         expect(response).to be_success
-        expect(assigns(:results)).to be_a(Array)
-        expect(assigns(:results).map(&:valid?)).to eq([false, false, false])
-        expect(assigns(:results).map(&:errors).map(&:messages)).to eq([{ member_of_collection_ids: [' does not exist'] }, { work_type_id: ["can't be blank"] }, { member_of_collection_ids: ['bad does not exist'], title: ["can't be blank"] }])
+        expect(assigns(:presenter)).to be_a(Work::Import::CsvDryRunResultsPresenter)
+        expect(assigns(:presenter).change_set_list.map(&:valid?)).to eq([false, false, false])
+        expect(assigns(:presenter).change_set_list.map(&:errors).map(&:messages)).to eq([{ member_of_collection_ids: [' does not exist'] }, { work_type_id: ["can't be blank"] }, { member_of_collection_ids: ['bad does not exist'], title: ["can't be blank"] }])
         expect(File).to be_exist(assigns(:file_name))
       end
     end

--- a/spec/cho/work/import/csv_dry_run_results_presenter_spec.rb
+++ b/spec/cho/work/import/csv_dry_run_results_presenter_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Work::Import::CsvDryRunResultsPresenter do
+  subject { described_class.new([valid_changeset]) }
+
+  let(:valid_changeset) do
+    change_set = Work::SubmissionChangeSet.new(Work::Submission.new)
+    change_set.validate(member_of_collection_ids: [collection.id], work_type_id: [work_type_id], title: 'My valid work')
+    change_set
+  end
+
+  let(:collection) { create :library_collection }
+  let(:work_type_id) { Work::Type.find_using(label: 'Generic').first.id }
+
+  its(:invalid_rows) { is_expected.to be_empty }
+  its(:invalid?) { is_expected.to be_falsey }
+  its(:error_count) { is_expected.to eq 0 }
+  its(:valid_rows) { is_expected.to eq [valid_changeset] }
+
+  context 'when there is invalid data' do
+    subject { described_class.new([invalid_changeset]) }
+
+    let(:invalid_changeset) do
+      change_set = Work::SubmissionChangeSet.new(Work::Submission.new)
+      change_set.validate(member_of_collection_ids: [collection.id], title: 'My invalid work')
+      change_set
+    end
+
+    its(:valid_rows) { is_expected.to be_empty }
+    its(:invalid?) { is_expected.to be_truthy }
+    its(:error_count) { is_expected.to eq 1 }
+    its(:invalid_rows) { is_expected.to eq [invalid_changeset] }
+  end
+end

--- a/spec/cho/work/import/import_spec.rb
+++ b/spec/cho/work/import/import_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Preview of CSV Import', type: :feature do
+  let(:collection) { create :library_collection, title: 'my collection' }
+  let(:work_1_file_name) { Rails.root.join('spec', 'fixtures', 'hello_world.txt') }
+  let(:work_2_file_name) { Rails.root.join('spec', 'fixtures', 'hello_world2.txt') }
+  let(:work_3_file_name) { Rails.root.join('spec', 'fixtures', 'hello_world3.txt') }
+  let(:csv_file) do
+    csv_file = Tempfile.new('csv_file.csv')
+
+    csv_file.write("member_of_collection_ids,work_type,title,file_name\n")
+    csv_file.write("#{collection.id},Generic,My Work 1,#{work_1_file_name}\n")
+    csv_file.write("#{collection.id},Generic,My Work 2,#{work_2_file_name}\n")
+    csv_file.write("#{collection.id},Generic,My Work 3,#{work_3_file_name}\n")
+    csv_file.close
+
+    csv_file
+  end
+
+  context 'import a valid csv' do
+    it 'displays the dry run of the import with valid works' do
+      visit(new_csv_file_path)
+      expect(page).to have_selector('h1', text: 'CSV Import')
+      attach_file('work_import_csv_file_file', csv_file.path)
+      click_button('Preview Import')
+      expect(page).to have_selector('h1', text: 'Import Preview')
+      expect(page).to have_content('Total Number of Works with Errors 0')
+      within('table') do
+        expect(page).to have_selector('th', text: 'Title')
+        expect(page).to have_selector('th', text: 'Status')
+        expect(page).to have_selector('tr', text: 'My Work 1 Success')
+        expect(page).to have_selector('tr', text: 'My Work 2 Success')
+        expect(page).to have_selector('tr', text: 'My Work 3 Success')
+      end
+      click_button('Perform Import')
+      expect(page).to have_selector('h1', text: 'Successful Import')
+      within('ul.result-list') do
+        expect(page).to have_selector('li a', text: 'My Work 1')
+        expect(page).to have_selector('li a', text: 'My Work 2')
+        expect(page).to have_selector('li a', text: 'My Work 3')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

Improve and implement the UI workflow for importing a CSV file based on a wireframe.

References ticket: (if any) #236 #235 

Why was this necessary?

Admin users would like to import works via a CSV file because it is easier and matches their workflow when wanting to import many things.

## Changes

Putting dry run results into a table with status messages for good stuff and works with errors. Created a partial for the errors to loop through each error message for the import.

Added some Bootstrap styles and moved the caption text into a header element. Fixes rubocop errors, makes the form inline, moves the cancel into the form, adds header to CSV Import start page.

Added new nav action in the catalog controller for CSV import, added partial for the link, and added i18n for the text.

Clean up CSV import views
Change button text to Preview Import
Show Import and Errors in the status section of the table
Display Errors in an unorderd list
Add cancel button
Disable perform Button if there are Errors
Add Counts to Top of Headers for Number of Imports and Number of Errors
Clean Up Import Table
Link or Button in the UI to get to Import process
Added feature test for CSV import workflow

Co-authored-by: Carolyn Cole <cam156@psu.edu>

Co-authored-by: Adam Wead <amsterdamos@gmail.com>

## Checklist

- [x] i18n enabled
- [x] adequate test coverage
- [x] accessible interface
