### PR TITLE
Updating solr_wrapper to use different mirror

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -3,6 +3,7 @@ version: 7.1.0
 port: 8983
 instance_dir: tmp/solr-development
 download_dir: tmp
+mirror_url: http://lib-solr-mirror.princeton.edu/dist/
 collection:
   persist: true
   dir: solr/config

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ group :development, :test do
   gem 'niftany'
   gem 'pry-byebug'
   gem 'pry-rails'
-  gem 'solr_wrapper', '>= 0.3'
+  gem 'solr_wrapper', github: 'cbeer/solr_wrapper', branch: 'master'
   gem 'sqlite3'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,15 @@
 GIT
+  remote: https://github.com/cbeer/solr_wrapper.git
+  revision: 55910f63ca58cf7cdc1ab0ec3bb75ace22bbe1ba
+  branch: master
+  specs:
+    solr_wrapper (1.2.0)
+      faraday
+      retriable
+      ruby-progressbar
+      rubyzip
+
+GIT
   remote: https://github.com/stympy/faker.git
   revision: f8e1b81f8da82ea9eb88c4939a3a6801f97e5ac1
   branch: master
@@ -487,11 +498,6 @@ GEM
       tilt (~> 2.0)
     slop (4.6.2)
     smart_properties (1.13.1)
-    solr_wrapper (1.1.0)
-      faraday
-      retriable
-      ruby-progressbar
-      rubyzip
     solrizer (4.1.0)
       activesupport
       nokogiri
@@ -616,7 +622,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   selenium-webdriver
   shrine
-  solr_wrapper (>= 0.3)
+  solr_wrapper!
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3

--- a/config/solr_wrapper_test.yml
+++ b/config/solr_wrapper_test.yml
@@ -3,6 +3,7 @@ version: 7.1.0
 port: 8985
 instance_dir: tmp/solr-test
 download_dir: tmp
+mirror_url: http://lib-solr-mirror.princeton.edu/dist/
 collection:
   persist: false
   dir: solr/config

--- a/config/travis/solr_wrapper_test.yml
+++ b/config/travis/solr_wrapper_test.yml
@@ -3,6 +3,7 @@ version: 7.1.0
 port: 8985
 instance_dir: solr-test
 download_dir: dep_cache
+mirror_url: http://lib-solr-mirror.princeton.edu/dist/
 collection:
   persist: false
   dir: solr/config


### PR DESCRIPTION
## Description

Update solr wrapper to latest in master so we can use a different mirror.

Why was this necessary?

Travis appears to be timing out when downloading solr, indicating the url isn't responding.

## Changes

Are there any major changes in this PR that will change the release process? No

## Checklist

- [ ] i18n enabled
- [ ] adequate test coverage
- [ ] accessible interface
