### PR TITLE
Moving code out of seed into appropriate classes

### DIFF
--- a/app/cho/data_dictionary/csv_importer.rb
+++ b/app/cho/data_dictionary/csv_importer.rb
@@ -6,6 +6,12 @@ module DataDictionary
   class CsvImporter
     attr_reader :file, :lines, :attributes
 
+    def self.load_dictionary(dictionary_file = nil)
+      dictionary_file ||= Rails.root.join('config', 'data_dictionary', "data_dictionary_#{Rails.env.downcase}.csv")
+      importer = new(File.new(dictionary_file))
+      importer.import
+    end
+
     def initialize(file)
       @file = file
     end

--- a/app/cho/schema/configuration.rb
+++ b/app/cho/schema/configuration.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Schema
+  class Configuration
+    attr_reader :schema_config, :work_types
+
+    def initialize(schema_file_path = nil)
+      schema_file_path ||= Rails.root.join('config', 'data_dictionary', 'schema_fields.yml')
+      @schema_config = YAML.load_file(schema_file_path)[Rails.env]
+      @work_types = schema_config.map { |config| config.fetch('schema') }
+    end
+
+    def core_field_count
+      core_field_ids.length
+    end
+
+    def core_field_ids
+      @core_field_ids ||= Schema::MetadataCoreFields.generate(Valkyrie.config.metadata_adapter).map(&:id)
+    end
+
+    def load_work_types
+      work_types.each do |type|
+        work_type_config = Schema::WorkTypeConfiguration.new(schema_configuration: self, work_type: type)
+        work_type_config.generate_metadata_schema
+        work_type_config.generate_work_type unless type == 'Collection'
+      end
+    end
+  end
+end

--- a/app/cho/schema/metadata_core_fields.rb
+++ b/app/cho/schema/metadata_core_fields.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
 class Schema::MetadataCoreFields
-  def self.generate(persister)
+  def self.generate(adapter)
     fields = DataDictionary::Field.core_fields
     fields.to_a.each_with_index.map do |field, idx|
       schema_field = Schema::MetadataField.initialize_from_data_dictionary_field(field)
       schema_field.order_index = idx
-      saved_schema_field = Schema::MetadataField.where(label: schema_field.label).first
-      saved_schema_field = persister.save(resource: schema_field) if saved_schema_field.blank?
-      saved_schema_field
+      ChangeSetPersister.new(metadata_adapter: adapter, storage_adapter: nil).update_or_create(schema_field, unique_attribute: :label)
     end
   end
 end

--- a/app/cho/schema/work_type_configuration.rb
+++ b/app/cho/schema/work_type_configuration.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Schema
+  class WorkTypeConfiguration
+    attr_reader :schema_configuration, :work_type, :fields
+
+    def initialize(schema_configuration:, work_type:)
+      @schema_configuration = schema_configuration
+      @work_type = work_type
+      @fields = initialize_fields
+    end
+
+    def generate_metadata_schema
+      schema_fields = initialize_schema_fields
+
+      metadata_schema = Schema::Metadata.new(
+        label: work_type,
+        core_fields: schema_configuration.core_field_ids,
+        fields: schema_fields.map(&:id)
+      )
+      find_or_save(metadata_schema)
+    end
+
+    def generate_work_type
+      metadata_schema = Schema::Metadata.find_using(label: work_type).first
+      return nil if metadata_schema.blank?
+
+      work_type_schema = Work::Type.new(
+        label: work_type,
+        metadata_schema_id: metadata_schema.id,
+        processing_schema: 'default',
+        display_schema: 'default'
+      )
+      find_or_save(work_type_schema)
+    end
+
+    def initialize_schema_fields
+      return [] if fields.nil?
+
+      fields.map do |field, attributes|
+        data_dictionary_field = DataDictionary::Field.where(label: field).first
+        metadata_field = Schema::MetadataField.initialize_from_data_dictionary_field(data_dictionary_field)
+        metadata_field.order_index = (attributes.fetch('order_index', '1') + schema_configuration.core_field_count)
+        find_or_save(metadata_field)
+      end
+    end
+
+    private
+
+      def change_set_persister
+        @change_set_persister ||= ChangeSetPersister.new(metadata_adapter: Valkyrie.config.metadata_adapter, storage_adapter: nil)
+      end
+
+      def find_or_save(resource)
+        change_set_persister.update_or_create(resource, unique_attribute: :label)
+      end
+
+      def initialize_fields
+        work_type_config = schema_configuration.schema_config.select { |config| config.fetch('schema') == work_type }
+        return nil if work_type_config.blank?
+
+        work_type_config.first.fetch('fields')
+      end
+  end
+end

--- a/app/valkyrie/change_set_persister.rb
+++ b/app/valkyrie/change_set_persister.rb
@@ -14,6 +14,12 @@ class ChangeSetPersister
     persister.save(resource: change_set.resource)
   end
 
+  def update_or_create(resource, unique_attribute:)
+    attribute_value = resource.send(unique_attribute)
+    return resource.class.where(unique_attribute => attribute_value).first if resource.class.where(label: attribute_value).count.positive?
+    save(change_set: Valkyrie::ChangeSet.new(resource))
+  end
+
   def validate_and_save(change_set:, resource_params:)
     return change_set unless change_set.validate(resource_params)
     change_set = store_files(change_set)

--- a/config/data_dictionary/schema_fields.yml
+++ b/config/data_dictionary/schema_fields.yml
@@ -6,6 +6,7 @@ development: &development
   - schema: 'Document'
     fields:
       contributor:
+        display_name: 'My contributor'
         order_index: 2
       time_period:
         order_index: 1
@@ -46,6 +47,7 @@ development: &development
       alternate_title:
         order_index: 1
       contributor:
+        display_name: 'My contributor'
         order_index: 2
       time_period:
         order_index: 3

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,61 +2,10 @@
 class SeedMAP
   class << self
 
-    def load_data_dictionary
-      dictionary_file = Rails.root.join('config', 'data_dictionary', "data_dictionary_#{Rails.env.downcase}.csv")
-      importer = DataDictionary::CsvImporter.new(File.new(dictionary_file))
-      importer.import
-    end
-
-    def schema_config
-      @schema_config ||= YAML.load_file(Rails.root.join('config', 'data_dictionary', "schema_fields.yml"))[Rails.env]
-    end
-
-    def metadata_schema(type)
-      core_field_ids = Schema::MetadataCoreFields.generate(Valkyrie.config.metadata_adapter.persister).map(&:id)
-      fields = schema_config.select { |config| config.fetch("schema") == type }.first.fetch("fields")
-      schema_fields = create_schema_fields(fields, core_field_ids)
-      Schema::Metadata.new(
-        label: type,
-        core_fields: core_field_ids,
-        fields: schema_fields.map(&:id)
-      )
-    end
-
-    def create_schema_fields(fields, core_field_ids)
-      fields.map do |field, attributes|
-        data_dictionary_field = DataDictionary::Field.where(label: field).first
-        metadata_field = Schema::MetadataField.initialize_from_data_dictionary_field(data_dictionary_field)
-        metadata_field.order_index = (attributes.fetch("order_index", "1") + core_field_ids.length)
-        seed_resource(metadata_field)
-      end
-    end
-
-    def work_type(type)
-      Work::Type.new(
-        label: type,
-        metadata_schema_id: Schema::Metadata.find_using(label: type).first.id,
-        processing_schema: 'default',
-        display_schema: 'default'
-      )
-    end
-
-    def load_work_types
-      schema_config.map { |config| config.fetch("schema") }.each do |type|
-        seed_resource(metadata_schema(type))
-        seed_resource(work_type(type)) unless type == 'Collection'
-      end
-    end
-
-    def seed_resource(resource)
-      return resource.class.where(label: resource.label).first if resource.class.where(label: resource.label).count > 0
-      Valkyrie.config.metadata_adapter.persister.save(resource: resource)
-    end
-
     def create
       return unless ActiveRecord::Base.connection.table_exists? 'orm_resources'
-      load_data_dictionary
-      load_work_types
+      DataDictionary::CsvImporter.load_dictionary
+      Schema::Configuration.new.load_work_types
     end
   end
 end

--- a/spec/cho/data_dictionary/csv_importer_spec.rb
+++ b/spec/cho/data_dictionary/csv_importer_spec.rb
@@ -46,4 +46,32 @@ RSpec.describe DataDictionary::CsvImporter do
       }.to change(DataDictionary::Field, :count).by(0).and(raise_error(Dry::Struct::Error))
     end
   end
+
+  describe 'load_dictionary' do
+    it 'loads the default (which is already loaded)' do
+      expect {
+        described_class.load_dictionary
+      }.to change(DataDictionary::Field, :count).by(0)
+    end
+
+    context 'another file' do
+      let(:csv_file) do
+        file = Tempfile.new
+        file.write(header)
+        file.write(csv_field1)
+        file.close
+        file
+      end
+
+      after do
+        csv_file.unlink
+      end
+
+      it 'loads the new fields' do
+        expect {
+          described_class.load_dictionary(csv_file.path)
+        }.to change(DataDictionary::Field, :count).by(1)
+      end
+    end
+  end
 end

--- a/spec/cho/schema/configuration_spec.rb
+++ b/spec/cho/schema/configuration_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'valkyrie/specs/shared_specs'
+
+RSpec.describe Schema::Configuration, type: :model do
+  subject(:schema_configuration) { described_class.new(schema_file) }
+
+  let(:schema_file) {}
+
+  its(:schema_config) { is_expected.to eq([{ 'schema' => 'Generic', 'fields' => { 'generic_field' => { 'order_index' => 1 } } },
+                                           { 'schema' => 'Document', 'fields' => { 'document_field' => { 'order_index' => 1 } } },
+                                           { 'schema' => 'Still Image',
+                                             'fields' => { 'still_image_field' => { 'order_index' => 1 } } },
+                                           { 'schema' => 'Map', 'fields' => { 'map_field' => { 'order_index' => 1 } } },
+                                           { 'schema' => 'Moving Image',
+                                             'fields' => { 'moving_image_field' => { 'order_index' => 1 } } },
+                                           { 'schema' => 'Audio', 'fields' => { 'audio_field' => { 'order_index' => 1 } } },
+                                           { 'schema' => 'Collection', 'fields' => [] }])}
+  its(:work_types) { is_expected.to eq(['Generic', 'Document', 'Still Image', 'Map', 'Moving Image', 'Audio', 'Collection']) }
+
+  describe '#load_work_types' do
+    it 'does nothing since the default types were already loaded' do
+      expect {
+        schema_configuration.load_work_types
+      }.to change { Valkyrie.config.metadata_adapter.query_service.find_all.count }.by(0)
+    end
+  end
+
+  context 'another schema is specified' do
+    let(:yaml_text) { "test:\n  - schema: 'Other'\n    fields:\n      other_field:\n        order_index: 1" }
+    let(:schema) do
+      file = Tempfile.new
+      file.write(yaml_text)
+      file.close
+      file
+    end
+
+    let(:schema_file) { schema.path }
+
+    after do
+      schema.unlink
+    end
+
+    its(:schema_config) { is_expected.to eq([{ 'schema' => 'Other', 'fields' => { 'other_field' => { 'order_index' => 1 } } }]) }
+
+    describe '#load_work_types' do
+      let(:other_field) { create :data_dictionary_field, label: 'other_field' }
+
+      before do
+        other_field
+      end
+      it 'adds a Schema::MetadataField, a Work::Type, and a Schema::Metadata' do
+        expect {
+          schema_configuration.load_work_types
+        }.to change { Schema::MetadataField.all.count }.by(1)
+          .and change { Work::Type.all.count }.by(1)
+          .and change { Schema::Metadata.all.count }.by(1)
+          .and change { Valkyrie.config.metadata_adapter.query_service.find_all.count }.by(3)
+      end
+    end
+  end
+end

--- a/spec/cho/schema/metadata_core_fields_spec.rb
+++ b/spec/cho/schema/metadata_core_fields_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Schema::MetadataCoreFields, type: :model do
-  let(:core_fields) { described_class.generate(Valkyrie.config.metadata_adapter.persister) }
+  let(:core_fields) { described_class.generate(Valkyrie.config.metadata_adapter) }
   let(:title_field) { Schema::MetadataField.where(label: 'title').first }
 
   it 'generates the core fields' do

--- a/spec/cho/schema/work_type_configuration_spec.rb
+++ b/spec/cho/schema/work_type_configuration_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'valkyrie/specs/shared_specs'
+
+RSpec.describe Schema::WorkTypeConfiguration, type: :model do
+  subject(:work_type_configuration) { described_class.new(schema_configuration: Schema::Configuration.new, work_type: work_type) }
+
+  describe '#fields' do
+    subject { work_type_configuration.fields }
+
+    let(:work_type) { 'Still Image' }
+
+    it { is_expected.to eq('still_image_field' => { 'order_index' => 1 }) }
+
+    context 'a non existing work type' do
+      let(:work_type) { 'Foo' }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#initialize_schema_fields' do
+    subject(:schema_fields) { work_type_configuration.initialize_schema_fields }
+
+    let(:work_type) { 'Generic' }
+
+    it 'creates a field based on the work type' do
+      expect(schema_fields.count).to eq(1)
+      expect(schema_fields.first.order_index).to eq(4)
+      expect(schema_fields.first.label).to eq('generic_field')
+    end
+
+    context 'a non existing work type' do
+      let(:work_type) { 'Foo' }
+
+      it { is_expected.to eq([]) }
+    end
+  end
+
+  describe '#generate_work_type' do
+    subject(:work_type_schema) { work_type_configuration.generate_work_type }
+
+    let(:work_type) { 'Generic' }
+
+    it 'creates a field based on the work type' do
+      expect(work_type_schema).to be_a(Work::Type)
+      expect(work_type_schema.label).to eq(work_type)
+    end
+
+    context 'a non existing work type' do
+      let(:work_type) { 'Foo' }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#generate_metadata_schema' do
+    subject(:metadata_schema) { work_type_configuration.generate_metadata_schema }
+
+    let(:work_type) { 'Generic' }
+
+    it 'creates a field based on the work type' do
+      expect(metadata_schema).to be_a(Schema::Metadata)
+      expect(metadata_schema.label).to eq(work_type)
+      expect(metadata_schema.fields.count).to eq(1)
+    end
+
+    context 'a non existing work type' do
+      let(:work_type) { 'Foo' }
+
+      it 'creates a field based on the work type' do
+        expect(metadata_schema).to be_a(Schema::Metadata)
+        expect(metadata_schema.label).to eq(work_type)
+        expect(metadata_schema.fields.count).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/valkyrie/change_set_persister_spec.rb
+++ b/spec/valkyrie/change_set_persister_spec.rb
@@ -94,6 +94,29 @@ RSpec.describe ChangeSetPersister do
     end
   end
 
+  describe '#find_or_save' do
+    subject(:find_or_save_call) { change_set_persister.update_or_create(resource, unique_attribute: :label) }
+
+    let(:metadata_adapter) { Valkyrie.config.metadata_adapter }
+    let(:resource) { build :data_dictionary_field, label: 'new_label' }
+
+    it 'saves the resource and returns it' do
+      expect { find_or_save_call }.to change(DataDictionary::Field, :count).by(1)
+      expect(find_or_save_call.label).to eq('new_label')
+    end
+
+    context 'An existing field' do
+      let(:existing_field) { create :data_dictionary_field, label: 'new_label' }
+
+      before { existing_field }
+
+      it 'does not save the field' do
+        expect { find_or_save_call }.to change(DataDictionary::Field, :count).by(0)
+        expect(find_or_save_call.id).to eq(existing_field.id)
+      end
+    end
+  end
+
   context 'when the persister fails' do
     let(:mock_persister) { double }
     let(:change_set) { DataDictionary::FieldChangeSet.new(DataDictionary::Field.new) }


### PR DESCRIPTION
This allows it to be tested

This is a precursor to adding more functionality to the Schema configuration to allow for each schema to override data dictionary field attribute values

refs #437

## Description

References ticket: (if any)

Why was this necessary?

## Changes

Are there any major changes in this PR that will change the release process?

## Checklist

- [ ] i18n enabled
- [ ] adequate test coverage
- [ ] accessible interface
