### PR TITLE
Adding schema config merge to initialize_from_data_dictionary_field

### DIFF
--- a/app/cho/schema/metadata_field.rb
+++ b/app/cho/schema/metadata_field.rb
@@ -5,10 +5,26 @@ module Schema
     attribute :order_index, Valkyrie::Types::Int
     attribute :data_dictionary_field_id, Valkyrie::Types::ID.optional
 
-    def self.initialize_from_data_dictionary_field(data_dictionary_field)
-      field = new(data_dictionary_field.attributes.except(:created_at, :updated_at, :internal_resource, :id))
-      field.data_dictionary_field_id = data_dictionary_field.id
-      field
-    end
+    class << self
+      def initialize_from_data_dictionary_field(data_dictionary_field, schema_field_config = {})
+        attributes = data_dictionary_field.attributes.except(:created_at, :updated_at, :internal_resource, :id)
+        attributes = merge_attributes(attributes, schema_field_config)
+        field = new(attributes)
+        field.data_dictionary_field_id = data_dictionary_field.id
+        field
+      end
+
+      private
+
+        def merge_attributes(data_dictionary_attributes, schema_field_config)
+          return data_dictionary_attributes if schema_field_config.blank?
+          safe_schema_field_config = schema_field_config.reject { |key, _value| reserved_keys.include?(key) }
+          data_dictionary_attributes.merge(safe_schema_field_config)
+        end
+
+        def reserved_keys
+          [:label, :requirement_designation, :core_field]
+        end
+     end
   end
 end

--- a/app/cho/schema/work_type_configuration.rb
+++ b/app/cho/schema/work_type_configuration.rb
@@ -39,7 +39,7 @@ module Schema
 
       fields.map do |field, attributes|
         data_dictionary_field = DataDictionary::Field.where(label: field).first
-        metadata_field = Schema::MetadataField.initialize_from_data_dictionary_field(data_dictionary_field)
+        metadata_field = Schema::MetadataField.initialize_from_data_dictionary_field(data_dictionary_field, attributes)
         metadata_field.order_index = (attributes.fetch('order_index', '1') + schema_configuration.core_field_count)
         find_or_save(metadata_field)
       end

--- a/config/data_dictionary/schema_fields.yml
+++ b/config/data_dictionary/schema_fields.yml
@@ -142,6 +142,7 @@ test:
     fields:
       still_image_field:
         order_index: 1
+        display_name: 'Photograph'
   - schema: 'Map'
     fields:
       map_field:

--- a/spec/cho/schema/configuration_spec.rb
+++ b/spec/cho/schema/configuration_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Schema::Configuration, type: :model do
   its(:schema_config) { is_expected.to eq([{ 'schema' => 'Generic', 'fields' => { 'generic_field' => { 'order_index' => 1 } } },
                                            { 'schema' => 'Document', 'fields' => { 'document_field' => { 'order_index' => 1 } } },
                                            { 'schema' => 'Still Image',
-                                             'fields' => { 'still_image_field' => { 'order_index' => 1 } } },
+                                             'fields' => { 'still_image_field' => { 'order_index' => 1, 'display_name' => 'Photograph' } } },
                                            { 'schema' => 'Map', 'fields' => { 'map_field' => { 'order_index' => 1 } } },
                                            { 'schema' => 'Moving Image',
                                              'fields' => { 'moving_image_field' => { 'order_index' => 1 } } },

--- a/spec/cho/schema/metadata_field_spec.rb
+++ b/spec/cho/schema/metadata_field_spec.rb
@@ -59,9 +59,10 @@ RSpec.describe Schema::MetadataField, type: :model do
   end
 
   describe '#initialize_from_data_dictionary_field' do
-    subject(:schema_field) { described_class.initialize_from_data_dictionary_field(data_dictionary_field) }
+    subject(:schema_field) { described_class.initialize_from_data_dictionary_field(data_dictionary_field, schema_field_config) }
 
     let(:data_dictionary_field) { DataDictionary::Field.where(label: 'title').first }
+    let(:schema_field_config) {}
     let(:expected_metadata) { { controlled_vocabulary: 'no_vocabulary',
                                 core_field: true,
                                 default_value: nil,
@@ -79,8 +80,48 @@ RSpec.describe Schema::MetadataField, type: :model do
 
     its(:attributes) { is_expected.to include(expected_metadata) }
 
-    it 'sets the data dictionry field id' do
+    it 'sets the data dictionary field id' do
       expect(schema_field.data_dictionary_field_id.to_s).to eq(data_dictionary_field.id.to_s)
+    end
+
+    context 'additional configuration from the schema' do
+      let(:schema_field_config) { { controlled_vocabulary: 'no_vocabulary',
+                                    default_value: 'My Awsome Work',
+                                    display_name: 'Silly Title',
+                                    display_transformation: 'no_transformation',
+                                    help_text: 'help me with my silly title',
+                                    index_type: 'facet',
+                                    label: 'title123',
+                                    requirement_designation: 'required_to_publish',
+                                    core_field: false,
+                                    order_index: 20,
+                                    validation: 'no_validation' } }
+
+      let(:expected_metadata) { { controlled_vocabulary: 'no_vocabulary',
+                                  core_field: true,
+                                  default_value: 'My Awsome Work',
+                                  display_name: 'Silly Title',
+                                  display_transformation: 'no_transformation',
+                                  field_type: 'string',
+                                  help_text: 'help me with my silly title',
+                                  index_type: 'facet',
+                                  internal_resource: 'Schema::MetadataField',
+                                  label: 'title',
+                                  multiple: true,
+                                  requirement_designation: 'required',
+                                  order_index: 20,
+                                  validation: 'no_validation' } }
+
+      its(:attributes) { is_expected.to include(expected_metadata) }
+    end
+
+    context 'additional configuration from the schema' do
+      let(:schema_field_config) { { blah: 'no_vocabulary',
+                                    not_found: 'My Awesome Work',
+                                    here: 'Silly Title',
+                                    there: 'no_transformation' } }
+
+      its(:attributes) { is_expected.to include(expected_metadata) }
     end
   end
 end

--- a/spec/cho/schema/work_type_configuration_spec.rb
+++ b/spec/cho/schema/work_type_configuration_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Schema::WorkTypeConfiguration, type: :model do
 
     let(:work_type) { 'Still Image' }
 
-    it { is_expected.to eq('still_image_field' => { 'order_index' => 1 }) }
+    it { is_expected.to eq('still_image_field' => { 'order_index' => 1, 'display_name' => 'Photograph' }) }
 
     context 'a non existing work type' do
       let(:work_type) { 'Foo' }


### PR DESCRIPTION
refs #437

## Description

References ticket: (if any) refs #437

Why was this necessary?  Allows for schema values to override the data dictionary fields.

## Changes

Are there any major changes in this PR that will change the release process? No

## Checklist

- [ ] i18n enabled
- [ ] adequate test coverage
- [ ] accessible interface
