### PR TITLE
Allowing find by multiple terms

### DIFF
--- a/spec/cho/shared/common_queries_spec.rb
+++ b/spec/cho/shared/common_queries_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe CommonQueries do
       include CommonQueries
       attribute :id, Valkyrie::Types::ID.optional
       attribute :label, Valkyrie::Types::String
+      attribute :other, Valkyrie::Types::String
       attribute :bool_val, Valkyrie::Types::Strict::Bool
     end
 
@@ -86,6 +87,8 @@ RSpec.describe CommonQueries do
     let(:resource2) { CommonResource.new(label: 'second resource', bool_val: false) }
     let(:resource3) { CommonResource.new(label: 'third resource', bool_val: true) }
     let(:resource4) { CommonResource.new(bool_val: false) }
+    let(:resource5) { CommonResource.new(label: 'same label', other: 'other key', bool_val: true) }
+    let(:resource6) { CommonResource.new(label: 'same label', other: 'my key', bool_val: true) }
 
     it 'retrieves a resource based on its label' do
       persisted_resource = Valkyrie.config.metadata_adapter.persister.save(resource: resource1)
@@ -109,6 +112,14 @@ RSpec.describe CommonQueries do
       Valkyrie.config.metadata_adapter.persister.save(resource: resource2)
       persisted_resource = Valkyrie.config.metadata_adapter.persister.save(resource: resource4)
       results = CommonResource.find_using(label: nil)
+      expect(results.count).to eq(1)
+      expect(results.first.id).to eq(persisted_resource.id)
+    end
+
+    it 'retrieves a resource based on its label and other key' do
+      Valkyrie.config.metadata_adapter.persister.save(resource: resource5)
+      persisted_resource = Valkyrie.config.metadata_adapter.persister.save(resource: resource6)
+      results = CommonResource.find_using(label: 'same label', other: 'my key')
       expect(results.count).to eq(1)
       expect(results.first.id).to eq(persisted_resource.id)
     end

--- a/spec/valkyrie/find_using_spec.rb
+++ b/spec/valkyrie/find_using_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe FindUsing do
       include DataDictionary::FieldsForObject
       attribute :id, Valkyrie::Types::ID.optional
       attribute :framjam, Valkyrie::Types::String
+      attribute :flimjam, Valkyrie::Types::String
     end
 
     class SimilarResource < Valkyrie::Resource
@@ -34,20 +35,26 @@ RSpec.describe FindUsing do
     let(:retrieved_resource) { query_service.custom_queries.find_using(framjam: 'some label').first }
 
     its(:framjam) { is_expected.to eq(retrieved_resource.framjam) }
+
+    context 'when providing multiple terms' do
+      before do
+        resource = SampleResource.new(framjam: 'some label', flimjam: 'label')
+        Valkyrie.config.metadata_adapter.persister.save(resource: resource)
+      end
+
+      let(:sample_resource)    { SampleResource.new(framjam: 'some label', flimjam: 'another label') }
+      let(:retrieved_resource) {
+        query_service.custom_queries.find_using(framjam: 'some label', flimjam: 'another label').first
+      }
+
+      its(:id) { is_expected.to eq(retrieved_resource.id) }
+    end
   end
 
   context 'without a saved resource' do
     subject { query_service.custom_queries.find_using(framjam: 'some label').first }
 
     it { is_expected.to be_nil }
-  end
-
-  context 'when providing multiple terms' do
-    it 'raises and error' do
-      expect {
-        query_service.custom_queries.find_using(framjam: 'some label', flimjam: 'another label')
-      }.to raise_error(ArgumentError, 'only one query term is supported')
-    end
   end
 
   context 'when providing a model' do


### PR DESCRIPTION
## Description

References ticket: (if any) #437

Why was this necessary? Schema::Fields are going to be unique by their WorkType and Label not just their label.  Allowing for multiple fields will let us find them

## Changes

Allow find_using to accept multiple terms

Are there any major changes in this PR that will change the release process? no

## Checklist

- [ ] i18n enabled
- [ ] adequate test coverage
- [ ] accessible interface
