### PR TITLE
FileSet resource class for grouping files

### DIFF
--- a/app/cho/schema/configuration.rb
+++ b/app/cho/schema/configuration.rb
@@ -2,12 +2,16 @@
 
 module Schema
   class Configuration
-    attr_reader :schema_config, :work_types
+    attr_reader :schemas, :schema_config
+
+    Struct.new('Schema', :type, :work_type?)
 
     def initialize(schema_file_path = nil)
       schema_file_path ||= Rails.root.join('config', 'data_dictionary', 'schema_fields.yml')
       @schema_config = YAML.load_file(schema_file_path)[Rails.env]
-      @work_types = schema_config.map { |config| config.fetch('schema') }
+      @schemas = schema_config.map do |config|
+        Struct::Schema.new(config.fetch('schema'), (config.fetch('work_type', 'true') == 'true'))
+      end
     end
 
     def core_field_count
@@ -19,10 +23,10 @@ module Schema
     end
 
     def load_work_types
-      work_types.each do |type|
-        work_type_config = Schema::WorkTypeConfiguration.new(schema_configuration: self, work_type: type)
+      schemas.each do |schema|
+        work_type_config = Schema::WorkTypeConfiguration.new(schema_configuration: self, work_type: schema.type)
         work_type_config.generate_metadata_schema
-        work_type_config.generate_work_type unless type == 'Collection'
+        work_type_config.generate_work_type if schema.work_type?
       end
     end
   end

--- a/app/cho/work/file_set.rb
+++ b/app/cho/work/file_set.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# A primary resource type in CHO, a file set contains other File resources each of which relates
+# to a single original binary source.
+# File sets are indexed both in Solr and and Postgres using the {IndexingAdapter}.
+class Work::FileSet < Valkyrie::Resource
+  include CommonQueries
+  include DataDictionary::FieldsForObject
+
+  attribute :id, Valkyrie::Types::ID.optional
+  attribute :member_ids, Valkyrie::Types::Set.of(Valkyrie::Types::ID)
+end

--- a/app/cho/work/file_set_change_set.rb
+++ b/app/cho/work/file_set_change_set.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Work
+  class FileSetChangeSet < Valkyrie::ChangeSet
+    validates :member_ids, with: :validate_members!
+    validates :member_ids, presence: true
+    property :member_ids,
+             multiple: true,
+             required: false,
+             type: Types::Strict::Array.of(Valkyrie::Types::ID)
+
+    include DataDictionary::FieldsForChangeSet
+    include WithValidMembers
+
+    delegate :url_helpers, to: 'Rails.application.routes'
+
+    def initialize(*args)
+      super(*args)
+    end
+  end
+end

--- a/app/cho/work/submission_change_set.rb
+++ b/app/cho/work/submission_change_set.rb
@@ -14,19 +14,12 @@ module Work
              type: Types::Strict::Array.of(Valkyrie::Types::ID)
 
     include DataDictionary::FieldsForChangeSet
+    include WithValidMembers
+
     delegate :url_helpers, to: 'Rails.application.routes'
 
     def initialize(*args)
       super(*args)
-    end
-
-    # @note modifies the elements in the field to contain resources that exist. Any non-existing
-    #   resources are added as errors to the change set.
-    def validate_members!(field)
-      members = self[field].map { |id| Member.new(id) }
-      members.each do |member|
-        errors.add(field, "#{member.id} does not exist") unless member.exists?
-      end
     end
 
     def validate_work_type_id!(field)
@@ -64,21 +57,6 @@ module Work
         url_helpers.work_path(model)
       else
         url_helpers.works_path
-      end
-    end
-
-    class Member
-      attr_reader :id
-
-      def initialize(id)
-        @id = Valkyrie::ID.new(id)
-      end
-
-      def exists?
-        Valkyrie.config.metadata_adapter.query_service.find_by(id: id)
-        true
-      rescue Valkyrie::Persistence::ObjectNotFoundError
-        false
       end
     end
 

--- a/app/cho/work/with_valid_members.rb
+++ b/app/cho/work/with_valid_members.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Work::WithValidMembers
+  # @note modifies the elements in the field to contain resources that exist. Any non-existing
+  #   resources are added as errors to the change set.
+  def validate_members!(field)
+    members = self[field].map { |id| Member.new(id) }
+    members.each do |member|
+      errors.add(field, "#{member.id} does not exist") unless member.exists?
+    end
+  end
+
+  class Member
+    attr_reader :id
+
+    def initialize(id)
+      @id = Valkyrie::ID.new(id)
+    end
+
+    def exists?
+      Valkyrie.config.metadata_adapter.query_service.find_by(id: id)
+      true
+    rescue Valkyrie::Persistence::ObjectNotFoundError
+      false
+    end
+  end
+end

--- a/config/data_dictionary/schema_fields.yml
+++ b/config/data_dictionary/schema_fields.yml
@@ -3,6 +3,10 @@ development: &development
     fields: []
   - schema: 'Collection'
     fields: []
+    work_type: 'false'
+  - schema: 'FileSet'
+    fields: []
+    work_type: 'false'
   - schema: 'Document'
     fields:
       contributor:
@@ -157,4 +161,8 @@ test:
         order_index: 1
   - schema: 'Collection'
     fields: []
+    work_type: 'false'
+  - schema: 'FileSet'
+    fields: []
+    work_type: 'false'
 production: *development

--- a/spec/cho/schema/configuration_spec.rb
+++ b/spec/cho/schema/configuration_spec.rb
@@ -19,13 +19,27 @@ RSpec.describe Schema::Configuration, type: :model do
         { 'schema' => 'Moving Image',
           'fields' => { 'moving_image_field' => { 'order_index' => 1 } } },
         { 'schema' => 'Audio', 'fields' => { 'audio_field' => { 'order_index' => 1 } } },
-        { 'schema' => 'Collection', 'fields' => [] }
+        { 'schema' => 'Collection', 'fields' => [], 'work_type' => 'false' },
+        { 'schema' => 'FileSet', 'fields' => [], 'work_type' => 'false' }
       ]
     )
   end
 
-  its(:work_types) do
-    is_expected.to eq(['Generic', 'Document', 'Still Image', 'Map', 'Moving Image', 'Audio', 'Collection'])
+  describe '#schemas' do
+    it 'reads each schema from the config file' do
+      expect(schema_configuration.schemas.first).to be_a(Struct::Schema)
+      expect(schema_configuration.schemas.map(&:type)).to contain_exactly(
+        'Generic', 'Document', 'Still Image', 'Map', 'Moving Image', 'Audio', 'Collection', 'FileSet'
+      )
+      expect(schema_configuration.schemas.select { |s| s.type == 'Generic' }.first).to be_work_type
+      expect(schema_configuration.schemas.select { |s| s.type == 'Document' }.first).to be_work_type
+      expect(schema_configuration.schemas.select { |s| s.type == 'Still Image' }.first).to be_work_type
+      expect(schema_configuration.schemas.select { |s| s.type == 'Map' }.first).to be_work_type
+      expect(schema_configuration.schemas.select { |s| s.type == 'Moving Image' }.first).to be_work_type
+      expect(schema_configuration.schemas.select { |s| s.type == 'Audio' }.first).to be_work_type
+      expect(schema_configuration.schemas.select { |s| s.type == 'Collection' }.first).not_to be_work_type
+      expect(schema_configuration.schemas.select { |s| s.type == 'FileSet' }.first).not_to be_work_type
+    end
   end
 
   describe '#load_work_types' do

--- a/spec/cho/work/file_set_change_set_spec.rb
+++ b/spec/cho/work/file_set_change_set_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Work::FileSetChangeSet do
+  subject(:change_set) { described_class.new(resource) }
+
+  let(:resource) { Work::FileSet.new }
+
+  describe '#append_id' do
+    before { change_set.append_id = Valkyrie::ID.new('test') }
+    its(:append_id) { is_expected.to eq(Valkyrie::ID.new('test')) }
+    its([:append_id]) { is_expected.to eq(Valkyrie::ID.new('test')) }
+  end
+
+  describe '#required?' do
+    it 'has a required title' do
+      expect(change_set).to be_required(:title)
+    end
+  end
+
+  describe '#fields=' do
+    before { change_set.prepopulate! }
+    its(:title) { is_expected.to be_empty }
+    its(:member_ids) { is_expected.to be_empty }
+  end
+
+  describe '#validate' do
+    subject { change_set.errors }
+
+    before { change_set.validate(params) }
+
+    context 'without a title' do
+      let(:params) { {} }
+
+      its(:full_messages) { is_expected.to include("Title can't be blank") }
+    end
+
+    context 'with non-existent parents' do
+      let(:params) { { member_ids: ['nothere'] } }
+
+      its(:full_messages) { is_expected.to include('Member ids nothere does not exist') }
+    end
+
+    context 'without members' do
+      let(:params) { { member_ids: [] } }
+
+      its(:full_messages) { is_expected.to include("Member ids can't be blank") }
+    end
+
+    context 'with all required fields' do
+      let(:file) { create :work_file }
+      let(:params) { { title: 'filename.txt', member_ids: [file.id] } }
+
+      its(:full_messages) { is_expected.to be_empty }
+    end
+  end
+
+  describe '#member_ids' do
+    before { change_set.validate(member_ids: ['1']) }
+
+    it 'casts ids to Valkyrie IDs' do
+      expect(change_set.member_ids.first).to be_kind_of(Valkyrie::ID)
+    end
+  end
+end

--- a/spec/cho/work/file_set_spec.rb
+++ b/spec/cho/work/file_set_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'valkyrie/specs/shared_specs'
+
+RSpec.describe Work::FileSet do
+  let(:resource_klass) { described_class }
+
+  it_behaves_like 'a Valkyrie::Resource'
+
+  describe 'member_ids' do
+    its(:member_ids) { is_expected.to be_empty }
+  end
+end


### PR DESCRIPTION
## Description

Fixes #550 

Provides a resource to group multiple Work::File objects together. This is analogous to the FileSet class in the Hydra works extension to PCDM. One original file is grouped together with multiple derivative files, including auto and manually generated derivatives, and extracted information such as text or other technical metadata.

## Changes

Are there any major changes in this PR that will change the release process? No.

## Checklist

- [x] i18n enabled
- [x] adequate test coverage
- [x] accessible interface
