### PR TITLE
MVP 2 Accessibility Check-up

### DIFF
--- a/app/assets/stylesheets/cho.scss
+++ b/app/assets/stylesheets/cho.scss
@@ -1,3 +1,3 @@
 @charset "UTF-8";
 
-@import 'cho/variables', 'cho/blacklight', 'cho/data_dictionary_fields', 'cho/form', 'cho/scaffolds';
+@import 'cho/variables', 'cho/blacklight', 'cho/data_dictionary_fields', 'cho/facets', 'cho/form', 'cho/scaffolds';

--- a/app/assets/stylesheets/cho/blacklight.scss
+++ b/app/assets/stylesheets/cho/blacklight.scss
@@ -15,7 +15,7 @@
   }
 }
 
-.navbar-collapse { font-size: .8rem; }
+.navbar-collapse { font-size: .9rem; }
 
 // styles to address inconsistent usage of search widgets
 // scss-lint:disable SelectorFormat
@@ -27,7 +27,11 @@
 .dl-invert dt { color: $gray-middle; }
 
 // Button visited link color
-.btn-danger:visited { color: $primary-white; }
+.btn-danger:visited,
+.btn-primary:visited { color: $primary-white; }
+
+// Button background color
+.btn-primary { background-color: $btn-primary-color; }
 
 // Adds the colored focus around the Bootstrap dropdown
 .dropdown-toggle:focus {

--- a/app/assets/stylesheets/cho/facets.scss
+++ b/app/assets/stylesheets/cho/facets.scss
@@ -1,0 +1,14 @@
+// Bootstrap overrides for color contrast needs to be heavy handed because they use the !important declaration
+// scss-lint:disable ImportantRule
+.text-success,
+.facet-values li .selected { color: $green-bg-text !important;}
+
+.facet-limit-active {
+  border-color: $green-bg-text !important;
+
+  .card-header {
+    background-color: $green-bg-text !important;
+    color: $primary-white;
+  }
+}
+// scss-lint:enable ImportantRule

--- a/app/assets/stylesheets/cho/form.scss
+++ b/app/assets/stylesheets/cho/form.scss
@@ -15,3 +15,12 @@ input { margin-bottom: 1rem; }
   color: $required-red;
   vertical-align: super;
 }
+
+label {
+  display: block;
+}
+
+// Overrides the block labels in the forms because they are generated inputs from the Data Dictionary.
+// They are hard to style using Bootstrap and override because they are not standard Rails or HTML.
+// This is a work around.
+.select-resources label { display: inline; }

--- a/app/assets/stylesheets/cho/scaffolds.scss
+++ b/app/assets/stylesheets/cho/scaffolds.scss
@@ -64,7 +64,3 @@ div {
     list-style: square;
   }
 }
-
-label {
-  display: block;
-}

--- a/app/assets/stylesheets/cho/variables.scss
+++ b/app/assets/stylesheets/cho/variables.scss
@@ -1,12 +1,15 @@
-// Color variables to be used throughout ScholarSphere.
+// Color variables to be used throughout CHO
 
 $primary-white: #fff;
 $gray-middle: #686868;
 $primary-black: #000;
 
-$required-red: #d9534f;
+$required-red: #d33a35;
 $green-notice: #008000;
+$green-bg-text: #1d7631;
 $blue-light: #66afe9;
+
+$btn-primary-color: #006cdf;
 
 $body-text-color: #333;
 

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -6,17 +6,15 @@
     <%= render '/manage' %>
     <%= render '/collection/nav' %>
     <%= render '/work/submissions/nav' %>
-  </ul>
+    <li>
+      <% if current_user %>
 
-  <ul class="nav navbar-nav">
-    <% if current_user %>
-      <li>
-        <%= link_to t('blacklight.header_links.logout'), devise_remote.destroy_user_session_path %>
-      </li>
-    <% else %>
-      <li>
-        <%= link_to t('blacklight.header_links.login'), devise_remote.new_user_session_path %>
-      </li>
-    <% end %>
+        <%= link_to t('blacklight.header_links.logout'), devise_remote.destroy_user_session_path,
+                    class: 'nav-link' %>
+      <% else %>
+        <%= link_to t('blacklight.header_links.login'), devise_remote.new_user_session_path,
+                    class: 'nav-link' %>
+      <% end %>
+    </li>
   </ul>
 </div>

--- a/app/views/batch/_document_list.html.erb
+++ b/app/views/batch/_document_list.html.erb
@@ -2,11 +2,14 @@
 <div id="documents" class="documents-<%= document_index_view_type %>">
   <%= form_for(:delete, url: batch_delete_path, method: :post) do |form| %>
     Select resources to delete:
-    <ol>
+    <ol class="select-resources">
       <% documents.each do |document| %>
         <li>
           <%= link_to_document document, document_show_link_field(document) %>
-          [ <%= form.check_box :ids, { multiple: true }, document.id, nil %> Delete ]
+          [ <%= form.check_box :ids, { multiple: true }, document.id, nil %>
+             <%= label_tag('delete_ids_' + document.id) do %>
+               Delete <span class="sr-only"><%= document.title_data_dictionary_field.first %></span>
+          <% end %> ]
         </li>
       <% end %>
       <%= form.submit t('cho.batch.delete.submit') %>

--- a/app/views/search_history/index.html.erb
+++ b/app/views/search_history/index.html.erb
@@ -7,15 +7,15 @@
     <h2 class='section-heading'><%= t('blacklight.search_history.no_history') %></h2>
   <% else %>
     <p>
-    <%= link_to t('blacklight.search_history.clear.action_title'),
-                blacklight.clear_search_history_path,
-                method: :delete,
-                data: { confirm: t('blacklight.search_history.clear.action_confirm') },
-                class: 'btn btn-danger float-md-right' %>
+      <%= link_to t('blacklight.search_history.clear.action_title'),
+                  blacklight.clear_search_history_path,
+                  method: :delete,
+                  data: { confirm: t('blacklight.search_history.clear.action_confirm') },
+                  class: 'btn btn-danger float-md-right' %>
     </p>
     <h2 class='section-heading'><%= t('blacklight.search_history.recent') %></h2>
     <ul>
-      <% @searches.each_with_index do |search,index| %>
+      <% @searches.select { |search| search.query_params.key?('q') }.each_with_index do |search,index| %>
         <%= content_tag :li, id: "document_#{index + 1}" do %>
           <span><%= link_to_previous_search(search_state.reset(search.query_params).to_hash) %></span>
         <% end #content_tag %>

--- a/app/views/work/import/csv/create.html.erb
+++ b/app/views/work/import/csv/create.html.erb
@@ -1,10 +1,11 @@
 <h1><%= t('cho.csv.create.heading') %></h1>
 
-<p><%= t('cho.csv.create.description') %></p>
-
 <%= form_for(@csv_file, url: csv_validate_path) do |form| %>
 
   <%= form.hidden_field :file, value: @csv_file.cached_file_data %>
+  <%= label_tag(:work_import_csv_file_file) do %>
+    <%= t('cho.csv.create.description') %>
+  <% end %>
   <%= form.file_field :file %>
 
   <div class="actions">

--- a/app/views/work/import/csv/update.html.erb
+++ b/app/views/work/import/csv/update.html.erb
@@ -1,10 +1,11 @@
 <h1><%= t('cho.csv.update.heading') %></h1>
 
-<p><%= t('cho.csv.update.description') %></p>
-
 <%= form_for(@csv_file, url: csv_validate_path) do |form| %>
 
   <%= form.hidden_field :file, value: @csv_file.cached_file_data %>
+  <%= label_tag(:work_import_csv_file_file) do %>
+    <%= t('cho.csv.update.description') %>
+  <% end %>
   <%= form.file_field :file %>
 
   <div class="actions">

--- a/spec/blacklight/search_history_spec.rb
+++ b/spec/blacklight/search_history_spec.rb
@@ -8,12 +8,17 @@ RSpec.describe 'Search History Page', type: :feature do
       visit '/'
       fill_in 'q', with: 'book'
       click_button 'search'
+      fill_in 'q', with: ''
+      click_button 'search'
       click_link 'History'
     end
     it 'shows searches' do
       expect(page).to have_content 'Your recent searches'
-      expect(page).to have_content 'book'
-      expect(page).not_to have_content 'dang'
+      within '#content' do
+        expect(page).to have_content 'book'
+        expect(page).not_to have_content 'dang'
+        expect(page.all('li').count).to eq(1)
+      end
       visit '/'
       fill_in 'q', with: 'dang'
       click_button 'search'


### PR DESCRIPTION
Co-authored-by: Adam Wead <amsterdamos@gmail.com>

## Description
Update styles to user util links for the link reorganization. Removes empty searches from search history. Improves accessibility of the delete checkboxes on the select resources page, Adds label for form elements on the work create and update page. Updates CSS for contrast and accessibility errors. 

References ticket: (if any) #306

Why was this necessary?

WAVE accessibility toolbar reported errors and warnings throughout the interface.

## Changes
 Improved the links in the toolbar and the search history showing blank searches. Lots of color contrast changes and some Bootstrap overrides until Bootstrap 4 tickets for accessibility are closed.


Are there any major changes in this PR that will change the release process? No

## Checklist

- [x] i18n enabled
- [ ] adequate test coverage
- [x] accessible interface
