### PR TITLE
Add use type URIs to Work::File

### DIFF
--- a/app/cho/vocab/file_use.rb
+++ b/app/cho/vocab/file_use.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rdf'
+
+# @note this is extending from the PCDM use ontology. All URIs and namespaces are fake right now until
+#   we can decide how to define our own ontologies.
+module Vocab
+  class FileUse < RDF::Vocabulary('https://libraries.psu.edu/use#')
+    # Ontology definition
+    ontology :"https://libraries.psu.edu/use#",
+             comment: %(Ontology for a local ontology of file rotes that extends the PCDM use ontology to add
+                        subclasses of PCDM File for the different roles files have in relation to the Object
+                        they are attached to.),
+             "dc:title": %(CHO File Use)
+
+    # Class definitions
+    term :RedactedPreservationMasterFile,
+         comment: %(Best quality representation of the Object with sensitive information redacted for security.
+                    Appropriate for long-term preservation.),
+         label: 'redacted preservation master file',
+         "rdf:subClassOf": %(http://pcdm.org/use#PreservationMasterFile),
+         "rdfs:isDefinedBy": %(chouse:),
+         type: 'rdfs:Class'
+    term :AccessFile,
+         comment: %(A medium quality representation of the Object appropriate for serving to users
+                    generated automatically from a higher-quality source.),
+         label: 'access file',
+         "rdf:subClassOf": %(http://pcdm.org/use#ServiceFile),
+         "rdfs:isDefinedBy": %(chomuse:),
+         type: 'rdfs:Class'
+  end
+end

--- a/app/cho/work/file.rb
+++ b/app/cho/work/file.rb
@@ -4,10 +4,10 @@
 # Files are indexed both in Solr and and Postgres using the {IndexingAdapter}.
 class Work::File < Valkyrie::Resource
   include CommonQueries
+  include WithUseType
 
   attribute :id, Valkyrie::Types::ID.optional
   attribute :original_filename, Valkyrie::Types::String
-  attribute :use, Valkyrie::Types::Set
   attribute :file_identifier, Valkyrie::Types::ID.optional
 
   # @return [String] path to binary file

--- a/app/cho/work/file_change_set.rb
+++ b/app/cho/work/file_change_set.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Work
+  class FileChangeSet < Valkyrie::ChangeSet
+    property :use, multiple: true, required: true, default: [Valkyrie::Vocab::PCDMUse.PreservationMasterFile]
+    validates :use, 'work/use_type': true
+
+    property :original_filename, multiple: false, required: true
+    validates :original_filename, presence: true
+  end
+end

--- a/app/cho/work/use_type_validator.rb
+++ b/app/cho/work/use_type_validator.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Work
+  class UseTypeValidator < ActiveModel::EachValidator
+    def validate_each(record, attribute, value)
+      values = Array.wrap(value)
+      bad_uris = values.reject { |v| Work::WithUseType::USE_TYPE_URIS.include?(v) }
+      return if bad_uris.empty? && values.present?
+      record.errors.add attribute, error_message(bad_uris)
+    end
+
+    def error_message(uris)
+      if uris.empty?
+        'cannot be empty'
+      else
+        "cannot be #{uris.join(', ')}"
+      end
+    end
+  end
+end

--- a/app/cho/work/with_use_type.rb
+++ b/app/cho/work/with_use_type.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Work::WithUseType
+  extend ActiveSupport::Concern
+
+  USE_TYPE_URIS = [
+    Valkyrie::Vocab::PCDMUse.ExtractedText,
+    Valkyrie::Vocab::PCDMUse.PreservationMasterFile,
+    Vocab::FileUse.RedactedPreservationMasterFile,
+    Vocab::FileUse.AccessFile,
+    Valkyrie::Vocab::PCDMUse.ServiceFile,
+    Valkyrie::Vocab::PCDMUse.ThumbnailImage
+  ].freeze
+
+  class UseTypes
+    def self.call(value)
+      raise Dry::Struct::Error, "#{value} is not a valid use type" unless valid?(value)
+      value
+    end
+
+    def self.valid?(value)
+      USE_TYPE_URIS.include?(value)
+    end
+  end
+
+  included do
+    attribute :use, Valkyrie::Types::Set.member(UseTypes).default([Valkyrie::Vocab::PCDMUse.PreservationMasterFile])
+  end
+
+  def preservation!
+    self.use = [Valkyrie::Vocab::PCDMUse.PreservationMasterFile]
+  end
+
+  def preservation?
+    use.include?(Valkyrie::Vocab::PCDMUse.PreservationMasterFile)
+  end
+
+  def preservation_redacted!
+    self.use = [Vocab::FileUse.RedactedPreservationMasterFile]
+  end
+
+  def preservation_redacted?
+    use.include?(Vocab::FileUse.RedactedPreservationMasterFile)
+  end
+
+  def text!
+    self.use = [Valkyrie::Vocab::PCDMUse.ExtractedText]
+  end
+
+  def text?
+    use.include?(Valkyrie::Vocab::PCDMUse.ExtractedText)
+  end
+
+  def access!
+    self.use = [Vocab::FileUse.AccessFile]
+  end
+
+  def access?
+    use.include?(Vocab::FileUse.AccessFile)
+  end
+
+  def service!
+    self.use = [Valkyrie::Vocab::PCDMUse.ServiceFile]
+  end
+
+  def service?
+    use.include?(Valkyrie::Vocab::PCDMUse.ServiceFile)
+  end
+
+  def thumbnail!
+    self.use = [Valkyrie::Vocab::PCDMUse.ThumbnailImage]
+  end
+
+  def thumbnail?
+    use.include?(Valkyrie::Vocab::PCDMUse.ThumbnailImage)
+  end
+end

--- a/app/valkyrie/change_set_persister.rb
+++ b/app/valkyrie/change_set_persister.rb
@@ -89,8 +89,7 @@ class ChangeSetPersister
     def work_file(change_set:, adapter_file:)
       Work::File.new(
         file_identifier: adapter_file.id,
-        original_filename: change_set.file.original_filename,
-        use: [Valkyrie::Vocab::PCDMUse.OriginalFile]
+        original_filename: change_set.file.original_filename
       )
     end
 

--- a/spec/cho/work/file_change_set_spec.rb
+++ b/spec/cho/work/file_change_set_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Work::FileChangeSet do
+  subject(:change_set) { described_class.new(resource) }
+
+  let(:resource) { Work::File.new }
+
+  before { change_set.prepopulate! }
+
+  describe '#append_id' do
+    before { change_set.append_id = Valkyrie::ID.new('test') }
+    its(:append_id) { is_expected.to eq(Valkyrie::ID.new('test')) }
+    its([:append_id]) { is_expected.to eq(Valkyrie::ID.new('test')) }
+  end
+
+  describe '#use' do
+    it { is_expected.to be_multiple(:use) }
+    it { is_expected.to be_required(:use) }
+    its(:use) { is_expected.to contain_exactly(Valkyrie::Vocab::PCDMUse.PreservationMasterFile) }
+  end
+
+  describe '#original_filename' do
+    it { is_expected.not_to be_multiple(:original_filename) }
+    it { is_expected.to be_required(:original_filename) }
+    its(:original_filename) { is_expected.to be_nil }
+  end
+
+  describe '#validate' do
+    subject { change_set.errors }
+
+    before do
+      change_set.validate(params)
+    end
+
+    context 'without an original filename' do
+      let(:params) { {} }
+
+      its(:full_messages) { is_expected.to contain_exactly("Original filename can't be blank") }
+    end
+
+    context 'with an incorrect use type' do
+      let(:params) { { original_filename: 'file.txt', use: ['blarg'] } }
+
+      its(:full_messages) { is_expected.to contain_exactly('Use cannot be blarg') }
+    end
+
+    context 'without any use type' do
+      let(:params) { { original_filename: 'file.txt', use: [] } }
+
+      its(:full_messages) { is_expected.to contain_exactly('Use cannot be empty') }
+    end
+
+    context 'with a nil use type' do
+      let(:params) { { original_filename: 'file.txt', use: nil } }
+
+      its(:full_messages) { is_expected.to contain_exactly('Use cannot be empty') }
+    end
+  end
+end

--- a/spec/cho/work/file_spec.rb
+++ b/spec/cho/work/file_spec.rb
@@ -17,6 +17,15 @@ RSpec.describe Work::File do
     file.file_identifier = binary_content.id
     saved_resource = Valkyrie.config.metadata_adapter.persister.save(resource: file)
     expect(saved_resource.file_identifier).to eq(binary_content.id)
+    expect(saved_resource.use).to contain_exactly(Valkyrie::Vocab::PCDMUse.PreservationMasterFile)
+  end
+
+  describe '#use' do
+    context 'with an invalid use type' do
+      it 'raises an error' do
+        expect { file.use = 'asdf' }.to raise_error(Dry::Struct::Error, 'asdf is not a valid use type')
+      end
+    end
   end
 
   describe '#path' do

--- a/spec/cho/work/with_use_type_spec.rb
+++ b/spec/cho/work/with_use_type_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Work::WithUseType, type: :model do
+  before (:all) do
+    class MyFileModel < Valkyrie::Resource
+      include Work::WithUseType
+    end
+  end
+
+  after (:all) do
+    ActiveSupport::Dependencies.remove_constant('MyFileModel')
+  end
+
+  subject(:model) { MyFileModel.new }
+
+  context 'with a preservation type' do
+    before { model.preservation! }
+
+    it do
+      is_expected.not_to be_text
+      is_expected.not_to be_access
+      is_expected.to be_preservation
+      is_expected.not_to be_preservation_redacted
+      is_expected.not_to be_service
+      is_expected.not_to be_thumbnail
+    end
+  end
+
+  context 'with a redacted preservation type' do
+    before { model.preservation_redacted! }
+
+    it do
+      is_expected.not_to be_text
+      is_expected.not_to be_access
+      is_expected.not_to be_preservation
+      is_expected.to be_preservation_redacted
+      is_expected.not_to be_service
+      is_expected.not_to be_thumbnail
+    end
+  end
+
+  context 'with a text type' do
+    before { model.text! }
+
+    it do
+      is_expected.to be_text
+      is_expected.not_to be_access
+      is_expected.not_to be_preservation
+      is_expected.not_to be_preservation_redacted
+      is_expected.not_to be_service
+      is_expected.not_to be_thumbnail
+    end
+  end
+
+  context 'with a access type' do
+    before { model.access! }
+
+    it do
+      is_expected.not_to be_text
+      is_expected.to be_access
+      is_expected.not_to be_preservation
+      is_expected.not_to be_preservation_redacted
+      is_expected.not_to be_service
+      is_expected.not_to be_thumbnail
+    end
+  end
+
+  context 'with a service type' do
+    before { model.service! }
+
+    it do
+      is_expected.not_to be_text
+      is_expected.not_to be_access
+      is_expected.not_to be_preservation
+      is_expected.not_to be_preservation_redacted
+      is_expected.to be_service
+      is_expected.not_to be_thumbnail
+    end
+  end
+
+  context 'with a thumbnail type' do
+    before { model.thumbnail! }
+
+    it do
+      is_expected.not_to be_text
+      is_expected.not_to be_access
+      is_expected.not_to be_preservation
+      is_expected.not_to be_preservation_redacted
+      is_expected.not_to be_service
+      is_expected.to be_thumbnail
+    end
+  end
+
+  context 'field_type is bogus' do
+    let(:model) { MyFileModel.new(use: 'bogus') }
+
+    it 'raises an error' do
+      expect { model }.to raise_error(Dry::Struct::Error)
+    end
+  end
+end

--- a/spec/factories/work_file.rb
+++ b/spec/factories/work_file.rb
@@ -7,7 +7,7 @@ require Rails.root.join('spec', 'support', 'seed_map')
 FactoryBot.define do
   factory :work_file, class: Work::File do
     original_filename 'original_name'
-    use [Valkyrie::Vocab::PCDMUse.OriginalFile]
+    use [Valkyrie::Vocab::PCDMUse.PreservationMasterFile]
 
     to_create do |resource|
       Valkyrie.config.metadata_adapter.persister.save(resource: resource)

--- a/spec/valkyrie/change_set_persister_spec.rb
+++ b/spec/valkyrie/change_set_persister_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe ChangeSetPersister do
         }.to change { metadata_adapter.query_service.find_all.count }.by(2)
         expect(saved_change_set.model.files).to eq(work_files.map(&:id))
         expect(work_file.original_filename).to eq('hello_world.txt')
-        expect(work_file.use.map(&:to_s)).to eq(['http://pcdm.org/use#OriginalFile'])
+        expect(work_file.use.map(&:to_s)).to eq(['http://pcdm.org/use#PreservationMasterFile'])
       end
     end
   end


### PR DESCRIPTION
## Description

Connects to #512

This doesn't define a schema for Work::File resources, but instead provides an internal controlled vocabulary for what use types we can assign to the file.

I'm totally satisfied with it. I've provided a Work::FileChangeSet to provided better feedback for errors with file, but we're not using it yet. I imagine it will be needed for later tickets when reporting errors with file sets during the bag import process.

Also, there is duplication of validation between the file resource and its change set. This is so the existing change set persister can save files correctly, with a default preservation use type. This will also need to change later as we will want to pass specific use types to the persister.

## Changes

Are there any major changes in this PR that will change the release process? No.

## Checklist

- [ ] i18n enabled
- [ ] adequate test coverage
- [ ] accessible interface