### PR TITLE
Allowing the display name to be show on the edit page or work and collection

### DIFF
--- a/app/cho/schema/input_field.rb
+++ b/app/cho/schema/input_field.rb
@@ -25,6 +25,10 @@ module Schema
       metadata_field.label
     end
 
+    def display_label
+      metadata_field.display_name || metadata_field.label.titleize
+    end
+
     def field
       if text?
         form.text_area metadata_field.label, options_for_text_area

--- a/app/cho/schema/metadata_core_fields.rb
+++ b/app/cho/schema/metadata_core_fields.rb
@@ -3,7 +3,7 @@
 class Schema::MetadataCoreFields
   def self.generate(adapter, work_type:)
     fields = DataDictionary::Field.core_fields
-    fields.to_a.each_with_index.map do |field, idx|
+    fields.sort_by(&:created_at).each_with_index.map do |field, idx|
       schema_field = Schema::MetadataField.initialize_from_data_dictionary_field(field, work_type: work_type)
       schema_field.order_index = idx
       ChangeSetPersister.new(

--- a/app/views/shared/_form_fields.html.erb
+++ b/app/views/shared/_form_fields.html.erb
@@ -1,6 +1,6 @@
 <%- resource.input_fields(form).each do |input| %>
   <%= input.label do %>
-    <%= input.label_text.titleize %>
+    <%= input.display_label %>
     <% if input.required? %>
       <span class="required no-bold"> required</span>
     <% end %>

--- a/config/data_dictionary/data_dictionary_test.csv
+++ b/config/data_dictionary/data_dictionary_test.csv
@@ -1,5 +1,5 @@
 Label,Field Type,Requirement Designation,Validation,Multiple,Controlled Vocabulary,Default Value,Display Name,Display Transformation,Index Type,Help Text,Core Field
-title,string,required,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,true
+title,string,required,no_validation,true,no_vocabulary,,Object Title,no_transformation,no_facet,help me,true
 subtitle,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,true
 description,text,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,true
 created,date,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false

--- a/spec/cho/data_dictionary/fields_controller_spec.rb
+++ b/spec/cho/data_dictionary/fields_controller_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe DataDictionary::FieldsController, type: :controller do
       'multiple' => true,
       'controlled_vocabulary' => 'no_vocabulary',
       'default_value' => nil,
-      'display_name' => nil,
+      'display_name' => 'Object Title',
       'display_transformation' => 'no_transformation',
       'url' => "http://test.host/data_dictionary_fields/#{title_field.id}.json"
     }
@@ -128,7 +128,8 @@ RSpec.describe DataDictionary::FieldsController, type: :controller do
           "Default Value,Display Name,Display Transformation,Index Type,Help Text,Core Field\n"
         )
         expect(response.body).to include(
-          "title,string,required,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,true\n"
+          'title,string,required,no_validation,true,no_vocabulary,,Object Title,'\
+          "no_transformation,no_facet,help me,true\n"
         )
         expect(response.body).to include(
           'abc123_label,date,recommended,no_validation,false,no_vocabulary,abc123,My Abc123,'\

--- a/spec/cho/schema/metadata_field_spec.rb
+++ b/spec/cho/schema/metadata_field_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Schema::MetadataField, type: :model do
     let(:expected_metadata) { { controlled_vocabulary: 'no_vocabulary',
                                 core_field: true,
                                 default_value: nil,
-                                display_name: nil,
+                                display_name: 'Object Title',
                                 display_transformation: 'no_transformation',
                                 field_type: 'string',
                                 help_text: 'help me',

--- a/spec/views/work_submissions/edit.html.erb_spec.rb
+++ b/spec/views/work_submissions/edit.html.erb_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'work/submissions/edit', type: :view do
     let(:work_type) { Work::Type.where(label: 'Still Image').first }
 
     it 'renders the edit form' do
-      assert_form('still_image_field')
+      assert_form('still_image_field', 'Photograph')
     end
   end
 
@@ -63,11 +63,16 @@ RSpec.describe 'work/submissions/edit', type: :view do
     end
   end
 
-  def assert_form(specific_field)
+  def assert_form(specific_field, display_label = nil)
+    display_label ||= specific_field.titleize
     assert_select 'form[action=?][method=?]', work_path(@work.model), 'post' do
+      assert_select 'label[for=?]', 'work_submission_title', text: "Object Title\n       required"
       assert_select 'input[name=?]', 'work_submission[title]'
+      assert_select 'label[for=?]', 'work_submission_subtitle', text: 'Subtitle'
       assert_select 'input[name=?]', 'work_submission[subtitle]'
+      assert_select 'label[for=?]', 'work_submission_description', text: 'Description'
       assert_select 'textarea[name=?]', 'work_submission[description]'
+      assert_select 'label[for=?]', "work_submission_#{specific_field}", text: display_label
       assert_select 'input[name=?]', "work_submission[#{specific_field}]"
     end
   end


### PR DESCRIPTION

## Description

refs #437

Why was this necessary?  The display name was not being used for a label.

## Changes

Use the display name on the edit form.
Update the test data dictionary to have  a display name for title to test this further.

Are there any major changes in this PR that will change the release process?

## Checklist

- [ ] i18n enabled
- [ ] adequate test coverage
- [ ] accessible interface
