### PR TITLE
Adding display name to index and show

### DIFF
--- a/app/blacklight/catalog_helper.rb
+++ b/app/blacklight/catalog_helper.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module CatalogHelper
+  include Blacklight::CatalogHelperBehavior
+
+  ##
+  # Look up the label for the index field
+  def index_field_label(document, field)
+    lookup_display_name(document, field) || super
+  end
+
+  ##
+  # Look up the label for the show field
+  def document_show_field_label(document, field)
+    lookup_display_name(document, field) || super
+  end
+
+  private
+
+    def lookup_display_name(document, field)
+      return nil if document.schema.blank?
+
+      parts = field.split('_')
+      field_label = parts[0, parts.count - 1].join('_')
+      field_schema = document.schema.field(field_label)
+
+      return nil if field_schema.blank?
+
+      field_schema.display_name
+    end
+end

--- a/app/blacklight/solr_document.rb
+++ b/app/blacklight/solr_document.rb
@@ -47,4 +47,20 @@ class SolrDocument
   def collection?
     internal_resource_name.include?('Collection')
   end
+
+  def work_type
+    @work_type ||= Array.wrap(self[:work_type_ssim]).first
+  end
+
+  def schema
+    @schema ||= Schema::Metadata.where(label: schema_label).first
+  end
+
+  def schema_label
+    @schema_label ||= if collection?
+                        'Collection'
+                      else
+                        work_type
+                      end
+  end
 end

--- a/app/cho/schema/metadata.rb
+++ b/app/cho/schema/metadata.rb
@@ -33,6 +33,11 @@ module Schema
       @loaded_fields ||= load_fields(@fields)
     end
 
+    def field(label)
+      loaded_core_fields.select { |field| field.label == label }.first ||
+        loaded_fields.select { |field| field.label == label }.first
+    end
+
     private
 
       def gather_field_ids(new_fields)

--- a/spec/blacklight/solr_document_spec.rb
+++ b/spec/blacklight/solr_document_spec.rb
@@ -118,4 +118,18 @@ RSpec.describe SolrDocument, type: :model do
       it { is_expected.to be_truthy }
     end
   end
+
+  describe '#schema' do
+    subject { solr_document.schema }
+
+    let(:document) { { 'internal_resource_tsim' => 'Work::Submission', work_type_ssim: ['Document'] } }
+
+    its(:label) { is_expected.to eq('Document') }
+
+    context 'for a collection' do
+      let(:document) { { 'internal_resource_tsim' => 'ArchivalCollection' } }
+
+      its(:label) { is_expected.to eq('Collection') }
+    end
+  end
 end

--- a/spec/cho/schema/metadata_spec.rb
+++ b/spec/cho/schema/metadata_spec.rb
@@ -76,4 +76,16 @@ RSpec.describe Schema::Metadata, type: :model do
       reloaded_model.loaded_fields
     end
   end
+
+  describe '#field' do
+    subject { model.field('core1') }
+
+    it { is_expected.to eq(core_fields[0]) }
+
+    context 'not a core field' do
+      subject { model.field('field1') }
+
+      it { is_expected.to eq(fields[0]) }
+    end
+  end
 end

--- a/spec/cho/work/submissions/index_spec.rb
+++ b/spec/cho/work/submissions/index_spec.rb
@@ -14,12 +14,12 @@ RSpec.describe Work::Submission, type: :feature do
     fill_in(:q, with: 'Work Index View')
     click_button('Search')
     within('div#documents') do
-      expect(page).to have_blacklight_label('title_tesim').with('Title')
-      expect(page).to have_blacklight_field('title_tesim').with('No files')
+      expect(page).to have_blacklight_label('title_tesim').with('Object Title')
+      expect(page).to have_blacklight_field('title_tesim').with('Work Index View')
       expect(page).to have_blacklight_label('work_type_ssim').with('Work Type')
       expect(page).to have_blacklight_field('work_type_ssim').with('Generic')
-      expect(page).to have_blacklight_label('member_of_collections_ssim').with('Collections')
-      expect(page).to have_blacklight_field('member_of_collections_ssim').with('Library Collection')
+      expect(page).to have_blacklight_label('member_of_collection_ids_ssim').with('Collections')
+      expect(page).to have_blacklight_field('member_of_collection_ids_ssim').with('Library Collection')
       expect(page).to have_link('Library Collection')
     end
   end

--- a/spec/cho/work/submissions/show_spec.rb
+++ b/spec/cho/work/submissions/show_spec.rb
@@ -16,12 +16,12 @@ RSpec.describe Work::Submission, type: :feature do
     it 'displays only metadata' do
       visit(polymorphic_path([:solr_document], id: work.id))
       within('div#document') do
-        expect(page).to have_blacklight_label('title_tesim').with('Title')
+        expect(page).to have_blacklight_label('title_tesim').with('Object Title')
         expect(page).to have_blacklight_field('title_tesim').with('No files')
         expect(page).to have_blacklight_label('work_type_ssim').with('Work Type')
         expect(page).to have_blacklight_field('work_type_ssim').with('Document')
-        expect(page).to have_blacklight_label('member_of_collections_ssim').with('Collections')
-        expect(page).to have_blacklight_field('member_of_collections_ssim').with('Library Collection')
+        expect(page).to have_blacklight_label('member_of_collection_ids_ssim').with('Collections')
+        expect(page).to have_blacklight_field('member_of_collection_ids_ssim').with('Library Collection')
         expect(page).to have_link('Library Collection')
       end
       expect(page).not_to have_selector('h2', text: 'Files')

--- a/spec/support/matchers/blacklight.rb
+++ b/spec/support/matchers/blacklight.rb
@@ -2,9 +2,7 @@
 
 RSpec::Matchers.define :have_blacklight_field do |field|
   match do |_actual|
-    within('dd.blacklight-' + field) do
-      page.has_content(value)
-    end
+    page.has_selector?('dd.blacklight-' + field, text: @value)
   end
 
   chain :with do |value|
@@ -14,9 +12,7 @@ end
 
 RSpec::Matchers.define :have_blacklight_label do |field|
   match do |_actual|
-    within('dt.blacklight-' + field) do
-      page.has_content(value)
-    end
+    page.has_selector?('dt.blacklight-' + field, text: @value)
   end
 
   chain :with do |value|


### PR DESCRIPTION
Fixed up custom matchers to truely match
Added override of CatalogHelper to change label based on document schema
updated solr document to lookup schema
updated Schma::Metadata to find field by label in either core or regular fields

## Description

Fixes: #437 

Why was this necessary?

## Changes

Are there any major changes in this PR that will change the release process?

## Checklist

- [ ] i18n enabled
- [ ] adequate test coverage
- [ ] accessible interface
