### PR TITLE
Adding in dry-transactions for creating updating and deleting a file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
 gem 'bootsnap', require: false
 gem 'coffee-rails', '~> 4.2'
 gem 'devise_remote'
+gem 'dry-transaction'
 gem 'execjs'
 gem 'faker', github: 'stympy/faker', branch: 'master'
 gem 'figaro'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,15 +205,29 @@ GEM
     dry-core (0.4.5)
       concurrent-ruby (~> 1.0)
     dry-equalizer (0.2.1)
+    dry-events (0.1.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 0.4)
+      dry-equalizer (~> 0.2)
     dry-logic (0.4.2)
       dry-container (~> 0.2, >= 0.2.6)
       dry-core (~> 0.2)
       dry-equalizer (~> 0.2)
+    dry-matcher (0.7.0)
+    dry-monads (1.0.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 0.4, >= 0.4.4)
+      dry-equalizer
     dry-struct (0.4.0)
       dry-core (~> 0.4, >= 0.4.1)
       dry-equalizer (~> 0.2)
       dry-types (~> 0.12, >= 0.12.2)
       ice_nine (~> 0.11)
+    dry-transaction (0.13.0)
+      dry-container (>= 0.2.8)
+      dry-events (>= 0.1.0)
+      dry-matcher (>= 0.7.0)
+      dry-monads (>= 0.4.0)
     dry-types (0.12.2)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.1)
@@ -610,6 +624,7 @@ DEPENDENCIES
   coveralls
   database_cleaner
   devise_remote
+  dry-transaction
   execjs
   factory_bot_rails
   faker!

--- a/app/cho/transaction/file/create.rb
+++ b/app/cho/transaction/file/create.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Transaction
+  module File
+    class Create
+      include Dry::Transaction(container: Operations::Container)
+
+      # Operations will be resolved from the `Container` specified above
+      step :validate, with: 'file.validate'
+      step :save, with: 'file.save'
+    end
+  end
+end

--- a/app/cho/transaction/file/delete.rb
+++ b/app/cho/transaction/file/delete.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Transaction
+  module File
+    class Delete
+      include Dry::Transaction(container: Operations::Container)
+
+      # Operations will be resolved from the `Container` specified above
+      step :delete, with: 'file.delete'
+    end
+  end
+end

--- a/app/cho/transaction/file/update.rb
+++ b/app/cho/transaction/file/update.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Transaction
+  module File
+    class Update
+      include Dry::Transaction(container: Operations::Container)
+
+      # Operations will be resolved from the `Container` specified above
+      step :validate, with: 'file.validate'
+      step :save, with: 'file.save'
+    end
+  end
+end

--- a/app/cho/transaction/operations/container.rb
+++ b/app/cho/transaction/operations/container.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Transaction
+  module Operations
+    class Container
+      extend Dry::Container::Mixin
+
+      namespace 'file' do
+        register 'save' do
+          Operations::File::Save.new
+        end
+        register 'validate' do
+          Operations::File::Validate.new
+        end
+        register 'delete' do
+          Operations::File::Delete.new
+        end
+      end
+    end
+  end
+end

--- a/app/cho/transaction/operations/container.rb
+++ b/app/cho/transaction/operations/container.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require 'dry/container'
+require 'dry/transaction'
+require 'dry/transaction/operation'
+
 module Transaction
   module Operations
     class Container

--- a/app/cho/transaction/operations/file/delete.rb
+++ b/app/cho/transaction/operations/file/delete.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Transaction
+  module Operations
+    module File
+      class Delete
+        include Dry::Transaction::Operation
+
+        def call(file)
+          Success(file)
+        rescue StandardError
+          Failure('error persisting file')
+        end
+      end
+    end
+  end
+end

--- a/app/cho/transaction/operations/file/delete.rb
+++ b/app/cho/transaction/operations/file/delete.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'dry/transaction/operation'
+
 module Transaction
   module Operations
     module File

--- a/app/cho/transaction/operations/file/save.rb
+++ b/app/cho/transaction/operations/file/save.rb
@@ -1,16 +1,45 @@
 # frozen_string_literal: true
 
+require 'dry/transaction/operation'
+
 module Transaction
   module Operations
     module File
       class Save
         include Dry::Transaction::Operation
 
-        def call(file)
-          Success(file)
-        rescue StandardError
-          Failure('error persisting file')
+        def call(change_set)
+          saved_work_file = metadata_adapter.persister.save(resource: work_file(change_set))
+          change_set.model.files << saved_work_file.id
+          Success(change_set)
+        rescue StandardError => e
+          Failure("Error persisting file: #{e.message}")
         end
+
+        private
+
+          def work_file(change_set)
+            Work::File.new(
+              file_identifier: adapter_file(change_set).id,
+              original_filename: change_set.file.original_filename
+            )
+          end
+
+          def adapter_file(change_set)
+            storage_adapter.upload(
+              file: change_set.file.tempfile,
+              original_filename: change_set.file.original_filename,
+              resource: change_set.model
+            )
+          end
+
+          def storage_adapter
+            @storage_adapter ||= Valkyrie.config.storage_adapter
+          end
+
+          def metadata_adapter
+            @metadata_adapter ||= Valkyrie::MetadataAdapter.find(:indexing_persister)
+          end
       end
     end
   end

--- a/app/cho/transaction/operations/file/save.rb
+++ b/app/cho/transaction/operations/file/save.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Transaction
+  module Operations
+    module File
+      class Save
+        include Dry::Transaction::Operation
+
+        def call(file)
+          Success(file)
+        rescue StandardError
+          Failure('error persisting file')
+        end
+      end
+    end
+  end
+end

--- a/app/cho/transaction/operations/file/validate.rb
+++ b/app/cho/transaction/operations/file/validate.rb
@@ -1,15 +1,23 @@
 # frozen_string_literal: true
 
+require 'dry/transaction/operation'
+
 module Transaction
   module Operations
     module File
       class Validate
-        include Dry::Transaction::Operation
+        include ::Dry::Transaction::Operation
 
-        def call(file)
-          Success(file)
-        rescue StandardError
-          Failure('error persisting file')
+        # @note We return a failure if the change set doesn't support files or doesn't contain
+        #  any files to save. It's unclear whether this is a correct usage for a transactions,
+        #  and if failures should be reserved only for exceptions. An alternative could be to
+        #  move the guard clause to File::Save, but it seems to make sense to have it here as
+        #  a validation.
+        def call(change_set)
+          return Failure(change_set) unless change_set.respond_to?(:file) && change_set.file.present?
+          Success(change_set)
+        rescue StandardError => e
+          Failure("Error validating file: #{e.message}")
         end
       end
     end

--- a/app/cho/transaction/operations/file/validate.rb
+++ b/app/cho/transaction/operations/file/validate.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Transaction
+  module Operations
+    module File
+      class Validate
+        include Dry::Transaction::Operation
+
+        def call(file)
+          Success(file)
+        rescue StandardError
+          Failure('error persisting file')
+        end
+      end
+    end
+  end
+end

--- a/config/data_dictionary/schema_fields.yml
+++ b/config/data_dictionary/schema_fields.yml
@@ -1,13 +1,21 @@
 development: &development
-  - schema: 'Generic'
-    fields: []
   - schema: 'Collection'
     fields: []
     work_type: 'false'
   - schema: 'FileSet'
     fields: []
     work_type: 'false'
+  - schema: 'Generic'
+    file:
+      create: Transaction::File::Create
+      update: Transaction::File::Update
+      delete: Transaction::File::Delete
+    fields: []
   - schema: 'Document'
+    file:
+      create: Transaction::File::Create
+      update: Transaction::File::Update
+      delete: Transaction::File::Delete
     fields:
       contributor:
         display_name: 'My contributor'
@@ -31,6 +39,10 @@ development: &development
       access_rights:
         order_index: 10
   - schema: 'Still Image'
+    file:
+      create: Transaction::File::Create
+      update: Transaction::File::Update
+      delete: Transaction::File::Delete
     fields:
       alternate_title:
         order_index: 1
@@ -47,6 +59,10 @@ development: &development
       access_rights:
         order_index: 7
   - schema: 'Map'
+    file:
+      create: Transaction::File::Create
+      update: Transaction::File::Update
+      delete: Transaction::File::Delete
     fields:
       alternate_title:
         order_index: 1
@@ -86,6 +102,10 @@ development: &development
       access_rights:
         order_index: 18
   - schema: 'Moving Image'
+    file:
+      create: Transaction::File::Create
+      update: Transaction::File::Update
+      delete: Transaction::File::Delete
     fields:
       alternate_title:
         order_index: 1
@@ -110,6 +130,10 @@ development: &development
       access_rights:
         order_index: 11
   - schema: 'Audio'
+    file:
+      create: Transaction::File::Create
+      update: Transaction::File::Update
+      delete: Transaction::File::Delete
     fields:
       alternate_title:
         order_index: 1

--- a/spec/cho/transaction/file/create_spec.rb
+++ b/spec/cho/transaction/file/create_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Transaction::File::Create do
+  let(:transaction) { described_class.new }
+
+  describe '::steps' do
+    subject { described_class.steps.map(&:name) }
+
+    it { is_expected.to contain_exactly(:validate, :save) }
+  end
+
+  it { is_expected.to respond_to(:call) }
+end

--- a/spec/cho/transaction/file/delete_spec.rb
+++ b/spec/cho/transaction/file/delete_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Transaction::File::Delete do
+  let(:transaction) { described_class.new }
+
+  describe '::steps' do
+    subject { described_class.steps.map(&:name) }
+
+    it { is_expected.to contain_exactly(:delete) }
+  end
+
+  it { is_expected.to respond_to(:call) }
+end

--- a/spec/cho/transaction/file/update_spec.rb
+++ b/spec/cho/transaction/file/update_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Transaction::File::Update do
+  let(:transaction) { described_class.new }
+
+  describe '::steps' do
+    subject { described_class.steps.map(&:name) }
+
+    it { is_expected.to contain_exactly(:validate, :save) }
+  end
+
+  it { is_expected.to respond_to(:call) }
+end

--- a/spec/cho/transaction/operations/file/delete_spec.rb
+++ b/spec/cho/transaction/operations/file/delete_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Transaction::Operations::File::Delete do
+  let(:operation) { described_class.new }
+
+  describe '#call' do
+    subject { operation.call('file') }
+
+    context 'with a successful delete' do
+      its(:success) { is_expected.to eq('file') }
+    end
+
+    context 'with a failed delete' do
+      before { allow(Dry::Monads::Result::Success).to receive(:new).and_raise(StandardError) }
+
+      its(:failure) { is_expected.to eq('error persisting file') }
+    end
+  end
+end

--- a/spec/cho/transaction/operations/file/save_spec.rb
+++ b/spec/cho/transaction/operations/file/save_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Transaction::Operations::File::Save do
+  let(:operation) { described_class.new }
+
+  describe '#call' do
+    context 'with a successful save' do
+      let!(:collection) { create(:collection) }
+      let(:resource) { build(:work, title: 'with a file', member_of_collection_ids: [collection.id]) }
+      let(:change_set) { Work::SubmissionChangeSet.new(resource) }
+      let(:temp_file) { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'fixtures', 'hello_world.txt')) }
+      let(:resource_params) { { label: 'abc123', file: temp_file } }
+
+      before { change_set.validate(resource_params) }
+
+      it 'returns Success' do
+        expect {
+          result = operation.call(change_set)
+          expect(result).to be_success
+          expect(result.success).to eq(change_set)
+        }.to change { Work::File.count }.by(1)
+      end
+    end
+
+    context 'with an unsuccessful save' do
+      let(:mock_adapter) { instance_double(IndexingAdapter) }
+
+      before do
+        allow(operation).to receive(:metadata_adapter).and_return(mock_adapter)
+        allow(mock_adapter).to receive(:persister).and_raise(StandardError, 'unsupported adapter')
+      end
+
+      it 'returns Failure' do
+        expect {
+          result = operation.call('change_set')
+          expect(result).to be_failure
+          expect(result.failure).to eq('Error persisting file: unsupported adapter')
+        }.to change { Work::File.count }.by(0)
+      end
+    end
+  end
+end

--- a/spec/cho/transaction/operations/file/validate_spec.rb
+++ b/spec/cho/transaction/operations/file/validate_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Transaction::Operations::File::Validate do
+  let(:operation) { described_class.new }
+
+  describe '#call' do
+    subject { operation.call(change_set) }
+
+    context 'when the change set supports files' do
+      let(:change_set) { instance_double(Work::SubmissionChangeSet) }
+
+      before { allow(change_set).to receive(:file).and_return(['file']) }
+
+      its(:success) { is_expected.to eq(change_set) }
+    end
+
+    context 'when the change set does not support files' do
+      let(:change_set) { Valkyrie::ChangeSet.new({}) }
+
+      its(:failure) { is_expected.to eq(change_set) }
+    end
+
+    context 'when there is an unknown error' do
+      let(:change_set) { instance_double(Work::SubmissionChangeSet) }
+
+      before { allow(change_set).to receive(:file).and_raise(StandardError, 'something went wrong') }
+
+      its(:failure) { is_expected.to eq('Error validating file: something went wrong') }
+    end
+  end
+end


### PR DESCRIPTION
## Description

@awead  @mtribone and I have been looking at how dry-transactions could fit into the system.

We included the gem and added classes (no implementation), and configuration for how it might work.  Let us know if this seems reasonable and we will try to hook it into the file creation process in the existing system.

The very basic idea is that you have Transactions in the system that you can choose from in your configuration for what you want to occur when a file is created, updated, and deleted.  Each transaction is a dry-transaction, which is a series of operations.  Operations cab be reused between Transactions and we could have different Transactions for different work types.

## Changes

Adds a basic set of dry-transactions operations for a file.

Are there any major changes in this PR that will change the release process?

## Checklist

- [ ] i18n enabled
- [ ] adequate test coverage
- [ ] accessible interface
