### PR TITLE
Allow core fields to be overridden

### DIFF
--- a/app/blacklight/catalog_controller.rb
+++ b/app/blacklight/catalog_controller.rb
@@ -43,7 +43,7 @@ class CatalogController < ApplicationController
     config.index.title_field = 'title_tesim'
     config.show.title_field = 'title_tesim'
 
-    DataDictionary::Field.all.each do |map_field|
+    DataDictionary::Field.all.sort_by(&:created_at).each do |map_field|
       catalog_field = "#{map_field.label.parameterize.underscore.to_sym}_tesim"
       catalog_label = map_field.label.titleize
       config.add_index_field catalog_field, label: catalog_label

--- a/app/cho/data_dictionary/field.rb
+++ b/app/cho/data_dictionary/field.rb
@@ -27,7 +27,7 @@ module DataDictionary
     end
 
     def self.core_fields
-      @core_fields ||= where(core_field: true)
+      @core_fields ||= where(core_field: true).sort_by(&:created_at)
     end
 
     # @note This defined how the field should be addressed when creating dynamic methods for access

--- a/app/cho/schema/work_type_configuration.rb
+++ b/app/cho/schema/work_type_configuration.rb
@@ -43,7 +43,12 @@ module Schema
           data_dictionary_field,
           attributes.merge(work_type: work_type)
         )
-        metadata_field.order_index = (attributes.fetch('order_index', '1').to_i + core_field_count)
+        metadata_field.order_index = if metadata_field.core_field
+                                       attributes.fetch('order_index',
+                                                        core_field_hash[metadata_field.label].order_index).to_i
+                                     else
+                                       (attributes.fetch('order_index', '1').to_i + core_field_count)
+                                     end
         find_or_save(metadata_field)
       end
     end
@@ -76,6 +81,14 @@ module Schema
 
       def core_fields
         @core_fields ||= schema_configuration.core_field_ids(work_type)
+      end
+
+      def core_field_hash
+        @core_field_hash ||= Hash[loaded_core_fields.map { |item| [item.label, item] }]
+      end
+
+      def loaded_core_fields
+        @loaded_core_fields ||= core_fields.map { |id| MetadataField.find(id) }
       end
   end
 end

--- a/config/data_dictionary/schema_fields.yml
+++ b/config/data_dictionary/schema_fields.yml
@@ -157,6 +157,9 @@ test:
         order_index: 1
   - schema: 'Audio'
     fields:
+      subtitle:
+        order_index: 25
+        display_name: 'Additional Info'
       audio_field:
         order_index: 1
   - schema: 'Collection'

--- a/spec/cho/schema/configuration_spec.rb
+++ b/spec/cho/schema/configuration_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe Schema::Configuration, type: :model do
         { 'schema' => 'Map', 'fields' => { 'map_field' => { 'order_index' => 1 } } },
         { 'schema' => 'Moving Image',
           'fields' => { 'moving_image_field' => { 'order_index' => 1 } } },
-        { 'schema' => 'Audio', 'fields' => { 'audio_field' => { 'order_index' => 1 } } },
+        { 'schema' => 'Audio', 'fields' => { 'subtitle' => { 'order_index' => 25, 'display_name' => 'Additional Info' },
+                                             'audio_field' => { 'order_index' => 1 } } },
         { 'schema' => 'Collection', 'fields' => [], 'work_type' => 'false' },
         { 'schema' => 'FileSet', 'fields' => [], 'work_type' => 'false' }
       ]

--- a/spec/cho/schema/work_type_configuration_spec.rb
+++ b/spec/cho/schema/work_type_configuration_spec.rb
@@ -20,6 +20,13 @@ RSpec.describe Schema::WorkTypeConfiguration, type: :model do
 
       it { is_expected.to be_nil }
     end
+
+    context 'a work type with overridden core fields' do
+      let(:work_type) { 'Audio' }
+
+      it { is_expected.to eq('audio_field' => { 'order_index' => 1 },
+                             'subtitle' => { 'order_index' => 25, 'display_name' => 'Additional Info' }) }
+    end
   end
 
   describe '#initialize_schema_fields' do
@@ -38,6 +45,21 @@ RSpec.describe Schema::WorkTypeConfiguration, type: :model do
       let(:work_type) { 'Foo' }
 
       it { is_expected.to eq([]) }
+    end
+
+    context 'a work type with overridden core fields' do
+      let(:work_type) { 'Audio' }
+
+      it 'creates a field based on the work type' do
+        expect(schema_fields.count).to eq(2)
+        expect(schema_fields.first.order_index).to eq(25)
+        expect(schema_fields.first.label).to eq('subtitle')
+        expect(schema_fields.first.work_type).to eq(work_type)
+        expect(schema_fields.first.display_name).to eq('Additional Info')
+        expect(schema_fields.last.order_index).to eq(4)
+        expect(schema_fields.last.label).to eq('audio_field')
+        expect(schema_fields.last.work_type).to eq(work_type)
+      end
     end
   end
 
@@ -76,6 +98,21 @@ RSpec.describe Schema::WorkTypeConfiguration, type: :model do
         expect(metadata_schema).to be_a(Schema::Metadata)
         expect(metadata_schema.label).to eq(work_type)
         expect(metadata_schema.fields.count).to eq(0)
+      end
+    end
+
+    context 'a work type with overridden core fields' do
+      let(:work_type) { 'Audio' }
+
+      it 'creates a field based on the work type' do
+        expect(metadata_schema).to be_a(Schema::Metadata)
+        expect(metadata_schema.label).to eq(work_type)
+        expect(metadata_schema.fields.count).to eq(2)
+        field = Schema::MetadataField.find(Valkyrie::ID.new(metadata_schema.fields.first.id))
+        expect(field.order_index).to eq(25)
+        expect(field.label).to eq('subtitle')
+        expect(field.display_name).to eq('Additional Info')
+        expect(field.work_type).to eq(work_type)
       end
     end
   end

--- a/spec/support/seed_map.rb
+++ b/spec/support/seed_map.rb
@@ -3,4 +3,4 @@
 # This loads the database so that the classes can be set up correctly
 #   Catalog Controller and Work::Submission dynamically build code based
 #   on this seeded data dictionary
-Rails.application.load_seed
+Rails.application.load_seed if ENV['RAILS_ENV'] == 'test'

--- a/spec/views/work_submissions/edit.html.erb_spec.rb
+++ b/spec/views/work_submissions/edit.html.erb_spec.rb
@@ -59,16 +59,17 @@ RSpec.describe 'work/submissions/edit', type: :view do
     let(:work_type) { Work::Type.where(label: 'Audio').first }
 
     it 'renders the edit form' do
-      assert_form('audio_field')
+      assert_form('audio_field', 'Audio Field', 'Additional Info')
     end
   end
 
-  def assert_form(specific_field, display_label = nil)
+  def assert_form(specific_field, display_label = nil, subtitle_label = nil)
     display_label ||= specific_field.titleize
+    subtitle_label ||= 'Subtitle'
     assert_select 'form[action=?][method=?]', work_path(@work.model), 'post' do
       assert_select 'label[for=?]', 'work_submission_title', text: "Object Title\n       required"
       assert_select 'input[name=?]', 'work_submission[title]'
-      assert_select 'label[for=?]', 'work_submission_subtitle', text: 'Subtitle'
+      assert_select 'label[for=?]', 'work_submission_subtitle', text: subtitle_label
       assert_select 'input[name=?]', 'work_submission[subtitle]'
       assert_select 'label[for=?]', 'work_submission_description', text: 'Description'
       assert_select 'textarea[name=?]', 'work_submission[description]'


### PR DESCRIPTION
## Description
add sort to catalog data dictionary display
add sort to core fields
make sure the order index does not get overriden

Fixes: #437

Why was this necessary?
Allows core field to be overridden without killing the order index.  Not this does not update the order on the show and index views, but does update the order on the edit and new forms.

## Changes

Are there any major changes in this PR that will change the release process? no

## Checklist

- [ ] i18n enabled
- [ ] adequate test coverage
- [ ] accessible interface
