### PR TITLE
Updating Sprockets to address CVE-2018-3760

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -535,7 +535,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)


### PR DESCRIPTION
## Description

Patches security vulnerability in the sprockets gem outlined in https://nvd.nist.gov/vuln/detail/CVE-2018-3760.

