### PR TITLE
Adding transactions for creating, validating, and creating change sets

### DIFF
--- a/app/cho/transaction/operations/container.rb
+++ b/app/cho/transaction/operations/container.rb
@@ -20,6 +20,18 @@ module Transaction
           Operations::File::Delete.new
         end
       end
+
+      namespace 'shared' do
+        register 'validate' do
+          Operations::Shared::Validate.new
+        end
+        register 'create_change_set' do
+          Operations::Shared::CreateChangeSet.new
+        end
+        register 'save' do
+          Operations::Shared::Save.new
+        end
+      end
     end
   end
 end

--- a/app/cho/transaction/operations/shared/create_change_set.rb
+++ b/app/cho/transaction/operations/shared/create_change_set.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Transaction
+  module Operations
+    module Shared
+      class CreateChangeSet
+        include Dry::Transaction::Operation
+
+        def call(resource)
+          change_set_class = change_set_class(resource)
+          Success(change_set_class.new(resource))
+        end
+
+        private
+
+          def change_set_class(resource)
+            Object.const_get("#{resource.class}ChangeSet")
+          rescue StandardError
+            Valkyrie::ChangeSet
+          end
+      end
+    end
+  end
+end

--- a/app/cho/transaction/operations/shared/save.rb
+++ b/app/cho/transaction/operations/shared/save.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Transaction
+  module Operations
+    module Shared
+      class Save
+        include Dry::Transaction::Operation
+
+        def call(change_set, persister:)
+          change_set.sync
+          Success(persister.save(resource: change_set))
+        rescue StandardError => error
+          change_set.errors.add(:save, error.message)
+          Failure(change_set)
+        end
+      end
+    end
+  end
+end

--- a/app/cho/transaction/operations/shared/validate.rb
+++ b/app/cho/transaction/operations/shared/validate.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Transaction
+  module Operations
+    module Shared
+      class Validate
+        include Dry::Transaction::Operation
+
+        def call(change_set, additional_attributes: {})
+          change_set.validate(additional_attributes)
+          if change_set.valid?
+            Success(change_set)
+          else
+            Failure(change_set)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/cho/transaction/shared/save_with_change_set.rb
+++ b/app/cho/transaction/shared/save_with_change_set.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Transaction
+  module Shared
+    class SaveWithChangeSet
+      include Dry::Transaction(container: Operations::Container)
+
+      # Operations will be resolved from the `Container` specified above
+      step :validate, with: 'shared.validate'
+      step :save_file, with: 'file.save'
+      step :save, with: 'shared.save'
+
+      def save_file(change_set)
+        result = Transaction::Operations::File::Validate.new.call(change_set)
+        return Success(change_set) if result.failure?
+
+        super(change_set)
+      end
+    end
+  end
+end

--- a/app/cho/transaction/shared/save_with_resource.rb
+++ b/app/cho/transaction/shared/save_with_resource.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Transaction
+  module Shared
+    class SaveWithResource
+      include Dry::Transaction(container: Operations::Container)
+
+      # Operations will be resolved from the `Container` specified above
+      step :create_change_set, with: 'shared.create_change_set'
+      step :validate, with: 'shared.validate'
+      step :save_file, with: 'file.save'
+      step :save, with: 'shared.save'
+
+      def save_file(change_set)
+        result = Transaction::Operations::File::Validate.new.call(change_set)
+        return Success(change_set) if result.failure?
+
+        super(change_set)
+      end
+    end
+  end
+end

--- a/spec/cho/transaction/operations/shared/create_changeset_spec.rb
+++ b/spec/cho/transaction/operations/shared/create_changeset_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Transaction::Operations::Shared::CreateChangeSet do
+  let(:operation) { described_class.new }
+
+  describe '#call' do
+    subject { operation.call(resource) }
+
+    context 'when the resource is a work' do
+      let(:resource) { Work::Submission.new }
+
+      its(:success) { is_expected.to be_a(Work::SubmissionChangeSet) }
+    end
+
+    context 'when the resource is a data dictionary field' do
+      let(:resource) { DataDictionary::Field.new }
+
+      its(:success) { is_expected.to be_a(DataDictionary::FieldChangeSet) }
+    end
+
+    context 'when the resource is a random object' do
+      let(:resource) { 'abc123' }
+
+      its(:success) { is_expected.to be_a(Valkyrie::ChangeSet) }
+    end
+  end
+end

--- a/spec/cho/transaction/operations/shared/save_spec.rb
+++ b/spec/cho/transaction/operations/shared/save_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Transaction::Operations::Shared::Save do
+  let(:collection) { create :collection }
+  let(:change_set) { Work::SubmissionChangeSet.new(resource) }
+  let(:operation) { described_class.new }
+
+  describe '#call' do
+    context 'when the resource is a work' do
+      subject(:operation_result) { operation.call(change_set, persister: adapter.persister).success }
+
+      let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
+
+      let(:resource) { build :work_submission, member_of_collection_ids: [collection.id], title: 'My Title' }
+
+      its(:class) { is_expected.to eq(Work::Submission) }
+      its(:id) { is_expected.not_to be_empty }
+      its(:title) { is_expected.to eq(['My Title']) }
+    end
+
+    context 'when save fails' do
+      subject(:operation_result) { operation.call(change_set, persister: adapter.persister) }
+
+      let(:adapter) { IndexingAdapter.new(metadata_adapter: nil, index_adapter: nil) }
+      let(:persister) { IndexingAdapter::Persister.new(metadata_adapter: nil) }
+      let(:resource) { build :work_submission, member_of_collection_ids: [collection.id], title: 'My Title' }
+
+      before do
+        allow(adapter).to receive(:persister).and_return(persister)
+        allow(persister).to receive(:save).and_raise(StandardError.new('bogus error'))
+      end
+
+      it 'fails gracefully' do
+        expect(operation_result).to be_failure
+        expect(operation_result.failure.class).to eq(Work::SubmissionChangeSet)
+        expect(operation_result.failure.errors.messages).to eq(save: ['bogus error'])
+      end
+    end
+  end
+end

--- a/spec/cho/transaction/operations/shared/validate_spec.rb
+++ b/spec/cho/transaction/operations/shared/validate_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Transaction::Operations::Shared::Validate do
+  let(:operation) { described_class.new }
+  let(:collection) { create :collection }
+
+  describe '#call' do
+    subject(:operation_result) { operation.call(Work::SubmissionChangeSet.new(resource)) }
+
+    context 'when the resource is a work' do
+      let(:resource) { build :work_submission, member_of_collection_ids: [collection.id] }
+
+      its(:success) { is_expected.to be_a(Work::SubmissionChangeSet) }
+    end
+
+    context 'when the resource is invalid' do
+      let(:resource) { Work::Submission.new({}) }
+
+      it 'returns errors' do
+        expect(operation_result.failure.errors.messages).to eq(work_type_id: ["can't be blank"],
+                                                               member_of_collection_ids: ["can't be blank"],
+                                                               title: ["can't be blank"])
+      end
+    end
+  end
+end

--- a/spec/valkyrie/change_set_persister_spec.rb
+++ b/spec/valkyrie/change_set_persister_spec.rb
@@ -102,6 +102,11 @@ RSpec.describe ChangeSetPersister do
         expect(saved_change_set.label).to eq('abc123')
       }.to change { metadata_adapter.query_service.find_all.count }.by(1)
     end
+
+    it 'reports the error in the parameters' do
+      output = change_set_persister.validate_and_save_with_buffer(change_set: change_set, resource_params: {})
+      expect(output.errors.messages).to eq(label: ['can\'t be blank'])
+    end
   end
 
   describe '#delete' do
@@ -223,11 +228,6 @@ RSpec.describe ChangeSetPersister do
           resource_params: { label: 'abc123' }
         )
         expect(output.errors.messages).to eq(save: ['save was not successful'])
-      end
-
-      it 'reports the error in the parameters' do
-        output = change_set_persister.validate_and_save_with_buffer(change_set: change_set, resource_params: {})
-        expect(output.errors.messages).to eq(label: ['can\'t be blank'])
       end
     end
 


### PR DESCRIPTION
## Description

These transactions can be used for any object

Modified change_set_persister to utilize the new transactions

Why was this necessary?  Utilizing the new pattern

## Changes

1. Created new shared operations: CreateChangeSet, Validate, and Save
1.  Created a Save transaction for any object
1. Updated ChangeSetPersister to use the new Transaction

Are there any major changes in this PR that will change the release process? no

## Checklist

- [ ] i18n enabled
- [ ] adequate test coverage
- [ ] accessible interface
