### PR TITLE
Implement file sets with GUI upload

### DIFF
--- a/app/blacklight/solr_document.rb
+++ b/app/blacklight/solr_document.rb
@@ -30,10 +30,10 @@ class SolrDocument
     Array.wrap(self['internal_resource_tsim']).first
   end
 
-  # @return [Array<Work::File>]
-  def files
-    Array.wrap(self['files_ssim']).map do |id|
-      Work::File.find(Valkyrie::ID.new(id.sub(/^id-/, '')))
+  # @return [Array<Work::FileSet>]
+  def file_sets
+    Array.wrap(self['file_set_ids_ssim']).map do |id|
+      Work::FileSet.find(Valkyrie::ID.new(id.sub(/^id-/, '')))
     end
   end
 

--- a/app/cho/transaction/operations/file/save.rb
+++ b/app/cho/transaction/operations/file/save.rb
@@ -9,14 +9,19 @@ module Transaction
         include Dry::Transaction::Operation
 
         def call(change_set)
-          saved_work_file = metadata_adapter.persister.save(resource: work_file(change_set))
-          change_set.model.files << saved_work_file.id
+          saved_work_file_set = metadata_adapter.persister.save(resource: work_file_set(change_set))
+          change_set.model.file_set_ids << saved_work_file_set.id
           Success(change_set)
         rescue StandardError => e
           Failure("Error persisting file: #{e.message}")
         end
 
         private
+
+          def work_file_set(change_set)
+            file = metadata_adapter.persister.save(resource: work_file(change_set))
+            Work::FileSet.new(member_ids: [file.id], title: change_set.file.original_filename)
+          end
 
           def work_file(change_set)
             Work::File.new(

--- a/app/cho/work/submission.rb
+++ b/app/cho/work/submission.rb
@@ -14,9 +14,9 @@ module Work
 
     attribute :member_of_collection_ids, Valkyrie::Types::Set.of(Valkyrie::Types::ID)
 
-    # A list of Work::Files.
-    #  The stored valkyrie resource for files attached to a submission
-    attribute :files, Valkyrie::Types::Set
+    # A list of Work::FileSet resources.
+    #  The stored valkyrie ids for file sets attached to the submission
+    attribute :file_set_ids, Valkyrie::Types::Set.of(Valkyrie::Types::ID)
 
     # Accessors needed for shrine to send the temporary uploaded file
     #  to the controller

--- a/app/cho/work/submission_change_set.rb
+++ b/app/cho/work/submission_change_set.rb
@@ -5,13 +5,22 @@ module Work
     validates :work_type_id, presence: true
     validates :work_type_id, with: :validate_work_type_id!
     property :work_type_id, multiple: false, required: true, type: Valkyrie::Types::ID
-    property :file, multiple: false, required: false
+
     validates :member_of_collection_ids, with: :validate_members!
     validates :member_of_collection_ids, presence: true
     property :member_of_collection_ids,
              multiple: true,
              required: false,
              type: Types::Strict::Array.of(Valkyrie::Types::ID)
+
+    validates :file_set_ids, with: :validate_members!
+    property :file_set_ids,
+             multiple: true,
+             required: false,
+             type: Types::Strict::Array.of(Valkyrie::Types::ID)
+
+    # File submitted via the GUI upload
+    property :file, multiple: false, required: false
 
     include DataDictionary::FieldsForChangeSet
     include WithValidMembers

--- a/app/valkyrie/change_set_persister.rb
+++ b/app/valkyrie/change_set_persister.rb
@@ -90,9 +90,16 @@ class ChangeSetPersister
   private
 
     def before_delete(change_set:)
-      return unless change_set.resource.try(:files)
-      change_set.resource.files.each do |file_id|
+      return unless change_set.resource.try(:file_set_ids)
+      change_set.resource.file_set_ids.each do |file_set_id|
+        delete_file_set(resource: Work::FileSet.find(file_set_id))
+      end
+    end
+
+    def delete_file_set(resource:)
+      resource.member_ids.each do |file_id|
         delete_file(resource: Work::File.find(file_id))
+        persister.delete(resource: resource)
       end
     end
 

--- a/app/views/catalog/_file_sets.html.erb
+++ b/app/views/catalog/_file_sets.html.erb
@@ -1,7 +1,7 @@
 <h2><%= t('cho.work.show.files_heading') %></h2>
 
 <ul>
-  <%- files.each do |file| %>
-    <li><%= file.original_filename %></li>
+  <%- file_sets.each do |file_set| %>
+    <li><%= file_set.title %></li>
   <%- end %>
 </ul>

--- a/app/views/catalog/_show_work_submission.html.erb
+++ b/app/views/catalog/_show_work_submission.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: 'show', locals: { document: @document } %>
 
-<% unless @document.files.empty? %>
-  <%= render partial: 'files', locals: { files: @document.files } %>
+<% unless @document.file_sets.empty? %>
+  <%= render partial: 'file_sets', locals: { file_sets: @document.file_sets } %>
 <% end %>

--- a/spec/blacklight/solr_document_spec.rb
+++ b/spec/blacklight/solr_document_spec.rb
@@ -19,15 +19,15 @@ RSpec.describe SolrDocument, type: :model do
     its(:internal_resource) { is_expected.to be(MyResource) }
   end
 
-  describe '#files' do
-    subject { solr_document.files.first }
+  describe '#file_sets' do
+    subject { solr_document.file_sets.first }
 
-    let(:work_file) { create :work_file }
-    let(:document) { { 'internal_resource_tsim' => 'MyResource', files_ssim: [work_file.id.to_s] } }
+    let(:file_set) { create :file_set }
+    let(:document) { { 'internal_resource_tsim' => 'MyResource', file_set_ids_ssim: [file_set.id.to_s] } }
 
-    its(:to_h) { is_expected.to include(original_filename: 'original_name',
-                                        internal_resource: 'Work::File',
-                                        id: Valkyrie::ID.new(work_file.id)) }
+    its(:to_h) { is_expected.to include(title: ['Original File Name'],
+                                        internal_resource: 'Work::FileSet',
+                                        id: Valkyrie::ID.new(file_set.id)) }
   end
 
   describe '#member_of_collections' do

--- a/spec/cho/metrics/work_spec.rb
+++ b/spec/cho/metrics/work_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Metrics::Work do
   let(:metric)    { described_class.new(length: 1, output: report) }
   let(:report)    { StringIO.new }
   let(:work)      { ::Work::Submission.all.first }
-  let(:file_uri)  { URI(Work::File.find(work.files.first).file_identifier.to_s) }
+  let(:file_set)  { Work::FileSet.find(work.file_set_ids.first) }
+  let(:file_uri)  { URI(Work::File.find(file_set.member_ids.first).file_identifier.to_s) }
 
   describe '#file_size' do
     subject { metric }

--- a/spec/cho/transaction/operations/file/save_spec.rb
+++ b/spec/cho/transaction/operations/file/save_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe Transaction::Operations::File::Save do
           result = operation.call(change_set)
           expect(result).to be_success
           expect(result.success).to eq(change_set)
-        }.to change { Work::File.count }.by(1)
+          expect(result.success.file_set_ids.count).to eq(1)
+        }.to change { Work::File.count }.by(1).and change { Work::FileSet.count }.by(1)
       end
     end
 

--- a/spec/cho/work/submissions/change_set_spec.rb
+++ b/spec/cho/work/submissions/change_set_spec.rb
@@ -26,6 +26,10 @@ RSpec.describe Work::SubmissionChangeSet do
     it 'has multiple parents' do
       expect(change_set).to be_multiple(:member_of_collection_ids)
     end
+
+    it 'has multiple file sets' do
+      expect(change_set).to be_multiple(:file_set_ids)
+    end
   end
 
   describe '#required?' do
@@ -45,6 +49,7 @@ RSpec.describe Work::SubmissionChangeSet do
     its(:work_type) { is_expected.to be_nil }
     its(:file) { is_expected.to be_nil }
     its(:member_of_collection_ids) { is_expected.to be_empty }
+    its(:file_set_ids) { is_expected.to be_empty }
   end
 
   describe '#validate' do
@@ -95,6 +100,14 @@ RSpec.describe Work::SubmissionChangeSet do
 
     it 'casts ids to Valkyrie IDs' do
       expect(change_set.member_of_collection_ids.first).to be_kind_of(Valkyrie::ID)
+    end
+  end
+
+  describe '#file_set_ids' do
+    before { change_set.validate(file_set_ids: ['1']) }
+
+    it 'casts ids to Valkyrie IDs' do
+      expect(change_set.file_set_ids.first).to be_kind_of(Valkyrie::ID)
     end
   end
 

--- a/spec/cho/work/submissions/submission_spec.rb
+++ b/spec/cho/work/submissions/submission_spec.rb
@@ -72,4 +72,24 @@ RSpec.describe Work::Submission do
       its(:i18n_key) { is_expected.to eq('work') }
     end
   end
+
+  describe '#file_set_ids' do
+    it 'is empty when not set' do
+      expect(resource_klass.new.file_set_ids).to be_empty
+    end
+
+    it 'can be set as an attribute' do
+      resource = resource_klass.new(file_set_ids: ['1', '2'])
+      expect(resource.attributes[:file_set_ids].map(&:id)).to contain_exactly('1', '2')
+      expect(resource.attributes[:file_set_ids].first.class).to eq(Valkyrie::ID)
+    end
+
+    it 'is included in the list of attributes' do
+      expect(resource_klass.new.has_attribute?(:file_set_ids)).to eq true
+    end
+
+    it 'is included in the list of fields' do
+      expect(resource_klass.fields).to include(:file_set_ids)
+    end
+  end
 end

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Explictly require the seed map so that we create the title field BEFORE the
+#   work object gets autoloaded.  This supports the title field being defined on the object
+require Rails.root.join('spec', 'support', 'seed_map')
+
+FactoryBot.define do
+  factory :file_set, class: Work::FileSet do
+    title 'Original File Name'
+
+    to_create do |resource|
+      Valkyrie.config.metadata_adapter.persister.save(resource: resource)
+    end
+  end
+end


### PR DESCRIPTION
## Description

Takes the existing single-file upload process done in the GUI and adds
the file set resource as the intermediary between the work and file.

## Changes

Are there any major changes in this PR that will change the release process? No

Single files that are uploaded via the GUI are now stored in a file set that is attached to the work resource.

## Checklist

- [x] i18n enabled
- [x] adequate test coverage
- [x] accessible interface
