### PR TITLE
Comments out the autocomplete feature

### DIFF
--- a/app/blacklight/catalog_controller.rb
+++ b/app/blacklight/catalog_controller.rb
@@ -167,10 +167,10 @@ class CatalogController < ApplicationController
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.
-    config.spell_max = 5
+    # config.spell_max = 5
 
     # Configuration for autocomplete suggestor
-    config.autocomplete_enabled = true
-    config.autocomplete_path = 'suggest'
+    # config.autocomplete_enabled = true
+    # config.autocomplete_path = 'suggest'
   end
 end


### PR DESCRIPTION
## Description

Fixes: #536 

Why was this necessary?

The autocomplete has a few accessibility issues and it also stores each state of the autocomplete in the search history, so we are "removing" the autocomplete by commenting it out in the catalog controller.

## Changes

Are there any major changes in this PR that will change the release process? Nope

## Checklist

- [ ] i18n enabled
- [ ] adequate test coverage
- [X] accessible interface
