### PR TITLE
Don't require operations for each class

### DIFF
--- a/app/cho/transaction/operations/file/characterize.rb
+++ b/app/cho/transaction/operations/file/characterize.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'dry/transaction/operation'
-
 module Transaction
   module Operations
     module File

--- a/app/cho/transaction/operations/file/delete.rb
+++ b/app/cho/transaction/operations/file/delete.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'dry/transaction/operation'
-
 module Transaction
   module Operations
     module File

--- a/app/cho/transaction/operations/file/save.rb
+++ b/app/cho/transaction/operations/file/save.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'dry/transaction/operation'
-
 module Transaction
   module Operations
     module File

--- a/app/cho/transaction/operations/file/validate.rb
+++ b/app/cho/transaction/operations/file/validate.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
-require 'dry/transaction/operation'
-
 module Transaction
   module Operations
     module File
       class Validate
-        include ::Dry::Transaction::Operation
+        include Dry::Transaction::Operation
 
         # @note We return a failure if the change set doesn't support files or doesn't contain
         #  any files to save. It's unclear whether this is a correct usage for a transactions,


### PR DESCRIPTION
Multiple calls to `require 'dry/transaction/operation'` are unnecessary.