### PR TITLE
File Selection Button Alignment

### DIFF
--- a/app/views/work/submissions/_form.html.erb
+++ b/app/views/work/submissions/_form.html.erb
@@ -17,12 +17,12 @@
 
   <%= form.hidden_field :file, value: work_form.model.cached_file_data %>
 
-  <%= form.label :file, class: 'sr-only' %>
+  <%= form.label :file, t('cho.form.file_selection') %>
   <%= form.file_field :file %>
 
   <%= render 'errors', work: work_form if work_form.errors.any? %>
 
-  <div class="actions">
+  <div class="actions pt-4">
     <%= form.submit work_form.submit_text %>
   </div>
 <% end %>

--- a/config/locales/cho.yml
+++ b/config/locales/cho.yml
@@ -4,6 +4,7 @@ en:
       metadata: "Basic Metadata"
       workflow: "Workflow"
       visibility: "Visibility"
+      file_selection: "File Selection"
     field_label:
       # For fields that are not in the data dictionary
       collection_type: "Collection Type"

--- a/spec/views/work_submissions/edit.html.erb_spec.rb
+++ b/spec/views/work_submissions/edit.html.erb_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe 'work/submissions/edit', type: :view do
       assert_select 'textarea[name=?]', 'work_submission[description]'
       assert_select 'label[for=?]', "work_submission_#{specific_field}", text: display_label
       assert_select 'input[name=?]', "work_submission[#{specific_field}]"
+      assert_select 'label', 'File Selection'
     end
   end
 end

--- a/spec/views/work_submissions/new.html.erb_spec.rb
+++ b/spec/views/work_submissions/new.html.erb_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'work/submissions/new', type: :view do
     assert_select 'form[action=?][method=?]', works_path, 'post' do
       assert_select 'input[name=?]', 'work_submission[title]'
       assert_select 'input[name=?]', 'work_submission[member_of_collection_ids][]'
+      assert_select 'label', 'File Selection'
     end
   end
 end


### PR DESCRIPTION
Removes the screen reader only class and exposes the i18n label to have the file selection elements below the collection datalist.

## Description

Fixes: #590 

Why was this necessary?

Alignment of the file selection form elements was too close to the collection member datalist and cuased user confusion.

## Changes

Are there any major changes in this PR that will change the release process? No

## Checklist

- [x] i18n enabled
- [x] adequate test coverage
- [x] accessible interface
