### PR TITLE
Guard against bags that don't exist

### DIFF
--- a/app/cho/import/bag.rb
+++ b/app/cho/import/bag.rb
@@ -12,6 +12,7 @@ class Import::Bag
 
   # @param [Pathname] path to the bag
   def initialize(path)
+    raise IOError, 'path to bag does not exist or is not readable' unless path.readable?
     @path = path
     @bag = BagIt::Bag.new(path)
     @batch_id, @date = bag.bag_dir.basename.to_s.split(FILENAME_SEPARATOR)

--- a/spec/cho/import/bag_spec.rb
+++ b/spec/cho/import/bag_spec.rb
@@ -105,4 +105,12 @@ RSpec.describe Import::Bag do
         .to include(works: ['File badID_01_preservation.tif does not match the parent directory'])
     end
   end
+
+  describe 'a bag with a non-existent path' do
+    let(:path) { Rails.root.join('spec', 'fixtures', 'bags', 'non-existent-bag') }
+
+    it 'raises an error' do
+      expect { described_class.new(path) }.to raise_error(IOError, 'path to bag does not exist or is not readable')
+    end
+  end
 end


### PR DESCRIPTION
## Description

Raise an error when attempting to validate a bag that doesn't exist,
otherwise, the default behavior of the BagIt gem is to create an empty
bag using that path.

Connects #549 


