### PR TITLE
Add path and identifier to import work

### DIFF
--- a/app/cho/import/work.rb
+++ b/app/cho/import/work.rb
@@ -5,10 +5,11 @@ class Import::Work
 
   validate :must_have_valid_files, :must_have_valid_file_sets
 
-  attr_reader :files, :nested_works
+  attr_reader :files, :nested_works, :path
 
   # @param [Pathname]
   def initialize(path)
+    @path = path
     @files = path.children.select(&:file?).map { |file| Import::File.new(file) }
     @nested_works = path.children.select(&:directory?).map { |directory| self.class.new(directory) }
   end
@@ -18,6 +19,10 @@ class Import::Work
     file_set_ids.map do |id|
       Import::FileSet.new(files.select { |file| file.file_set_id == id })
     end
+  end
+
+  def identifier
+    path.basename.to_s
   end
 
   private

--- a/spec/cho/import/work_spec.rb
+++ b/spec/cho/import/work_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe Import::Work do
       expect(work.nested_works.count).to eq(0)
       expect(work.file_sets.count).to eq(1)
       expect(work.file_sets.first).to be_representative
+      expect(work.path).to eq(Rails.root.join('tmp', 'workID'))
+      expect(work.identifier).to eq('workID')
     end
   end
 


### PR DESCRIPTION
## Description

Connects to #549 

Allows one to access the path to a work within a bag, and refer to its identifier, which is the name of its directory.

Why was the necessary?

In order to import works in a bag, we'll need to know where on the file system the work is, and if the work's identifier matches the one in the CSV file.

