### PR TITLE
Persist batch id on the work

### DIFF
--- a/app/cho/work/submission.rb
+++ b/app/cho/work/submission.rb
@@ -18,6 +18,8 @@ module Work
     #  The stored valkyrie ids for file sets attached to the submission
     attribute :file_set_ids, Valkyrie::Types::Set.of(Valkyrie::Types::ID)
 
+    attribute :batch_id, Valkyrie::Types::String.optional
+
     # Accessors needed for shrine to send the temporary uploaded file
     #  to the controller
     # For the moment we are uploading a single file.

--- a/app/cho/work/submission_change_set.rb
+++ b/app/cho/work/submission_change_set.rb
@@ -19,6 +19,8 @@ module Work
              required: false,
              type: Types::Strict::Array.of(Valkyrie::Types::ID)
 
+    property :batch_id, multiple: false, required: false
+
     # File submitted via the GUI upload
     property :file, multiple: false, required: false
 

--- a/spec/cho/work/submissions/change_set_spec.rb
+++ b/spec/cho/work/submissions/change_set_spec.rb
@@ -30,6 +30,10 @@ RSpec.describe Work::SubmissionChangeSet do
     it 'has multiple file sets' do
       expect(change_set).to be_multiple(:file_set_ids)
     end
+
+    it 'has a single batch id' do
+      expect(change_set).not_to be_multiple(:batch_id)
+    end
   end
 
   describe '#required?' do
@@ -50,6 +54,7 @@ RSpec.describe Work::SubmissionChangeSet do
     its(:file) { is_expected.to be_nil }
     its(:member_of_collection_ids) { is_expected.to be_empty }
     its(:file_set_ids) { is_expected.to be_empty }
+    its(:batch_id) { is_expected.to be_nil }
   end
 
   describe '#validate' do

--- a/spec/cho/work/submissions/submission_spec.rb
+++ b/spec/cho/work/submissions/submission_spec.rb
@@ -92,4 +92,23 @@ RSpec.describe Work::Submission do
       expect(resource_klass.fields).to include(:file_set_ids)
     end
   end
+
+  describe '#batch_id' do
+    it 'is nil when not set' do
+      expect(resource_klass.new.batch_id).to be_nil
+    end
+
+    it 'can be set as an attribute' do
+      resource = resource_klass.new(batch_id: Valkyrie::ID.new('123'))
+      expect(resource.attributes[:batch_id].to_s).to eq('123')
+    end
+
+    it 'is included in the list of attributes' do
+      expect(resource_klass.new.has_attribute?(:batch_id)).to eq true
+    end
+
+    it 'is included in the list of fields' do
+      expect(resource_klass.fields).to include(:batch_id)
+    end
+  end
 end


### PR DESCRIPTION
## Description

Fixes #597

Why was this necessary?

Allows us to track which batch, and therefore which zip file, created a work.
