### PR TITLE
Adding bag and import work to CsvDryRun

### DIFF
--- a/app/cho/work/submission_change_set.rb
+++ b/app/cho/work/submission_change_set.rb
@@ -27,6 +27,8 @@ module Work
     include DataDictionary::FieldsForChangeSet
     include WithValidMembers
 
+    attr_accessor :import_work
+
     delegate :url_helpers, to: 'Rails.application.routes'
 
     def initialize(*args)

--- a/config/data_dictionary/data_dictionary_test.csv
+++ b/config/data_dictionary/data_dictionary_test.csv
@@ -9,3 +9,4 @@ still_image_field,string,optional,no_validation,true,no_vocabulary,,,no_transfor
 moving_image_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false
 map_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false
 audio_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false
+identifier,string,required_to_publish,no_validation,true,no_vocabulary,,Identifier,no_transformation,no_facet,help me,true

--- a/spec/blacklight/solr_document_spec.rb
+++ b/spec/blacklight/solr_document_spec.rb
@@ -73,17 +73,17 @@ RSpec.describe SolrDocument, type: :model do
       }
     end
 
-    it { is_expected.to eq("abc123,,my_title,,,,,,value1|value2,,,\n") }
+    it { is_expected.to eq("abc123,,my_title,,,,,,,value1|value2,,,\n") }
 
     context 'a collection' do
       let(:collection) { create :library_collection }
       let(:work) { create :work, member_of_collection_ids: [collection.id], title: 'Work One' }
-      let(:work1_csv) { "#{work.id},#{collection.id},Work One,,,,,,,,," }
+      let(:work1_csv) { "#{work.id},#{collection.id},Work One,,,,,,,,,," }
       let(:work2) { create :work, member_of_collection_ids: [collection.id], title: 'Work Two' }
-      let(:work2_csv) { "#{work2.id},#{collection.id},Work Two,,,,,,,,," }
+      let(:work2_csv) { "#{work2.id},#{collection.id},Work Two,,,,,,,,,," }
 
       let(:csv_header) do
-        'id,member_of_collection_ids,title,subtitle,description,audio_field,'\
+        'id,member_of_collection_ids,title,subtitle,description,identifier,audio_field,'\
         'created,document_field,generic_field,map_field,moving_image_field,still_image_field'
       end
 

--- a/spec/cho/collection/change_set_behaviors_spec.rb
+++ b/spec/cho/collection/change_set_behaviors_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Collection::ChangeSetBehaviors do
 
   describe '#form_fields' do
     it 'contains all the fields from the collection schema' do
-      expect(change_set.form_fields.map(&:label)).to contain_exactly('subtitle', 'description', 'title')
+      expect(change_set.form_fields.map(&:label)).to contain_exactly('subtitle', 'description', 'title', 'identifier')
     end
   end
 
@@ -86,7 +86,9 @@ RSpec.describe Collection::ChangeSetBehaviors do
     let(:form) { double }
 
     it 'contains an array of Schema::InputFields' do
-      expect(change_set.input_fields(form).map(&:label_text)).to contain_exactly('subtitle', 'description', 'title')
+      expect(change_set.input_fields(form).map(&:label_text)).to contain_exactly(
+        'subtitle', 'description', 'title', 'identifier'
+      )
     end
   end
 end

--- a/spec/cho/data_dictionary/field_spec.rb
+++ b/spec/cho/data_dictionary/field_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe DataDictionary::Field, type: :model do
   describe '#core' do
     subject { described_class.core_fields.to_a.map(&:label) }
 
-    it { is_expected.to eq(['title', 'subtitle', 'description']) }
+    it { is_expected.to eq(['title', 'subtitle', 'description', 'identifier']) }
   end
 
   describe '#multiple' do

--- a/spec/cho/schema/configuration_spec.rb
+++ b/spec/cho/schema/configuration_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe Schema::Configuration, type: :model do
   describe '#core_field_ids' do
     it 'does not create more fields since the defaults were loaded' do
       expect {
-        expect(schema_configuration.core_field_ids('Generic').count).to eq(3)
-        expect(schema_configuration.core_field_count('Generic')).to eq(3)
+        expect(schema_configuration.core_field_ids('Generic').count).to eq(4)
+        expect(schema_configuration.core_field_count('Generic')).to eq(4)
       }.to change { Valkyrie.config.metadata_adapter.query_service.find_all.count }.by(0)
     end
   end
@@ -92,10 +92,10 @@ RSpec.describe Schema::Configuration, type: :model do
       it 'adds a Schema::MetadataField, a Work::Type, and a Schema::Metadata' do
         expect {
           schema_configuration.load_work_types
-        }.to change { Schema::MetadataField.all.count }.by(4) # 3 core fields + 1 other field
+        }.to change { Schema::MetadataField.all.count }.by(5) # 4 core fields + 1 other field
           .and change { Work::Type.all.count }.by(1)
           .and change { Schema::Metadata.all.count }.by(1)
-          .and change { Valkyrie.config.metadata_adapter.query_service.find_all.count }.by(6)
+          .and change { Valkyrie.config.metadata_adapter.query_service.find_all.count }.by(7)
         expect(title_field.display_name).to eq('my title')
       end
     end

--- a/spec/cho/schema/metadata_core_fields_spec.rb
+++ b/spec/cho/schema/metadata_core_fields_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe Schema::MetadataCoreFields, type: :model do
   let(:title_field) { Schema::MetadataField.where(label: 'title').first }
 
   it 'generates the core fields' do
-    expect(core_fields.map(&:label)).to eq(['title', 'subtitle', 'description'])
-    expect(core_fields.map(&:order_index)).to eq([0, 1, 2])
+    expect(core_fields.map(&:label)).to eq(['title', 'subtitle', 'description', 'identifier'])
+    expect(core_fields.map(&:order_index)).to eq([0, 1, 2, 3])
   end
 
   it 'saves the core fields' do
     saved_core_fields = core_fields.map { |field| Schema::MetadataField.find(field.id) }
-    expect(saved_core_fields.map(&:order_index)).to eq([0, 1, 2])
+    expect(saved_core_fields.map(&:order_index)).to eq([0, 1, 2, 3])
   end
 
   context 'multiple work types' do
@@ -22,7 +22,7 @@ RSpec.describe Schema::MetadataCoreFields, type: :model do
 
     it 'saves different core fields based on type' do
       core_field_ids = generic_core_fields.map(&:id) + document_core_fields.map(&:id)
-      expect(core_field_ids.uniq.count).to eq(6)
+      expect(core_field_ids.uniq.count).to eq(8)
     end
   end
 end

--- a/spec/cho/schema/work_type_configuration_spec.rb
+++ b/spec/cho/schema/work_type_configuration_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Schema::WorkTypeConfiguration, type: :model do
 
     it 'creates a field based on the work type' do
       expect(schema_fields.count).to eq(1)
-      expect(schema_fields.first.order_index).to eq(4)
+      expect(schema_fields.first.order_index).to eq(5)
       expect(schema_fields.first.label).to eq('generic_field')
       expect(schema_fields.first.work_type).to eq(work_type)
     end
@@ -56,7 +56,7 @@ RSpec.describe Schema::WorkTypeConfiguration, type: :model do
         expect(schema_fields.first.label).to eq('subtitle')
         expect(schema_fields.first.work_type).to eq(work_type)
         expect(schema_fields.first.display_name).to eq('Additional Info')
-        expect(schema_fields.last.order_index).to eq(4)
+        expect(schema_fields.last.order_index).to eq(5)
         expect(schema_fields.last.label).to eq('audio_field')
         expect(schema_fields.last.work_type).to eq(work_type)
       end

--- a/spec/cho/work/submissions/change_set_spec.rb
+++ b/spec/cho/work/submissions/change_set_spec.rb
@@ -153,10 +153,10 @@ RSpec.describe Work::SubmissionChangeSet do
 
       let(:work_field) { Schema::MetadataField.find_using(label: 'generic_field').first }
 
-      its(:count) { is_expected.to eq(4) }
+      its(:count) { is_expected.to eq(5) }
 
       it 'is ordered' do
-        expect(fields.map(&:label)).to eq(['title', 'subtitle', 'description', 'generic_field'])
+        expect(fields.map(&:label)).to eq(['title', 'subtitle', 'description', 'identifier', 'generic_field'])
       end
 
       context 'fields are reordered' do
@@ -166,7 +166,7 @@ RSpec.describe Work::SubmissionChangeSet do
         end
 
         it 'is ordered' do
-          expect(fields.map(&:label)).to eq(['generic_field', 'title', 'subtitle', 'description'])
+          expect(fields.map(&:label)).to eq(['generic_field', 'title', 'subtitle', 'description', 'identifier'])
         end
       end
     end
@@ -178,6 +178,7 @@ RSpec.describe Work::SubmissionChangeSet do
         expect(change_set.input_fields(form).map(&:label_text)).to contain_exactly('subtitle',
                                                                                    'description',
                                                                                    'generic_field',
+                                                                                   'identifier',
                                                                                    'title')
       end
     end

--- a/spec/support/import_factory/zip.rb
+++ b/spec/support/import_factory/zip.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# A factory for generating zip files of bags
+module ImportFactory
+  class Zip
+    # @param [ImportFactory::Bag]
+    def self.create(bag)
+      output_file = Rails.root.join('tmp', 'ingest-test', "#{bag.path.basename}.zip")
+      new(bag.path, output_file).write
+    end
+
+    attr_reader :input_dir, :output_file
+
+    # @param [Pathname] input_dir
+    # @param [Pathname] output_file
+    def initialize(input_dir, output_file)
+      @input_dir = input_dir
+      @output_file = output_file
+    end
+
+    def write
+      ::Zip::File.open(output_file, ::Zip::File::CREATE) do |zipfile|
+        zipfile.mkdir(input_dir.basename)
+        write_entries(input_dir.children, zipfile)
+      end
+    end
+
+    private
+
+      def write_entries(entries, zipfile)
+        entries.each do |entry|
+          if entry.directory?
+            recursively_deflate_directory(entry, zipfile)
+          else
+            zipfile.add(entry.relative_path_from(input_dir.dirname), entry)
+          end
+        end
+      end
+
+      def recursively_deflate_directory(directory, zipfile)
+        zipfile.mkdir(directory.relative_path_from(input_dir.dirname))
+        write_entries(directory.children, zipfile)
+      end
+  end
+end


### PR DESCRIPTION
## Description

Connects to #549 

Attaches the import works found in the bag to each result of the `CsvDryRun`. Bags are extracted and verified using a transaction, which is also available on the `CsvDryRun` object.

Why was this necessary?

In order to import new works from a csv file and a bag, we need to attach and verify the works found in the bag with the works that are specified in the csv file.

## Changes

* adds `identifier` to the test data dictionary so we can set it to the value specified in the csv
* includes an `ImportFactory::Zip` testing support class for creating zip files from bags created using `ImportFactory::Bag`
* defines a special `import_work` accessor on `SubmissionChangeSet` which is set by the csv dry run so we can assign an `Import::Work` object to the change set, but not persist or use it as a kind of property
* defines a bag on the csv dry run to capture any validation errors for display in a later feature
