### PR TITLE
Heading Hierarchy for Views and Layouts

### DIFF
--- a/app/assets/stylesheets/cho/blacklight.scss
+++ b/app/assets/stylesheets/cho/blacklight.scss
@@ -6,13 +6,7 @@
   background: none;
   overflow: visible;
   text-indent: .25%;
-
-  a:link,
-  a:hover,
-  a:visited {
-    color: $primary-white;
-    font-size: 1rem;
-  }
+  width: auto;
 }
 
 .navbar-collapse { font-size: .9rem; }

--- a/app/assets/stylesheets/cho/scaffolds.scss
+++ b/app/assets/stylesheets/cho/scaffolds.scss
@@ -16,11 +16,6 @@ a {
   &:visited {
     color: $gray-middle;
   }
-
-  &:hover {
-    background-color: $primary-black;
-    color: $primary-white;
-  }
 }
 
 th {

--- a/app/blacklight/layout_helper_behavior.rb
+++ b/app/blacklight/layout_helper_behavior.rb
@@ -20,13 +20,13 @@ module LayoutHelperBehavior
   # Classes used for sizing the main content of a Blacklight page
   # @return [String]
   def main_content_classes
-    'col-sm-8 col-sm-push-4 col-md-9 col-md-push-3'
+    'col-sm-8 col-md-9 order-2'
   end
 
   ##
   # Classes used for sizing the sidebar content of a Blacklight page
   # @return [String]
   def sidebar_classes
-    'col-sm-4 col-sm-pull-8 col-md-3 col-md-pull-9'
+    'col-sm-4 col-md-3 order-1'
   end
 end

--- a/app/views/batch/_home_text.html.erb
+++ b/app/views/batch/_home_text.html.erb
@@ -1,5 +1,5 @@
 <div class="page-header row">
-  <h2 class="col-md-8 page-heading"><%= t('cho.batch.select.heading') %></h2>
+  <h1 class="col-md-8 page-heading"><%= t('cho.batch.select.heading') %></h1>
 </div>
 
 <p><%= t('cho.batch.select.message') %></p>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,0 +1,20 @@
+<% @page_title = t('blacklight.bookmarks.page_title', application_name: application_name) %>
+
+<div id="content" class="col-md-12">
+  <h1 class='page-heading'><%= t('blacklight.bookmarks.title') %></h1>
+
+  <%- if current_or_guest_user.blank? -%>
+
+    <h2 class='section-heading'><%= t('blacklight.bookmarks.need_login') %></h2>
+
+  <%- elsif @response.documents.blank? -%>
+
+    <h2 class='section-heading'><%= t('blacklight.bookmarks.no_bookmarks') %></h2>
+  <% else %>
+    <%= render 'sort_and_per_page' %>
+    <%= render partial: 'tools', locals: { document_list: @response.documents } %>
+
+    <%= render_document_index %>
+    <%= render 'results_pagination' %>
+  <% end %>
+</div>

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -1,0 +1,28 @@
+<h1 class="sr-only top-content-title"><%= t('blacklight.search.search_results_header') %></h1>
+
+<% @page_title = t('blacklight.search.page_title.title', constraints: render_search_to_page_title(params), application_name: application_name) %>
+
+<% content_for(:head) do -%>
+  <%= render_opensearch_response_metadata %>
+  <%= rss_feed_link_tag %>
+  <%= atom_feed_link_tag %>
+  <%= json_api_link_tag %>
+<% end %>
+
+<% content_for(:container_header) do -%>
+  <%= render 'constraints' %>
+<% end %>
+
+<%= render 'search_header' %>
+
+<h2 class="sr-only"><%= t('blacklight.search.search_results') %></h2>
+
+<%- if @response.empty? %>
+  <%= render 'zero_results' %>
+<%- elsif render_grouped_response? %>
+  <%= render_grouped_document_index %>
+<%- else %>
+  <%= render_document_index %>
+<%- end %>
+
+<%= render 'results_pagination' %>

--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -1,13 +1,12 @@
 <%# Overrides the layout from Blacklight to use our local cho layout %>
 <% content_for(:content) do %>
   <% if content_for? :sidebar %>
-    <section id="sidebar" class="<%= sidebar_classes %>">
-      <%= content_for(:sidebar) %>
-    </section>
-
     <main id="content" class="<%= main_content_classes %>" role="main">
       <%= yield %>
     </main>
+    <section id="sidebar" class="<%= sidebar_classes %>">
+      <%= content_for(:sidebar) %>
+    </section>
   <% else %>
     <main class="col-md-12" role="main">
       <%= yield %>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-expand-md navbar-dark bg-dark topbar" role="navigation">
   <div class="<%= container_classes %>">
-    <h1 class="mb-0 navbar-brand"><%= link_to application_name, root_path %></h1>
+    <%= link_to application_name, root_path, class: 'navbar-brand pt-2' %>
     <button class="navbar-toggler navbar-toggler-right"
             type="button"
             data-toggle="collapse"


### PR DESCRIPTION
Removes the h1 from the navbar brand for better heading hierarchy and adjusts the styles for hover.

Overrides some Blacklight views and updates CHO views to correct the heading hierarchy and their display in the layout for better structure and accesibility.

## Description

Fixes: #535 

Why was this necessary?

Fixes the heading hierarchy for better accessibility. Headings should be ordered H1-H6 without skipping.

## Changes

Are there any major changes in this PR that will change the release process? No

## Checklist

- [x] i18n enabled
- [ ] adequate test coverage
- [x] accessible interface
