### PR TITLE
Operation to import files from a bag

### DIFF
--- a/app/cho/import/file.rb
+++ b/app/cho/import/file.rb
@@ -28,6 +28,11 @@ class Import::File
   def to_s
     file.basename.to_s
   end
+  alias_method :original_filename, :to_s
+
+  def path
+    file.to_s
+  end
 
   def work_id
     @work_id ||= parts.first

--- a/app/cho/import/file_set.rb
+++ b/app/cho/import/file_set.rb
@@ -11,8 +11,26 @@ class Import::FileSet
     files.select(&:representative?).count == files.count
   end
 
+  def title
+    if preservation
+      preservation.original_filename
+    elsif service
+      service.original_filename
+    end
+  end
+
   def id
     files.first.file_set_id
   end
   alias_method :to_s, :id
+
+  private
+
+    def preservation
+      @preservation ||= files.select(&:preservation?).first
+    end
+
+    def service
+      @service ||= files.select(&:service?).first
+    end
 end

--- a/app/cho/transaction/operations/container.rb
+++ b/app/cho/transaction/operations/container.rb
@@ -40,6 +40,9 @@ module Transaction
         register 'validate' do
           Operations::Import::Validate.new
         end
+        register 'work' do
+          Operations::Import::Work.new
+        end
       end
     end
   end

--- a/app/cho/transaction/operations/import/work.rb
+++ b/app/cho/transaction/operations/import/work.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Transaction
+  module Operations
+    module Import
+      class Work
+        include Dry::Transaction::Operation
+
+        attr_reader :model
+
+        # @param [Work::SubmissionChangeSet] change_set
+        def call(change_set)
+          return Success(change_set) if change_set.try(:import_work).nil?
+          @model = change_set.model
+          file_sets = saved_file_sets(change_set.import_work)
+          change_set.file_set_ids = file_sets.map(&:id)
+          Success(change_set)
+        rescue StandardError => exception
+          Failure("Error importing the work: #{exception.message}")
+        end
+
+        private
+
+          # @param [Import::Work] import_work
+          # @return [Array<Work::FileSet>]
+          def saved_file_sets(import_work)
+            import_work.file_sets.map do |file_set|
+              metadata_adapter.persister.save(resource: import_file_set(file_set))
+            end
+          end
+
+          # @param [Import::FileSet] file_set
+          # @return [Work::FileSet]
+          def import_file_set(file_set)
+            files = saved_files(file_set.files)
+            ::Work::FileSet.new(member_ids: files.map(&:id), title: file_set.title)
+          end
+
+          # @param [Array<Import::File>] files
+          # @return [Array<Work::File>]
+          def saved_files(files)
+            files.map do |file|
+              metadata_adapter.persister.save(resource: import_file(file))
+            end
+          end
+
+          # @param [Import::File] file
+          # @return [Work::File]
+          def import_file(file)
+            ::Work::File.new(
+              file_identifier: adapter_file(file).id,
+              original_filename: file.original_filename
+            )
+          end
+
+          def adapter_file(file)
+            storage_adapter.upload(
+              file: file,
+              original_filename: file.original_filename,
+              resource: model
+            )
+          end
+
+          def storage_adapter
+            @storage_adapter ||= Valkyrie.config.storage_adapter
+          end
+
+          def metadata_adapter
+            @metadata_adapter ||= Valkyrie::MetadataAdapter.find(:indexing_persister)
+          end
+      end
+    end
+  end
+end

--- a/app/cho/transaction/shared/save_with_change_set.rb
+++ b/app/cho/transaction/shared/save_with_change_set.rb
@@ -8,6 +8,7 @@ module Transaction
       # Operations will be resolved from the `Container` specified above
       step :validate, with: 'shared.validate'
       step :save_file, with: 'file.save'
+      step :import_work, with: 'import.work'
       step :save, with: 'shared.save'
 
       def save_file(change_set)

--- a/spec/cho/import/file_set_spec.rb
+++ b/spec/cho/import/file_set_spec.rb
@@ -32,4 +32,24 @@ RSpec.describe Import::FileSet do
       expect(file_set.method(:to_s)).to eq(file_set.method(:id))
     end
   end
+
+  describe '#title' do
+    context 'with a preservation file' do
+      let(:files) { [ImportFactory::File.create('work1234_0001_preservation.tif')] }
+
+      its(:title) { is_expected.to eq('work1234_0001_preservation.tif') }
+    end
+
+    context 'with a service file' do
+      let(:files) { [ImportFactory::File.create('work1234_0001_service.jpg')] }
+
+      its(:title) { is_expected.to eq('work1234_0001_service.jpg') }
+    end
+
+    context 'with neither access nor preservation files' do
+      let(:files) { [ImportFactory::File.create('work1234_0001_access.jpg')] }
+
+      its(:title) { is_expected.to be_nil }
+    end
+  end
 end

--- a/spec/cho/import/file_spec.rb
+++ b/spec/cho/import/file_spec.rb
@@ -109,6 +109,12 @@ RSpec.describe Import::File do
     its(:to_s) { is_expected.to eq('workID_0001_preservation.tif') }
   end
 
+  describe '#path' do
+    subject { ImportFactory::File.create('workID_0001_preservation.tif') }
+
+    its(:path) { is_expected.to eq(Rails.root.join('tmp', 'workID', 'workID_0001_preservation.tif').to_s) }
+  end
+
   describe '#service?' do
     context 'with a service file' do
       subject { ImportFactory::File.create('workID_0001_service.jp2') }

--- a/spec/cho/transaction/operations/import/work_spec.rb
+++ b/spec/cho/transaction/operations/import/work_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Transaction::Operations::Import::Work do
+  let(:operation) { described_class.new }
+  let(:change_set) { Work::SubmissionChangeSet.new(Work::Submission.new) }
+
+  let(:import_work) do
+    ImportFactory::Work.new_create(
+      workID: [
+        'workID_preservation.tif',
+        'workID_preservation-redacted.tif',
+        'workID_service.jp2',
+        'workID_text.txt',
+        'workID_thumb.jpg'
+      ]
+    )
+  end
+
+  describe '#call' do
+    context 'when there is no import work' do
+      subject { operation.call(change_set) }
+
+      it { is_expected.to be_success }
+    end
+
+    context 'when the adapter fails' do
+      let(:mock_adapter) { instance_double(IndexingAdapter) }
+
+      before do
+        allow(operation).to receive(:metadata_adapter).and_return(mock_adapter)
+        allow(mock_adapter).to receive(:persister).and_raise(StandardError, 'unsupported adapter')
+        change_set.import_work = import_work
+      end
+
+      it 'returns a failure' do
+        expect {
+          result = operation.call(change_set)
+          expect(result).to be_failure
+          expect(result.failure).to eq('Error importing the work: unsupported adapter')
+        }.to change { Work::File.count }.by(0).and change { ::Work::FileSet.count }.by(0)
+      end
+    end
+
+    context 'with an import work' do
+      before { change_set.import_work = import_work }
+
+      it 'adds the file sets to the work' do
+        expect {
+          result = operation.call(change_set)
+          expect(result).to be_success
+          expect(result.success).to eq(change_set)
+          expect(result.success.file_set_ids.count).to eq(1)
+        }.to change { ::Work::File.count }.by(5).and change { ::Work::FileSet.count }.by(1)
+      end
+    end
+  end
+end

--- a/spec/cho/transaction/shared/save_with_change_set_spec.rb
+++ b/spec/cho/transaction/shared/save_with_change_set_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Transaction::Shared::SaveWithChangeSet do
+  let(:transaction) { described_class.new }
+
+  describe '::steps' do
+    subject { described_class.steps.map(&:name) }
+
+    it { is_expected.to contain_exactly(:validate, :save_file, :import_work, :save) }
+  end
+
+  it { is_expected.to respond_to(:call) }
+end


### PR DESCRIPTION
## Description

Connects to #549 

Creates a transaction that imports a work from a bag and attaches it to a new work during the csv import process.

Why was this necessary?

This enables us to import works from a bag and a csv file.

## Changes

* new convenience methods on Import::File and Import::FileSet to better enable import
* Import::Work operation to add file sets and files from a bag to a new work
* updated feature test that uses bags to import works via csv