### PR TITLE
Remove single file upload from CSV import

### DIFF
--- a/app/cho/work/import/csv_dry_run.rb
+++ b/app/cho/work/import/csv_dry_run.rb
@@ -71,7 +71,6 @@ module Work
             'member_of_collection_ids',
             'work_type',
             'work_type_id',
-            'file_name',
             'batch_id',
             'id'
           ]

--- a/app/cho/work/import/work_hash_validator.rb
+++ b/app/cho/work/import/work_hash_validator.rb
@@ -42,7 +42,6 @@ module Work
           work_hash['member_of_collection_ids'] = Array.wrap(work_hash['member_of_collection_ids'])
           unless updating?
             work_hash['work_type_id'] = translate_work_type(work_hash['work_type']) if work_hash['work_type_id'].blank?
-            work_hash['file'] = translate_file_name(work_hash['file_name'])
           end
         end
 
@@ -53,15 +52,6 @@ module Work
           return nil if work_type_model.blank?
 
           work_type_model.id
-        end
-
-        def translate_file_name(file_name)
-          return nil if file_name.blank?
-
-          absolute_path = ::File.join(csv_base_path, file_name)
-          FileUtils.cp(absolute_path, Rails.root.join('tmp'))
-          file = ::File.new(Rails.root.join('tmp', ::File.basename(file_name)))
-          ActionDispatch::Http::UploadedFile.new(tempfile: file, filename: ::File.basename(file_name))
         end
 
         def csv_base_path

--- a/spec/cho/work/import/csv_controller_spec.rb
+++ b/spec/cho/work/import/csv_controller_spec.rb
@@ -4,16 +4,12 @@ require 'rails_helper'
 
 RSpec.describe Work::Import::CsvController, type: :controller do
   let(:collection) { create :library_collection, title: 'my collection' }
-  let(:work_1_file_name) { 'hello_world.txt' }
-  let(:work_2_file_name) { 'hello_world2.txt' }
-  let(:work_3_file_name) { 'hello_world3.txt' }
 
   let(:csv_file) do
     CsvFactory::Generic.new(
       member_of_collection_ids: [collection.id, collection.id, collection.id],
       work_type: ['Generic', 'Generic', 'Generic'],
-      title: ['My Work 1', 'My Work 2', 'My Work 3'],
-      file_name: [work_1_file_name, work_2_file_name, work_3_file_name]
+      title: ['My Work 1', 'My Work 2', 'My Work 3']
     )
   end
 
@@ -51,7 +47,6 @@ RSpec.describe Work::Import::CsvController, type: :controller do
         expect(response).to be_success
         expect(assigns(:presenter)).to be_a(Work::Import::CsvDryRunResultsPresenter)
         expect(assigns(:presenter).change_set_list.map(&:valid?)).to eq([true, true, true])
-        expect(File).to be_exist(assigns(:file_name))
       end
     end
 
@@ -60,8 +55,7 @@ RSpec.describe Work::Import::CsvController, type: :controller do
         CsvFactory::Generic.new(
           member_of_collection_ids: [nil, collection.id, 'bad'],
           work_type: ['Generic', 'Bad', 'Generic'],
-          title: ['My Work 1', 'My Work 2', nil],
-          file_name: [work_1_file_name, work_2_file_name, work_3_file_name]
+          title: ['My Work 1', 'My Work 2', nil]
         )
       end
 

--- a/spec/cho/work/import/csv_dry_run_spec.rb
+++ b/spec/cho/work/import/csv_dry_run_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Work::Import::CsvDryRun do
       end
     end
 
-    context 'invalid data' do
+    context 'with invalid data' do
       let(:csv_file) do
         CsvFactory::Generic.new(
           member_of_collection_ids: [collection.id], work_type_id: [work_type_id], title: [nil]
@@ -65,7 +65,7 @@ RSpec.describe Work::Import::CsvDryRun do
       end
     end
 
-    context 'valid and invalid data' do
+    context 'with both valid and invalid data' do
       let(:csv_file) do
         CsvFactory::Generic.new(
           member_of_collection_ids: [collection.id, collection.id, collection.id],
@@ -83,7 +83,7 @@ RSpec.describe Work::Import::CsvDryRun do
       end
     end
 
-    context 'Work Type string included ' do
+    context 'when a work type string is included ' do
       let(:csv_file) do
         CsvFactory::Generic.new(
           member_of_collection_ids: [collection.id, collection.id, collection.id],
@@ -101,12 +101,10 @@ RSpec.describe Work::Import::CsvDryRun do
       end
     end
 
-    context 'Work Type string included ' do
-      let(:file_name) { 'hello_world.txt' }
-
+    context 'when a batch id is included' do
       let(:csv_file) do
         CsvFactory::Generic.new(
-          member_of_collection_ids: [collection.id], work_type: ['Generic'], title: ['My Stuff'], file_name: [file_name]
+          member_of_collection_ids: [collection.id], work_type: ['Generic'], title: ['My Stuff'], batch_id: ['batch1']
         )
       end
 
@@ -114,7 +112,7 @@ RSpec.describe Work::Import::CsvDryRun do
         is_expected.to be_a Array
         expect(dry_run_results.count).to eq(1)
         expect(dry_run_results[0]).to be_valid
-        expect(dry_run_results[0].file).to be_a(ActionDispatch::Http::UploadedFile)
+        expect(dry_run_results[0].batch_id).to eq('batch1')
       end
     end
 

--- a/spec/cho/work/import/work_hash_validator_spec.rb
+++ b/spec/cho/work/import/work_hash_validator_spec.rb
@@ -45,7 +45,6 @@ RSpec.describe Work::Import::WorkHashValidator do
           expect(change_set.model).to be_a(Work::Submission)
           expect(change_set.work_type_id).to eq(generic_work_type.id)
           expect(change_set.member_of_collection_ids).to eq([collection.id])
-          expect(change_set.file).to be_a(ActionDispatch::Http::UploadedFile)
         end
 
         context 'with an absolute path configured' do
@@ -64,7 +63,6 @@ RSpec.describe Work::Import::WorkHashValidator do
             expect(change_set.model).to be_a(Work::Submission)
             expect(change_set.work_type_id).to eq(generic_work_type.id)
             expect(change_set.member_of_collection_ids).to eq([collection.id])
-            expect(change_set.file).to be_a(ActionDispatch::Http::UploadedFile)
           end
         end
       end


### PR DESCRIPTION
## Description

Fixes #549 

Removes the ability to upload single files in a CSV.

Why was this necessary?

Single-file upload is no longer supported in a CSV, only bag upload.
