### PR TITLE
Reporting dry-run results from bag import

### DIFF
--- a/app/cho/work/import/csv_dry_run_results_presenter.rb
+++ b/app/cho/work/import/csv_dry_run_results_presenter.rb
@@ -5,7 +5,7 @@ module Work
     # Presents the results of the dry run in a nice way for display
     class CsvDryRunResultsPresenter
       delegate :each, :to_a, to: :change_set_list
-      delegate :update?, to: :dry_run
+      delegate :update?, :bag, to: :dry_run
 
       attr_reader :dry_run
 
@@ -27,15 +27,20 @@ module Work
       end
 
       def invalid?
-        invalid_rows.present?
+        invalid_rows.present? || bag_errors.present?
       end
 
       def valid?
-        valid_rows.present?
+        valid_rows.present? && bag_errors.empty?
       end
 
       def error_count
         invalid_rows.count
+      end
+
+      def bag_errors
+        return [] if bag.success? || update?
+        bag.failure.errors.full_messages
       end
     end
   end

--- a/app/views/work/import/csv/dry_run_results.html.erb
+++ b/app/views/work/import/csv/dry_run_results.html.erb
@@ -1,5 +1,20 @@
 <h1><%= t('cho.csv.dry_run.heading') %></h1>
 
+<h2><%= t('cho.csv.dry_run.bag_status') %></h2>
+
+<% if @presenter.bag_errors.present? %>
+  <p><%= t('cho.csv.dry_run.bag_failure', count: @presenter.bag_errors.count) %></p>
+  <ul>
+    <% @presenter.bag_errors.each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+  </ul>
+<% else %>
+  <p><%= t('cho.csv.dry_run.bag_success') %></p>
+<% end %>
+
+<h2><%= t('cho.csv.dry_run.csv_status') %></h2>
+
 <% if @presenter.update? %>
   <p><%= t('cho.csv.dry_run.update_description') %></p>
 <% else %>

--- a/config/locales/cho.yml
+++ b/config/locales/cho.yml
@@ -75,6 +75,10 @@ en:
           status: "Status"
         submit: "Perform Import"
         cancel: "Cancel"
+        bag_status: Bag Status
+        bag_failure: "The bag contains %{count} error(s)"
+        bag_success: "The bag is valid and contains no errors"
+        csv_status: CSV Status
       import:
         failure:
           header: "Failed Import"

--- a/spec/cho/work/import/csv_dry_run_results_presenter_spec.rb
+++ b/spec/cho/work/import/csv_dry_run_results_presenter_spec.rb
@@ -8,13 +8,15 @@ RSpec.describe Work::Import::CsvDryRunResultsPresenter do
   let(:work_type_id) { Work::Type.find_using(label: 'Generic').first.id }
   let(:collection) { create :library_collection }
   let(:change_set) { instance_double(Work::SubmissionChangeSet) }
-  let(:mock_dry_run) { instance_double(Work::Import::CsvDryRun, results: [change_set]) }
+  let(:mock_dry_run) { instance_double(Work::Import::CsvDryRun, results: [change_set], bag: bag, update?: false) }
+  let(:bag) { Dry::Monads::Result::Success.new('success') }
 
   it { is_expected.to delegate_method(:update?).to(:dry_run) }
   it { is_expected.to delegate_method(:each).to(:change_set_list) }
   it { is_expected.to delegate_method(:to_a).to(:change_set_list) }
+  it { is_expected.to delegate_method(:bag).to(:dry_run) }
 
-  context 'when there is valid data' do
+  context 'when there is valid csv and valid bag data' do
     let(:change_set) do
       change_set = Work::SubmissionChangeSet.new(Work::Submission.new)
       change_set.validate(
@@ -25,11 +27,13 @@ RSpec.describe Work::Import::CsvDryRunResultsPresenter do
 
     its(:invalid_rows) { is_expected.to be_empty }
     its(:invalid?) { is_expected.to be_falsey }
+    its(:valid?) { is_expected.to be_truthy }
     its(:error_count) { is_expected.to eq 0 }
     its(:valid_rows) { is_expected.to eq [change_set] }
+    its(:bag_errors) { is_expected.to be_empty }
   end
 
-  context 'when there is invalid data' do
+  context 'when there is invalid csv data and valid bag data' do
     let(:change_set) do
       change_set = Work::SubmissionChangeSet.new(Work::Submission.new)
       change_set.validate(member_of_collection_ids: [collection.id], title: 'My invalid work')
@@ -38,7 +42,30 @@ RSpec.describe Work::Import::CsvDryRunResultsPresenter do
 
     its(:valid_rows) { is_expected.to be_empty }
     its(:invalid?) { is_expected.to be_truthy }
+    its(:valid?) { is_expected.to be_falsey }
     its(:error_count) { is_expected.to eq 1 }
     its(:invalid_rows) { is_expected.to eq [change_set] }
+    its(:bag_errors) { is_expected.to be_empty }
+  end
+
+  context 'when there is valid csv data and invalid bag data' do
+    let(:change_set) do
+      change_set = Work::SubmissionChangeSet.new(Work::Submission.new)
+      change_set.validate(
+        member_of_collection_ids: [collection.id], work_type_id: [work_type_id], title: 'My valid work'
+      )
+      change_set
+    end
+
+    let(:mock_error)   { instance_double(ActiveModel::Errors, full_messages: ['Error message']) }
+    let(:mock_failure) { instance_double(Import::Bag, errors: mock_error) }
+    let(:bag) { Dry::Monads::Result::Failure.new(mock_failure) }
+
+    its(:invalid_rows) { is_expected.to be_empty }
+    its(:error_count) { is_expected.to eq 0 }
+    its(:valid_rows) { is_expected.to eq [change_set] }
+    its(:invalid?) { is_expected.to be_truthy }
+    its(:valid?) { is_expected.to be_falsey }
+    its(:bag_errors) { is_expected.to contain_exactly('Error message') }
   end
 end


### PR DESCRIPTION
## Description

Fixes #562 

Displays errors from a bag used in the CSV import process.

## Changes

Are there any major changes in this PR that will change the release process? No

## Checklist

- [ ] i18n enabled
- [ ] adequate test coverage
- [ ] accessible interface
