### PR TITLE
Nicer validation error messages

### DIFF
--- a/app/cho/import/file.rb
+++ b/app/cho/import/file.rb
@@ -80,7 +80,7 @@ class Import::File
 
     def filename_must_include_work_id
       return if work_id == file.parent.basename.to_s
-      errors.add(:file, "#{self} does not match the parent directory")
+      errors.add(:file, :filename_must_include_work_id, file: self)
     end
 
     def filename_must_include_type

--- a/app/cho/work/import/csv_dry_run_results_presenter.rb
+++ b/app/cho/work/import/csv_dry_run_results_presenter.rb
@@ -40,7 +40,7 @@ module Work
 
       def bag_errors
         return [] if bag.success? || update?
-        bag.failure.errors.full_messages
+        bag.failure.errors.values.flatten
       end
     end
   end

--- a/config/locales/activemodel_errors.yml
+++ b/config/locales/activemodel_errors.yml
@@ -1,0 +1,12 @@
+en:
+  # custom validation error messages
+  activemodel:
+    errors:
+      models:
+        import/file:
+          attributes:
+            file:
+              filename_must_include_work_id: "%{file} does not match the parent directory"
+    attributes:
+      import/file:
+        file: Import file

--- a/spec/cho/import/bag_spec.rb
+++ b/spec/cho/import/bag_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Import::Bag do
     it do
       expect(bag).not_to be_valid
       expect(bag.errors.messages)
-        .to include(works: ['File badID_01_preservation.tif does not match the parent directory'])
+        .to include(works: ['Import file badID_01_preservation.tif does not match the parent directory'])
     end
   end
 

--- a/spec/cho/import/work_spec.rb
+++ b/spec/cho/import/work_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe Import::Work do
     it do
       expect(work).not_to be_valid
       expect(work.errors.messages).to include(
-        files: ['File workID_unsupported.jp2 does not have a valid file type']
+        files: ['Import file workID_unsupported.jp2 does not have a valid file type']
       )
       expect(work.files.count).to eq(5)
       expect(work.nested_works.count).to eq(0)
@@ -225,8 +225,8 @@ RSpec.describe Import::Work do
       expect(work).not_to be_valid
       expect(work.errors.messages).to include(
         files: [
-          'File wrongID.jp2 does not match the parent directory',
-          'File wrongID.jp2 does not have a valid file type'
+          'Import file wrongID.jp2 does not match the parent directory',
+          'Import file wrongID.jp2 does not have a valid file type'
         ]
       )
       expect(work.files.count).to eq(5)

--- a/spec/cho/transaction/operations/import/validate_spec.rb
+++ b/spec/cho/transaction/operations/import/validate_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Transaction::Operations::Import::Validate do
         expect(result.failure).to be_a(Import::Bag)
         expect(result.failure).not_to be_valid
         expect(result.failure.errors.messages).to include(
-          works: ['File badID_01_preservation.tif does not match the parent directory']
+          works: ['Import file badID_01_preservation.tif does not match the parent directory']
         )
       end
     end

--- a/spec/cho/work/import/create_spec.rb
+++ b/spec/cho/work/import/create_spec.rb
@@ -148,8 +148,9 @@ RSpec.describe 'Preview of CSV Import', type: :feature do
       attach_file('work_import_csv_file_file', csv_file.path)
       click_button('Preview Import')
       expect(page).to have_content('The bag contains 1 error(s)')
-      expect(page).to have_content(
-        'Works File badId_preservation.tif does not match the parent directory'
+      expect(page).to have_selector(
+        'li',
+        text: /^Import file badId_preservation.tif does not match the parent directory/
       )
     end
   end

--- a/spec/cho/work/import/csv_dry_run_results_presenter_spec.rb
+++ b/spec/cho/work/import/csv_dry_run_results_presenter_spec.rb
@@ -57,8 +57,7 @@ RSpec.describe Work::Import::CsvDryRunResultsPresenter do
       change_set
     end
 
-    let(:mock_error)   { instance_double(ActiveModel::Errors, full_messages: ['Error message']) }
-    let(:mock_failure) { instance_double(Import::Bag, errors: mock_error) }
+    let(:mock_failure) { instance_double(Import::Bag, errors: { work: 'Error message' }) }
     let(:bag) { Dry::Monads::Result::Failure.new(mock_failure) }
 
     its(:invalid_rows) { is_expected.to be_empty }


### PR DESCRIPTION
Overrides ActiveModel::Errors defaults to create custom error messages
using locale files.