### PR TITLE
Update Valkyrie and enable optimistic locking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ end
 # Main gems
 gem 'blacklight', '7.0.0.rc1'
 gem 'rails', '~> 5.1.3'
-gem 'valkyrie', '~> 1.0'
+gem 'valkyrie', '1.2.0.rc1'
 
 # For Blacklight with Sprockets
 gem 'bootstrap', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,11 +54,11 @@ GEM
       rsolr (>= 1.1.2, < 3)
       ruby-progressbar (~> 1.0)
       solrizer (>= 3.4, < 5)
-    active-triples (1.0.0)
+    active-triples (1.1.0)
       activemodel (>= 3.0.0)
       activesupport (>= 3.0.0)
-      rdf (~> 2.0, >= 2.0.2)
-      rdf-vocab (~> 2.0)
+      rdf (>= 2.0.2, < 4.0)
+      rdf-vocab (>= 2.0, < 4.0)
     activejob (5.1.6)
       activesupport (= 5.1.6)
       globalid (>= 0.3.6)
@@ -184,7 +184,7 @@ GEM
       devise (~> 4.0)
       rails (~> 5.0)
     diff-lcs (1.3)
-    disposable (0.4.3)
+    disposable (0.4.4)
       declarative (>= 0.0.9, < 1.0.0)
       declarative-builder (< 0.2.0)
       declarative-option (< 0.2.0)
@@ -232,7 +232,7 @@ GEM
       dry-events (>= 0.1.0)
       dry-matcher (>= 0.7.0)
       dry-monads (>= 0.4.0)
-    dry-types (0.12.2)
+    dry-types (0.12.3)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.1)
       dry-container (~> 0.3)
@@ -414,16 +414,16 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    rdf (2.2.12)
+    rdf (3.0.2)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
-    rdf-isomorphic (2.2.0)
-      rdf (>= 2.0, < 4.0)
-    rdf-turtle (2.2.2)
+    rdf-isomorphic (3.0.0)
+      rdf (~> 3.0)
+    rdf-turtle (3.0.1)
       ebnf (~> 1.1)
-      rdf (>= 2.2, < 4.0)
-    rdf-vocab (2.2.9)
-      rdf (>= 2.2, < 4.0)
+      rdf (~> 3.0)
+    rdf-vocab (3.0.3)
+      rdf (~> 3.0)
     redis (3.3.3)
     redis-namespace (1.5.3)
       redis (~> 3.0, >= 3.0.4)
@@ -576,7 +576,7 @@ GEM
     unf_ext (0.0.7.4)
     unicode-display_width (1.3.2)
     validatable (1.6.7)
-    valkyrie (1.0.0)
+    valkyrie (1.2.0.rc1)
       active-fedora
       active-triples
       activemodel
@@ -584,10 +584,10 @@ GEM
       activesupport
       draper
       dry-struct
-      dry-types
+      dry-types (~> 0.12.0)
       json
       json-ld
-      pg (< 1.0)
+      pg
       railties
       rdf
       reform
@@ -670,7 +670,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   twitter-typeahead-rails (= 0.11.1.pre.corejavascript)
   uglifier (>= 1.3.0)
-  valkyrie (~> 1.0)
+  valkyrie (= 1.2.0.rc1)
   web-console (>= 3.3.0)
   xray-rails
 

--- a/app/cho/transaction/operations/shared/save.rb
+++ b/app/cho/transaction/operations/shared/save.rb
@@ -9,6 +9,9 @@ module Transaction
         def call(change_set, persister:)
           change_set.sync
           Success(persister.save(resource: change_set))
+        rescue Valkyrie::Persistence::StaleObjectError
+          change_set.errors.add(:save, I18n.t('cho.stale_object_error', object_name: change_set.work_type.label))
+          Failure(change_set)
         rescue StandardError => error
           change_set.errors.add(:save, error.message)
           Failure(change_set)

--- a/app/cho/work/submission.rb
+++ b/app/cho/work/submission.rb
@@ -5,6 +5,7 @@
 # Works are indexed both in Solr and and Postgres using the {IndexingAdapter}.
 module Work
   class Submission < Valkyrie::Resource
+    enable_optimistic_locking
     include Valkyrie::Resource::AccessControls
     include DataDictionary::FieldsForObject
     include CommonQueries

--- a/app/cho/work/submission_change_set.rb
+++ b/app/cho/work/submission_change_set.rb
@@ -2,6 +2,9 @@
 
 module Work
   class SubmissionChangeSet < Valkyrie::ChangeSet
+    property :optimistic_lock_token, multiple: true, required: true,
+                                     type: Types::Strict::Array.of(Valkyrie::Types::OptimisticLockToken)
+
     validates :work_type_id, presence: true
     validates :work_type_id, with: :validate_work_type_id!
     property :work_type_id, multiple: false, required: true, type: Valkyrie::Types::ID

--- a/app/valkyrie/find_using.rb
+++ b/app/valkyrie/find_using.rb
@@ -30,11 +30,11 @@ class FindUsing
     query.each_key do |key|
       value = query[key]
       clause = if value.is_a?(String)
-                 "metadata @> '{\"#{key}\":\"#{value}\"}'"
+                 "metadata @> '{\"#{key}\":[\"#{value}\"]}'"
                elsif value.nil?
                  "metadata->>'#{key}' is null"
                else
-                 "metadata @> '{\"#{key}\":#{value}}'"
+                 "metadata @> '{\"#{key}\":[#{value}]}'"
                end
       clauses.push(clause)
     end

--- a/app/valkyrie/postgres/singular_metadata_adapter.rb
+++ b/app/valkyrie/postgres/singular_metadata_adapter.rb
@@ -9,12 +9,16 @@ module Postgres
 
     # @return [Class] {Valkyrie::Persistence::Postgres::QueryService}
     def query_service
-      @query_service ||= Valkyrie::Persistence::Postgres::QueryService.new(adapter: self)
+      @query_service ||= Valkyrie::Persistence::Postgres::QueryService.new(resource_factory: resource_factory)
     end
 
     # @return [Class] {Valkyrie::Persistence::Postgres::ResourceFactory}
     def resource_factory
-      Valkyrie::Persistence::Postgres::ResourceFactory
+      Valkyrie::Persistence::Postgres::ResourceFactory.new(adapter: self)
+    end
+
+    def id
+      @id ||= Valkyrie::ID.new(Digest::MD5.hexdigest(self.class.to_s))
     end
   end
 end

--- a/app/views/work/submissions/_form.html.erb
+++ b/app/views/work/submissions/_form.html.erb
@@ -14,6 +14,7 @@
   <% end %>
 
   <%= form.hidden_field :work_type_id, value: work_form.work_type_id %>
+  <%= form.hidden_field :optimistic_lock_token, multiple: true, value: work_form.optimistic_lock_token %>
 
   <%= form.hidden_field :file, value: work_form.model.cached_file_data %>
 

--- a/config/locales/cho.yml
+++ b/config/locales/cho.yml
@@ -106,4 +106,5 @@ en:
         success: "You have successfully deleted the following items: %{list}"
         cancel: "Cancel"
         submit: "Delete Selected Resources"
+    stale_object_error: ": the %{object_name} object you tried to save is stale.  Please reload the form to see the latest data."
 

--- a/db/migrate/20180810135054_create_path_gin_index.valkyrie_engine.rb
+++ b/db/migrate/20180810135054_create_path_gin_index.valkyrie_engine.rb
@@ -1,0 +1,7 @@
+# This migration comes from valkyrie_engine (originally 20171011224121)
+# frozen_string_literal: true
+class CreatePathGinIndex < ActiveRecord::Migration[5.1]
+  def change
+    add_index :orm_resources, 'metadata jsonb_path_ops', using: :gin
+  end
+end

--- a/db/migrate/20180810135055_create_internal_resource_index.valkyrie_engine.rb
+++ b/db/migrate/20180810135055_create_internal_resource_index.valkyrie_engine.rb
@@ -1,0 +1,7 @@
+# This migration comes from valkyrie_engine (originally 20171204224121)
+# frozen_string_literal: true
+class CreateInternalResourceIndex < ActiveRecord::Migration[5.1]
+  def change
+    add_index :orm_resources, :internal_resource
+  end
+end

--- a/db/migrate/20180810135056_create_updated_at_index.valkyrie_engine.rb
+++ b/db/migrate/20180810135056_create_updated_at_index.valkyrie_engine.rb
@@ -1,0 +1,7 @@
+# This migration comes from valkyrie_engine (originally 20180212092225)
+# frozen_string_literal: true
+class CreateUpdatedAtIndex < ActiveRecord::Migration[5.1]
+  def change
+    add_index :orm_resources, :updated_at
+  end
+end

--- a/db/migrate/20180810135057_add_optimistic_locking_to_orm_resources.valkyrie_engine.rb
+++ b/db/migrate/20180810135057_add_optimistic_locking_to_orm_resources.valkyrie_engine.rb
@@ -1,0 +1,7 @@
+# This migration comes from valkyrie_engine (originally 20180802220739)
+# frozen_string_literal: true
+class AddOptimisticLockingToOrmResources < ActiveRecord::Migration[5.1]
+  def change
+    add_column :orm_resources, :lock_version, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180226202420) do
+ActiveRecord::Schema.define(version: 20180810135057) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,7 +33,11 @@ ActiveRecord::Schema.define(version: 20180226202420) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "internal_resource"
+    t.integer "lock_version"
+    t.index "metadata jsonb_path_ops", name: "index_orm_resources_on_metadata_jsonb_path_ops", using: :gin
+    t.index ["internal_resource"], name: "index_orm_resources_on_internal_resource"
     t.index ["metadata"], name: "index_orm_resources_on_metadata", using: :gin
+    t.index ["updated_at"], name: "index_orm_resources_on_updated_at"
   end
 
   create_table "searches", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
## Description

Updates Valkyrie to 1.2.0.rc1 and enables optimistic locking on Work::Submission resources.

## Changes

Are there any major changes in this PR that will change the release process?

Postgres migration is required to add the new columns for the optimistic lock token.

## Checklist

- [ ] i18n enabled
- [ ] adequate test coverage
- [ ] accessible interface
