### PR TITLE
Enable ordering on all data dictionary properties

### DIFF
--- a/app/cho/data_dictionary/fields_for_object.rb
+++ b/app/cho/data_dictionary/fields_for_object.rb
@@ -16,7 +16,7 @@ module DataDictionary::FieldsForObject
       Rails.application.load_seed if DataDictionary::Field.all.empty? && Rails.env.test?
 
       DataDictionary::Field.all.each do |field|
-        attribute field.label.parameterize.underscore.to_sym, Valkyrie::Types::Set
+        attribute field.label.parameterize.underscore.to_sym, Valkyrie::Types::Set.meta(ordered: true)
       end
     end
   end


### PR DESCRIPTION
## Description

Uses the latest features from Valkyrie to ensure all properties that are defined dynamically via DataDictionary are ordered by default.

## Changes

Are there any major changes in this PR that will change the release process? No

## Checklist

- [ ] i18n enabled
- [ ] adequate test coverage
- [ ] accessible interface
