### PR TITLE
Updating Valkyrie to 1.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ end
 # Main gems
 gem 'blacklight', '7.0.0.rc1'
 gem 'rails', '~> 5.1.3'
-gem 'valkyrie', '1.2.0.rc1'
+gem 'valkyrie', '~> 1.2.0'
 
 # For Blacklight with Sprockets
 gem 'bootstrap', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,7 +206,7 @@ GEM
     dry-container (0.6.0)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.1, >= 0.1.3)
-    dry-core (0.4.5)
+    dry-core (0.4.7)
       concurrent-ruby (~> 1.0)
     dry-equalizer (0.2.1)
     dry-events (0.1.0)
@@ -279,7 +279,7 @@ GEM
     hydra-ldap (0.1.0)
       net-ldap
       rails
-    i18n (1.0.1)
+    i18n (1.1.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     inflecto (0.0.2)
@@ -291,7 +291,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.1.0)
-    json-ld (2.2.1)
+    json-ld (3.0.0)
       multi_json (~> 1.12)
       rdf (>= 2.2.8, < 4.0)
     kaminari (1.1.1)
@@ -353,13 +353,13 @@ GEM
       rubocop-rspec (~> 1.22, <= 1.22.2)
       scss_lint (~> 0.55)
     nio4r (2.3.1)
-    nokogiri (1.8.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     orm_adapter (0.5.0)
     parallel (1.12.1)
     parser (2.5.1.0)
       ast (~> 2.4.0)
-    pg (0.21.0)
+    pg (1.1.2)
     popper_js (1.12.9)
     powerpack (0.1.1)
     pry (0.11.0)
@@ -380,7 +380,7 @@ GEM
     rack (2.0.5)
     rack-protection (2.0.3)
       rack
-    rack-test (1.0.0)
+    rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.1.6)
       actioncable (= 5.1.6)
@@ -459,7 +459,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     retriable (3.1.2)
-    rsolr (2.2.0)
+    rsolr (2.2.1)
       builder (>= 2.1.2)
       faraday (>= 0.9.0)
     rspec-core (3.6.0)
@@ -491,7 +491,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     rubocop-rspec (1.22.2)
       rubocop (>= 0.52.1)
-    ruby-progressbar (1.9.0)
+    ruby-progressbar (1.10.0)
     rubyzip (1.2.1)
     rufus-scheduler (3.4.2)
       et-orbi (~> 1.0)
@@ -576,7 +576,7 @@ GEM
     unf_ext (0.0.7.4)
     unicode-display_width (1.3.2)
     validatable (1.6.7)
-    valkyrie (1.2.0.rc1)
+    valkyrie (1.2.0)
       active-fedora
       active-triples
       activemodel
@@ -670,7 +670,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   twitter-typeahead-rails (= 0.11.1.pre.corejavascript)
   uglifier (>= 1.3.0)
-  valkyrie (= 1.2.0.rc1)
+  valkyrie (~> 1.2.0)
   web-console (>= 3.3.0)
   xray-rails
 


### PR DESCRIPTION
## Description

Updates CHO to the 1.2.0 release of Valkyrie which supports optimistic locking and single-valued attributes.