### PR TITLE
Don't pass change sets to persisters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ end
 # Main gems
 gem 'blacklight', '7.0.0.rc1'
 gem 'rails', '~> 5.1.3'
-gem 'valkyrie', '1.2.0.rc1'
+gem 'valkyrie', '~> 1.2.0'
 
 # For Blacklight with Sprockets
 gem 'bootstrap', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,7 +206,7 @@ GEM
     dry-container (0.6.0)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.1, >= 0.1.3)
-    dry-core (0.4.5)
+    dry-core (0.4.7)
       concurrent-ruby (~> 1.0)
     dry-equalizer (0.2.1)
     dry-events (0.1.0)
@@ -279,7 +279,7 @@ GEM
     hydra-ldap (0.1.0)
       net-ldap
       rails
-    i18n (1.0.1)
+    i18n (1.1.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     inflecto (0.0.2)
@@ -291,7 +291,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.1.0)
-    json-ld (2.2.1)
+    json-ld (3.0.0)
       multi_json (~> 1.12)
       rdf (>= 2.2.8, < 4.0)
     kaminari (1.1.1)
@@ -353,13 +353,13 @@ GEM
       rubocop-rspec (~> 1.22, <= 1.22.2)
       scss_lint (~> 0.55)
     nio4r (2.3.1)
-    nokogiri (1.8.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     orm_adapter (0.5.0)
     parallel (1.12.1)
     parser (2.5.1.0)
       ast (~> 2.4.0)
-    pg (0.21.0)
+    pg (1.1.2)
     popper_js (1.12.9)
     powerpack (0.1.1)
     pry (0.11.0)
@@ -380,7 +380,7 @@ GEM
     rack (2.0.5)
     rack-protection (2.0.3)
       rack
-    rack-test (1.0.0)
+    rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.1.6)
       actioncable (= 5.1.6)
@@ -459,7 +459,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     retriable (3.1.2)
-    rsolr (2.2.0)
+    rsolr (2.2.1)
       builder (>= 2.1.2)
       faraday (>= 0.9.0)
     rspec-core (3.6.0)
@@ -491,7 +491,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     rubocop-rspec (1.22.2)
       rubocop (>= 0.52.1)
-    ruby-progressbar (1.9.0)
+    ruby-progressbar (1.10.0)
     rubyzip (1.2.1)
     rufus-scheduler (3.4.2)
       et-orbi (~> 1.0)
@@ -576,7 +576,7 @@ GEM
     unf_ext (0.0.7.4)
     unicode-display_width (1.3.2)
     validatable (1.6.7)
-    valkyrie (1.2.0.rc1)
+    valkyrie (1.2.0)
       active-fedora
       active-triples
       activemodel
@@ -670,7 +670,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   twitter-typeahead-rails (= 0.11.1.pre.corejavascript)
   uglifier (>= 1.3.0)
-  valkyrie (= 1.2.0.rc1)
+  valkyrie (~> 1.2.0)
   web-console (>= 3.3.0)
   xray-rails
 

--- a/app/cho/data_dictionary/csv_importer.rb
+++ b/app/cho/data_dictionary/csv_importer.rb
@@ -56,7 +56,7 @@ module DataDictionary
       def store_field(dictionary_field)
         change_set = find_existing_field(dictionary_field)
         change_set.validate(dictionary_field.attributes.slice(attributes))
-        adapter.persister.save(resource: change_set)
+        adapter.persister.save(resource: change_set.resource)
       end
 
       # @param [DataDictionary::Field] dictionary_field

--- a/app/cho/data_dictionary/fields_controller.rb
+++ b/app/cho/data_dictionary/fields_controller.rb
@@ -43,7 +43,7 @@ module DataDictionary
     # DELETE /data_dictionary_fields/1
     # DELETE /data_dictionary_fields/1.json
     def destroy
-      persister.delete(resource: delete_change_set)
+      persister.delete(resource: delete_change_set.resource)
       respond_to do |format|
         format.html { redirect_to data_dictionary_fields_url, notice: 'Metadata field was successfully destroyed.' }
         format.json { head :no_content }

--- a/app/cho/transaction/operations/shared/save.rb
+++ b/app/cho/transaction/operations/shared/save.rb
@@ -8,7 +8,7 @@ module Transaction
 
         def call(change_set, persister:)
           change_set.sync
-          Success(persister.save(resource: change_set))
+          Success(persister.save(resource: change_set.resource))
         rescue Valkyrie::Persistence::StaleObjectError
           change_set.errors.add(:save, I18n.t('cho.stale_object_error', object_name: change_set.work_type.label))
           Failure(change_set)

--- a/spec/cho/collection/with_members_spec.rb
+++ b/spec/cho/collection/with_members_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Collection::WithMembers do
     context 'when an association exists' do
       it 'returns the members associated with the resource' do
         change_set = Valkyrie::ChangeSet.new(ParentResource.new)
-        parent = Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: change_set)
+        parent = Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: change_set.resource)
         member = create(:work, member_of_collection_ids: [parent.id])
         reloaded_parent = Valkyrie.config.metadata_adapter.query_service.find_by(id: parent.id)
         expect(reloaded_parent.members.map(&:id)).to contain_exactly(member.id)
@@ -29,7 +29,7 @@ RSpec.describe Collection::WithMembers do
     context 'when no association exists' do
       it 'returns an empty array' do
         change_set = Valkyrie::ChangeSet.new(ParentResource.new)
-        parent = Valkyrie.config.metadata_adapter.persister.save(resource: change_set)
+        parent = Valkyrie.config.metadata_adapter.persister.save(resource: change_set.resource)
         reloaded_parent = Valkyrie.config.metadata_adapter.query_service.find_by(id: parent.id)
         expect(reloaded_parent.members).to be_empty
       end

--- a/spec/valkyrie/change_set_persister_spec.rb
+++ b/spec/valkyrie/change_set_persister_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ChangeSetPersister do
     it 'persists a change set to Postgres' do
       expect {
         change_set_persister.buffer_into_index do |persist|
-          persist.save(resource: change_set)
+          persist.save(resource: change_set.resource)
         end
       }.to change { metadata_adapter.query_service.find_all.count }.by(1)
     end
@@ -26,7 +26,7 @@ RSpec.describe ChangeSetPersister do
     it 'persists a change set to Solr' do
       expect {
         change_set_persister.buffer_into_index do |persist|
-          persist.save(resource: change_set)
+          persist.save(resource: change_set.resource)
         end
       }.to change { metadata_adapter.index_adapter.query_service.find_all.count }.by(1)
     end


### PR DESCRIPTION
## Description

During our upgrade to Valkyrie 1.2.0, we discovered that we were using persisters incorrectly and passing change sets to them, instead of resources. In order to follow the prescribed practices, we're fixing it so that we send resources to our persisters instead of change sets.