### PR TITLE
Import zip files as bags when uploaded via the GUI

### DIFF
--- a/app/cho/transaction/operations/import/extract.rb
+++ b/app/cho/transaction/operations/import/extract.rb
@@ -10,21 +10,23 @@ module Transaction
         include Dry::Transaction::Operation
 
         # @param [String] zip_name name of the zip file or batch id containing the bag
-        def call(zip_name)
-          zip_path = network_ingest_directory.join("#{zip_name}.zip")
+        # @param [Pathname] zip_path full path to the zip file containing the bag
+        def call(zip_name: nil, zip_path: nil)
+          zip_name ||= zip_path.basename('.zip')
+          zip_path ||= network_ingest_directory.join("#{zip_name}.zip")
           destination = extraction_directory.join(zip_name)
           return Success(destination) if destination.exist?
           unzip_bag(zip_path)
           Success(destination)
         rescue StandardError => exception
-          Failure("Error exacting the bag: #{exception.message}")
+          Failure("Error extracting the bag: #{exception.message}")
         end
 
         private
 
           # @param [String] path to zip file
           def unzip_bag(path)
-            Zip::File.open(path) do |zip_file|
+            ::Zip::File.open_buffer(::File.open(path)) do |zip_file|
               zip_file.each do |entry|
                 path = extraction_directory.join(entry.name)
                 FileUtils.mkdir_p(path.dirname)

--- a/app/cho/transaction/operations/import/zip.rb
+++ b/app/cho/transaction/operations/import/zip.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Transaction
+  module Operations
+    module Import
+      class Zip
+        include Dry::Transaction::Operation
+
+        def call(change_set)
+          bag = Transaction::Import::ImportFromZip.new.call(
+            zip_name: Pathname.new(change_set.file.original_filename).basename('.zip').to_s,
+            zip_path: change_set.file.path
+          )
+          return Failure(change_set) if bag.failure?
+          return Failure('Cannot import bags with more that one work') if bag.success.works.count > 1
+          change_set.import_work = bag.success.works.first
+          Success(change_set)
+        rescue StandardError => exception
+          Failure("Unable to import zip file from the GUI: #{exception}")
+        end
+      end
+    end
+  end
+end

--- a/app/cho/transaction/shared/save_with_change_set.rb
+++ b/app/cho/transaction/shared/save_with_change_set.rb
@@ -7,9 +7,21 @@ module Transaction
 
       # Operations will be resolved from the `Container` specified above
       step :validate, with: 'shared.validate'
-      step :save_file, with: 'file.save'
+      step :process_file
       step :import_work, with: 'import.work'
       step :save, with: 'shared.save'
+
+      private
+
+        def process_file(change_set)
+          return Success(change_set) if change_set.try(:file).nil?
+          mime_type = Mime::Type.lookup(change_set.file.content_type)
+          if mime_type.symbol == :zip
+            Operations::Import::Zip.new.call(change_set)
+          else
+            Operations::File::Save.new.call(change_set)
+          end
+        end
     end
   end
 end

--- a/app/cho/work/import/csv_dry_run.rb
+++ b/app/cho/work/import/csv_dry_run.rb
@@ -31,7 +31,7 @@ module Work
       end
 
       def bag
-        @bag ||= Transaction::Import::ImportFromZip.new.call(batch_id)
+        @bag ||= Transaction::Import::ImportFromZip.new.call(zip_name: batch_id)
       end
 
       private

--- a/spec/cho/transaction/operations/import/extract_spec.rb
+++ b/spec/cho/transaction/operations/import/extract_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Transaction::Operations::Import::Extract do
   let(:operation) { described_class.new }
 
   describe '#call' do
-    context 'when the zip file is successfully extracted' do
+    context 'with the name of the zip file' do
       let(:bag_path) { Pathname.new(ENV['extraction_directory']).expand_path.join('sample_zip') }
 
       before do
@@ -19,8 +19,25 @@ RSpec.describe Transaction::Operations::Import::Extract do
         ENV['network_ingest_directory'] = @network_ingest_directory
       end
 
-      it 'extracts the zip and returns Success' do
-        result = operation.call('sample_zip')
+      it 'successfully extracts the zip' do
+        result = operation.call(zip_name: 'sample_zip')
+        expect(result).to be_success
+        expect(result.success).to eq(bag_path)
+        expect(bag_path).to be_directory
+        expect(bag_path.join('data')).to be_directory
+        expect(bag_path.join('data', 'sample_object.txt')).to be_file
+        expect(bag_path.join('sample_file.txt')).to be_file
+      end
+    end
+
+    context 'with a full path to the zip file' do
+      let(:bag_path) { Pathname.new(ENV['extraction_directory']).expand_path.join('sample_zip') }
+      let(:zip_path) { Pathname.new(fixture_path).join('sample_zip.zip') }
+
+      before { FileUtils.rm_rf(bag_path) }
+
+      it 'successfully extracts the zip' do
+        result = operation.call(zip_path: zip_path)
         expect(result).to be_success
         expect(result.success).to eq(bag_path)
         expect(bag_path).to be_directory
@@ -34,10 +51,10 @@ RSpec.describe Transaction::Operations::Import::Extract do
       let(:path) { Rails.root.join('tmp', 'ingest-test', 'non-existent zip.zip') }
 
       it 'returns Failure' do
-        result = operation.call('non-existent zip')
+        result = operation.call(zip_name: 'non-existent zip')
         expect(result).to be_failure
         expect(result.failure).to eq(
-          "Error exacting the bag: File #{path} not found"
+          "Error extracting the bag: No such file or directory @ rb_sysopen - #{path}"
         )
       end
     end

--- a/spec/cho/transaction/shared/save_with_change_set_spec.rb
+++ b/spec/cho/transaction/shared/save_with_change_set_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Transaction::Shared::SaveWithChangeSet do
   describe '::steps' do
     subject { described_class.steps.map(&:name) }
 
-    it { is_expected.to contain_exactly(:validate, :save_file, :import_work, :save) }
+    it { is_expected.to contain_exactly(:validate, :process_file, :import_work, :save) }
   end
 
   it { is_expected.to respond_to(:call) }

--- a/spec/cho/work/submissions/new_spec.rb
+++ b/spec/cho/work/submissions/new_spec.rb
@@ -76,4 +76,35 @@ RSpec.describe Work::Submission, type: :feature do
       expect(page).to have_content('hello_world.txt')
     end
   end
+
+  context 'when attaching a zip file to the work' do
+    let!(:archival_collection) { create(:archival_collection, title: 'Collection with zipped work') }
+
+    let(:bag) do
+      ImportFactory::Bag.create(
+        batch_id: 'batch1_2018-09-10',
+        data: {
+          work1: ['work1_preservation.tif']
+        }
+      )
+    end
+
+    let(:zip_file) { ImportFactory::Zip.create(bag) }
+
+    it 'creates a new work object with files from zip' do
+      visit(root_path)
+      click_link('Create Work')
+      click_link('Generic')
+      expect(page).to have_content('New Generic Work')
+      fill_in('work_submission[title]', with: 'Work with attached zip')
+      fill_in('work_submission[member_of_collection_ids][]', with: archival_collection.id)
+      attach_file('File Selection', zip_file)
+      click_button('Create Work')
+      expect(page).to have_content('Work with attached zip')
+      expect(page).to have_content('Generic')
+      expect(page).to have_link('Edit')
+      expect(page).to have_selector('h2', text: 'Files')
+      expect(page).to have_content('work1_preservation.tif')
+    end
+  end
 end

--- a/spec/support/import_factory/zip.rb
+++ b/spec/support/import_factory/zip.rb
@@ -7,6 +7,7 @@ module ImportFactory
     def self.create(bag)
       output_file = Rails.root.join('tmp', 'ingest-test', "#{bag.path.basename}.zip")
       new(bag.path, output_file).write
+      output_file
     end
 
     attr_reader :input_dir, :output_file


### PR DESCRIPTION
## Description

Process zip uploads in the GUI as we do when we run csv import: import the zip files as bags and create the file sets and files contained within them.

Connected to #553 