### PR TITLE
Removing id attribute declaration

### DIFF
--- a/app/cho/collection/common_fields.rb
+++ b/app/cho/collection/common_fields.rb
@@ -8,7 +8,6 @@ module Collection::CommonFields
   VISIBILITY = ['public', 'authenticated', 'private'].freeze
 
   included do
-    attribute :id, Valkyrie::Types::ID.optional
     attribute :workflow, Valkyrie::Types::Set.of(Valkyrie::Types::String.enum(*WORKFLOW))
     attribute :visibility, Valkyrie::Types::Set.of(Valkyrie::Types::String.enum(*VISIBILITY))
   end

--- a/app/cho/data_dictionary/field.rb
+++ b/app/cho/data_dictionary/field.rb
@@ -13,7 +13,6 @@ module DataDictionary
     include WithIndexType
     include CommonQueries
 
-    attribute :id, Valkyrie::Types::ID.optional
     attribute :label, Valkyrie::Types::String
     attribute :default_value, Valkyrie::Types::String
     attribute :display_name, Valkyrie::Types::String

--- a/app/cho/schema/metadata.rb
+++ b/app/cho/schema/metadata.rb
@@ -7,7 +7,6 @@ module Schema
   class Metadata < Valkyrie::Resource
     include CommonQueries
 
-    attribute :id, Valkyrie::Types::ID.optional
     attribute :label, Valkyrie::Types::String
     attribute :core_fields, Valkyrie::Types::Array
     attribute :fields, Valkyrie::Types::Array

--- a/app/cho/work/file.rb
+++ b/app/cho/work/file.rb
@@ -6,7 +6,6 @@ class Work::File < Valkyrie::Resource
   include CommonQueries
   include WithUseType
 
-  attribute :id, Valkyrie::Types::ID.optional
   attribute :original_filename, Valkyrie::Types::String
   attribute :file_identifier, Valkyrie::Types::ID.optional
   attribute :fits_output, Valkyrie::Types::String

--- a/app/cho/work/file_set.rb
+++ b/app/cho/work/file_set.rb
@@ -7,6 +7,5 @@ class Work::FileSet < Valkyrie::Resource
   include CommonQueries
   include DataDictionary::FieldsForObject
 
-  attribute :id, Valkyrie::Types::ID.optional
   attribute :member_ids, Valkyrie::Types::Set.of(Valkyrie::Types::ID)
 end

--- a/app/cho/work/submission.rb
+++ b/app/cho/work/submission.rb
@@ -10,7 +10,6 @@ module Work
     include DataDictionary::FieldsForObject
     include CommonQueries
 
-    attribute :id, Valkyrie::Types::ID.optional
     attribute :work_type_id, Valkyrie::Types::ID.optional
 
     attribute :member_of_collection_ids, Valkyrie::Types::Set.of(Valkyrie::Types::ID)

--- a/app/cho/work/type.rb
+++ b/app/cho/work/type.rb
@@ -8,7 +8,6 @@ module Work
     include Valkyrie::Resource::AccessControls
     include CommonQueries
 
-    attribute :id, Valkyrie::Types::ID.optional
     attribute :label, Valkyrie::Types::String
     attribute :metadata_schema_id, Valkyrie::Types::ID.optional
     attribute :processing_schema, Valkyrie::Types::String

--- a/spec/cho/collection/with_members_spec.rb
+++ b/spec/cho/collection/with_members_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe Collection::WithMembers do
   before(:all) do
     class ParentResource < Valkyrie::Resource
       include Collection::WithMembers
-
-      attribute :id, Valkyrie::Types::ID.optional
     end
   end
 

--- a/spec/cho/shared/common_queries_spec.rb
+++ b/spec/cho/shared/common_queries_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CommonQueries do
   before(:all) do
     class CommonResource < Valkyrie::Resource
       include CommonQueries
-      attribute :id, Valkyrie::Types::ID.optional
+
       attribute :label, Valkyrie::Types::String
       attribute :other, Valkyrie::Types::String
       attribute :bool_val, Valkyrie::Types::Strict::Bool
@@ -14,7 +14,6 @@ RSpec.describe CommonQueries do
 
     class SampleResource < Valkyrie::Resource
       include CommonQueries
-      attribute :id, Valkyrie::Types::ID.optional
     end
   end
 

--- a/spec/valkyrie/find_model_spec.rb
+++ b/spec/valkyrie/find_model_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe FindModel do
 
   before(:all) do
     class SpecialModel < Valkyrie::Resource
-      attribute :id, Valkyrie::Types::ID.optional
     end
   end
 

--- a/spec/valkyrie/find_using_spec.rb
+++ b/spec/valkyrie/find_using_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe FindUsing do
     class SampleResource < Valkyrie::Resource
       include Valkyrie::Resource::AccessControls
       include DataDictionary::FieldsForObject
-      attribute :id, Valkyrie::Types::ID.optional
+
       attribute :framjam, Valkyrie::Types::String
       attribute :flimjam, Valkyrie::Types::String
     end
@@ -18,7 +18,7 @@ RSpec.describe FindUsing do
     class SimilarResource < Valkyrie::Resource
       include Valkyrie::Resource::AccessControls
       include DataDictionary::FieldsForObject
-      attribute :id, Valkyrie::Types::ID.optional
+
       attribute :framjam, Valkyrie::Types::String
     end
   end


### PR DESCRIPTION
# Description

The id attribute is now included in Valkyrie::Resource so we don't need to define it in our resources. This gets rid of some warnings during the test suite.
