### PR TITLE
Remove Files and Filesets from the Search Results

### DIFF
--- a/app/blacklight/search_builder.rb
+++ b/app/blacklight/search_builder.rb
@@ -2,12 +2,13 @@
 
 class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
+  self.default_processor_chain += [:show_only_works_and_collections]
 
-  ##
-  # @example Adding a new step to the processor chain
-  #   self.default_processor_chain += [:add_custom_data_to_query]
-  #
-  #   def add_custom_data_to_query(solr_parameters)
-  #     solr_parameters[:custom] = blacklight_params[:user_value]
-  #   end
+  # Do not include files and file sets in the search results
+  def show_only_works_and_collections(solr_parameters)
+    # add a new solr facet query ('fq') parameter that limits results to those with a 'public_b' field of 1
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] << 'internal_resource_ssim:("Collection::Archival" OR "Collection::Library"' \
+                             'OR "Collection::Curated" OR  "Work::Submission")'
+  end
 end

--- a/spec/blacklight/catalog_spec.rb
+++ b/spec/blacklight/catalog_spec.rb
@@ -4,4 +4,38 @@ require 'rails_helper'
 
 RSpec.describe CatalogController, type: :feature do
   it_behaves_like 'a search form', '/catalog'
+
+  context 'when searching for works' do
+    before { create(:work_submission, :with_file) }
+
+    it 'returns the work and excludes file sets and files' do
+      visit(root_path)
+      click_button('Search')
+      within('#documents') do
+        expect(page).to have_link('Sample Generic Work')
+        expect(page).not_to have_content('hello_world.txt')
+        expect(page).not_to have_content(Work::File.all.first.id)
+      end
+    end
+  end
+
+  context 'when searching for collections' do
+    before do
+      create(:archival_collection)
+      create(:curated_collection)
+      create(:library_collection)
+      create(:work_submission, :with_file)
+    end
+    it 'returns the collection and excludes file sets and files' do
+      visit(root_path)
+      click_button('Search')
+      within('#documents') do
+        expect(page).to have_link('Archival Collection')
+        expect(page).to have_link('Curated Collection')
+        expect(page).to have_link('Library Collection')
+        expect(page).not_to have_content('hello_world.txt')
+        expect(page).not_to have_content(Work::File.all.first.id)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description

Fixes: #498 

Why was this necessary?

Product owner requested that files and file sets are not returned in the listing of search results.

## Changes

Updates the blacklight search builder to filter on Collections and Works.

Are there any major changes in this PR that will change the release process? No

## Checklist

- [ ] i18n enabled
- [X] adequate test coverage
- [ ] accessible interface
