### PR TITLE
Don't rely on array orders when testing bags

### DIFF
--- a/app/cho/import/work.rb
+++ b/app/cho/import/work.rb
@@ -21,6 +21,10 @@ class Import::Work
     end
   end
 
+  def representative
+    file_sets.select(&:representative?).first
+  end
+
   def identifier
     path.basename.to_s
   end

--- a/spec/cho/import/bag_spec.rb
+++ b/spec/cho/import/bag_spec.rb
@@ -62,11 +62,11 @@ RSpec.describe Import::Bag do
 
     it do
       is_expected.not_to be_valid
-      expect(bag.errors.messages).to include(bag: [
-                                               'workID_service.jp2 cannot be under data',
-                                               'workID_text.txt cannot be under data',
-                                               'workID_thumb.jpg cannot be under data'
-                                             ])
+      expect(bag.errors.messages[:bag]).to include(
+        'workID_service.jp2 cannot be under data',
+        'workID_text.txt cannot be under data',
+        'workID_thumb.jpg cannot be under data'
+      )
     end
   end
 

--- a/spec/cho/import/work_spec.rb
+++ b/spec/cho/import/work_spec.rb
@@ -53,12 +53,11 @@ RSpec.describe Import::Work do
       expect(work.errors).to be_empty
       expect(work.files.count).to eq(12)
       expect(work.nested_works.count).to eq(0)
-      expect(work.file_sets.count).to eq(5)
-      expect(work.file_sets[0]).not_to be_representative
-      expect(work.file_sets[1]).not_to be_representative
-      expect(work.file_sets[2]).not_to be_representative
-      expect(work.file_sets[3]).not_to be_representative
-      expect(work.file_sets[4]).to be_representative
+      expect(work.file_sets.map(&:id)).to include('00001_01', '00001_02', '00002_01', '00002_02', nil)
+      expect(work.representative).to be_representative
+      expect(work.representative.files.map(&:original_filename)).to include(
+        'workID_service.pdf', 'workID_text.txt', 'workID_thumb.jpg'
+      )
     end
   end
 
@@ -83,10 +82,11 @@ RSpec.describe Import::Work do
       expect(work.errors).to be_empty
       expect(work.files.count).to eq(8)
       expect(work.nested_works.count).to eq(0)
-      expect(work.file_sets.count).to eq(3)
-      expect(work.file_sets[0]).not_to be_representative
-      expect(work.file_sets[1]).not_to be_representative
-      expect(work.file_sets[2]).to be_representative
+      expect(work.file_sets.map(&:id)).to include('00001', '00002', nil)
+      expect(work.representative).to be_representative
+      expect(work.representative.files.map(&:original_filename)).to include(
+        'workID_service.flac', 'workID_access.mp3', 'workID_text.txt', 'workID_thumb.jpg'
+      )
     end
   end
 


### PR DESCRIPTION
## Description

The order of the file sets present in the work was affecting certain
test runs. This refactors the tests to check for the different file set
ids as well as their representative without having to rely on the order
in which they are returned.

Additionally, the order of error messages in the bag is no longer being
tested.