### PR TITLE
Import file identifier should include the work id

### DIFF
--- a/app/cho/import/file.rb
+++ b/app/cho/import/file.rb
@@ -44,13 +44,13 @@ class Import::File
 
   # @return [String] inner most parts of the file
   # @example
-  #   Given a filename workID_00002_02_preservation.tif, the returned id would be 00002_02
+  #   Given a filename workID_00002_02_preservation.tif, the returned id would be workID_00002_02
   #   A filename such as workID_preservation.tif has no file set id.
   def file_set_id
     @file_set_id ||= begin
                        return if parts.count == 2
-                       inner_parts = parts.slice(1..-2)
-                       inner_parts.join(Import::Bag::FILENAME_SEPARATOR)
+                       parts.pop
+                       parts.join(Import::Bag::FILENAME_SEPARATOR)
                      end
   end
 

--- a/spec/cho/import/file_set_spec.rb
+++ b/spec/cho/import/file_set_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Import::FileSet do
   describe '#id' do
     let(:files) { [ImportFactory::File.create('work1234_0001_preservation.tif')] }
 
-    its(:id) { is_expected.to eq('0001') }
+    its(:id) { is_expected.to eq('work1234_0001') }
   end
 
   describe '#to_s' do

--- a/spec/cho/import/file_spec.rb
+++ b/spec/cho/import/file_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Import::File do
     context 'with a file in a set' do
       subject { ImportFactory::File.create('workID_0001_preservation.tif') }
 
-      its(:file_set_id) { is_expected.to eq('0001') }
+      its(:file_set_id) { is_expected.to eq('workID_0001') }
     end
   end
 

--- a/spec/cho/import/work_spec.rb
+++ b/spec/cho/import/work_spec.rb
@@ -53,7 +53,13 @@ RSpec.describe Import::Work do
       expect(work.errors).to be_empty
       expect(work.files.count).to eq(12)
       expect(work.nested_works.count).to eq(0)
-      expect(work.file_sets.map(&:id)).to include('00001_01', '00001_02', '00002_01', '00002_02', nil)
+      expect(work.file_sets.map(&:id)).to include(
+        'workID_00001_01',
+        'workID_00001_02',
+        'workID_00002_01',
+        'workID_00002_02',
+        nil
+      )
       expect(work.representative).to be_representative
       expect(work.representative.files.map(&:original_filename)).to include(
         'workID_service.pdf', 'workID_text.txt', 'workID_thumb.jpg'
@@ -82,7 +88,7 @@ RSpec.describe Import::Work do
       expect(work.errors).to be_empty
       expect(work.files.count).to eq(8)
       expect(work.nested_works.count).to eq(0)
-      expect(work.file_sets.map(&:id)).to include('00001', '00002', nil)
+      expect(work.file_sets.map(&:id)).to include('workID_00001', 'workID_00002', nil)
       expect(work.representative).to be_representative
       expect(work.representative.files.map(&:original_filename)).to include(
         'workID_service.flac', 'workID_access.mp3', 'workID_text.txt', 'workID_thumb.jpg'
@@ -269,7 +275,9 @@ RSpec.describe Import::Work do
 
     it do
       expect(work).not_to be_valid
-      expect(work.errors.messages).to include(file_sets: ['00001_01 does not have a service or preservation file'])
+      expect(work.errors.messages).to include(
+        file_sets: ['workID_00001_01 does not have a service or preservation file']
+      )
     end
   end
 


### PR DESCRIPTION
## Description

The identifier for an import work needs to include the work id as well
as its other numeric indicators. This is so it will map to the
identifier that is used in csv import.

Connected to #582