### PR TITLE
Make import_work a virtual property

### DIFF
--- a/app/cho/work/submission_change_set.rb
+++ b/app/cho/work/submission_change_set.rb
@@ -27,10 +27,10 @@ module Work
     # File submitted via the GUI upload
     property :file, multiple: false, required: false
 
+    property :import_work, virtual: true, required: false, multiple: false
+
     include DataDictionary::FieldsForChangeSet
     include WithValidMembers
-
-    attr_accessor :import_work
 
     delegate :url_helpers, to: 'Rails.application.routes'
 

--- a/spec/cho/work/submissions/change_set_spec.rb
+++ b/spec/cho/work/submissions/change_set_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe Work::SubmissionChangeSet do
     its(:member_of_collection_ids) { is_expected.to be_empty }
     its(:file_set_ids) { is_expected.to be_empty }
     its(:batch_id) { is_expected.to be_nil }
+    its(:import_work) { is_expected.to be_nil }
   end
 
   describe '#validate' do


### PR DESCRIPTION
## Description

Using Reform's virtual property features, we can make import_work
defined as a property on the change set only, and not pass it on to the
resource.

Connected to #582