### PR TITLE
Apply CSV metadata to FileSet

### DIFF
--- a/app/cho/work/file_set_change_set.rb
+++ b/app/cho/work/file_set_change_set.rb
@@ -3,7 +3,6 @@
 module Work
   class FileSetChangeSet < Valkyrie::ChangeSet
     validates :member_ids, with: :validate_members!
-    validates :member_ids, presence: true
     property :member_ids,
              multiple: true,
              required: false,

--- a/app/cho/work/import/csv_dry_run.rb
+++ b/app/cho/work/import/csv_dry_run.rb
@@ -55,7 +55,23 @@ module Work
           return if bag.failure?
 
           results.each do |change_set|
-            change_set.import_work = bag.success.works.select { |work| work.identifier == change_set.identifier }.first
+            import_work = bag.success.works.select { |work| work.identifier == change_set.identifier }.first
+            change_set.import_work = import_work
+            change_set.file_set_hashes = build_import_file_sets(import_work).compact if import_work.present?
+          end
+        end
+
+        def build_import_file_sets(import_work)
+          import_work.file_sets.map do |file_set|
+            file_set_hash = file_set_metadata(file_set.id).first
+            next if file_set_hash.nil?
+            FileSetHashValidator.new(file_set_hash).change_set
+          end
+        end
+
+        def file_set_metadata(file_set_id)
+          reader.file_set_hashes.select do |file_set|
+            file_set.fetch('identifier') == file_set_id
           end
         end
 

--- a/app/cho/work/import/csv_reader.rb
+++ b/app/cho/work/import/csv_reader.rb
@@ -9,12 +9,20 @@ module Work
 
       attr_reader :headers, :csv_hashes
 
-      delegate :each, :map, to: :csv_hashes
+      delegate :each, :map, to: :work_hashes
 
       def initialize(csv_file)
         csv_data = ::CSV.parse(csv_file)
         @headers = csv_data.shift
         @csv_hashes = csv_data.map { |a| Hash[@headers.zip(format_csv_data(a))] }
+      end
+
+      def work_hashes
+        csv_hashes.reject { |hash| hash.fetch('member_of_collection_ids').nil? }
+      end
+
+      def file_set_hashes
+        csv_hashes.select { |hash| hash.fetch('member_of_collection_ids').nil? }
       end
 
       private

--- a/app/cho/work/import/file_set_hash_validator.rb
+++ b/app/cho/work/import/file_set_hash_validator.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# Validates a file set hash using the Work::FileSetChangeSet
+#
+# @example file_set_hash
+#    {'title'=>'my awesome work', 'description'=> 'some description'}
+module Work
+  module Import
+    class FileSetHashValidator
+      attr_reader :change_set, :file_set_hash
+
+      def initialize(file_set_hash)
+        @file_set_hash = file_set_hash
+        @change_set = build_change_set
+        @change_set.validate(file_set_hash)
+      end
+
+      private
+
+        def updating?
+          file_set_hash.key?('id')
+        end
+
+        def build_change_set
+          if file_set.nil?
+            MissingChangeSet.new(MissingResource.new)
+          else
+            FileSetChangeSet.new(file_set)
+          end
+        end
+
+        def file_set
+          @file_set ||= if updating?
+                          FileSet.find(Valkyrie::ID.new(file_set_hash['id']))
+                        else
+                          FileSet.new
+                        end
+        end
+
+        class MissingResource < Valkyrie::Resource
+        end
+
+        class MissingChangeSet < Valkyrie::ChangeSet
+          def errors
+            current_errors = super
+            current_errors.add(:id, 'does not exist') unless current_errors.key?(:id)
+            current_errors
+          end
+
+          def valid?
+            false
+          end
+        end
+    end
+  end
+end

--- a/app/cho/work/import/work_hash_validator.rb
+++ b/app/cho/work/import/work_hash_validator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Validates a work hash using the Work::Submission::ChangeSet
+# Validates a work hash using the Work::SubmissionChangeSet
 #
 # @example work_hash
 #    {'member_of_collection_ids'=>'abc-123', 'work_type_id'=>'def-222', 'title'=>'my awesome work', 'description'=> ''}

--- a/app/cho/work/submission_change_set.rb
+++ b/app/cho/work/submission_change_set.rb
@@ -29,6 +29,13 @@ module Work
 
     property :import_work, virtual: true, required: false, multiple: false
 
+    property :file_set_hashes,
+             virtual: true,
+             multiple: true,
+             required: false,
+             default: [],
+             type: Types::Strict::Array
+
     include DataDictionary::FieldsForChangeSet
     include WithValidMembers
 

--- a/spec/cho/work/file_set_change_set_spec.rb
+++ b/spec/cho/work/file_set_change_set_spec.rb
@@ -42,12 +42,6 @@ RSpec.describe Work::FileSetChangeSet do
       its(:full_messages) { is_expected.to include('Member ids nothere does not exist') }
     end
 
-    context 'without members' do
-      let(:params) { { member_ids: [] } }
-
-      its(:full_messages) { is_expected.to include("Member ids can't be blank") }
-    end
-
     context 'with all required fields' do
       let(:file) { create :work_file }
       let(:params) { { title: 'filename.txt', member_ids: [file.id] } }

--- a/spec/cho/work/import/csv_controller_spec.rb
+++ b/spec/cho/work/import/csv_controller_spec.rb
@@ -63,10 +63,9 @@ RSpec.describe Work::Import::CsvController, type: :controller do
         expect(call).to render_template('dry_run_results')
         expect(response).to be_success
         expect(assigns(:presenter)).to be_a(Work::Import::CsvDryRunResultsPresenter)
-        expect(assigns(:presenter).change_set_list.map(&:valid?)).to eq([false, false, false])
+        expect(assigns(:presenter).change_set_list.map(&:valid?)).to eq([false, false])
         expect(assigns(:presenter).change_set_list.map(&:errors).map(&:messages)).to eq(
           [
-            { member_of_collection_ids: ["can't be blank"] },
             { work_type_id: ["can't be blank"] },
             { member_of_collection_ids: ['bad does not exist'], title: ["can't be blank"] }
           ]

--- a/spec/cho/work/import/csv_reader_spec.rb
+++ b/spec/cho/work/import/csv_reader_spec.rb
@@ -4,9 +4,12 @@ require 'rails_helper'
 
 RSpec.describe Work::Import::CsvReader do
   let(:reader) { described_class.new(csv_file) }
-  let(:csv_file) { StringIO.new("header1,header2\ndata1,data2\ndataA,dataB") }
+  let(:csv_file) { StringIO.new("id,member_of_collection_ids\ndata1,data2\ndataA,dataB") }
   let(:csv_hash) do
-    [{ 'header1' => 'data1', 'header2' => 'data2' }, { 'header1' => 'dataA', 'header2' => 'dataB' }]
+    [
+      { 'id' => 'data1', 'member_of_collection_ids' => 'data2' },
+      { 'id' => 'dataA', 'member_of_collection_ids' => 'dataB' }
+    ]
   end
 
   describe '#each' do
@@ -31,7 +34,7 @@ RSpec.describe Work::Import::CsvReader do
   describe '#headers' do
     subject { reader.headers }
 
-    it { is_expected.to eq(['header1', 'header2']) }
+    it { is_expected.to eq(['id', 'member_of_collection_ids']) }
   end
 
   describe '#csv_hashes' do
@@ -47,5 +50,17 @@ RSpec.describe Work::Import::CsvReader do
 
       it { is_expected.to eq(csv_hash) }
     end
+  end
+
+  context 'with one work and multiple file sets' do
+    subject { reader }
+
+    let(:csv_file) { StringIO.new("id,member_of_collection_ids\nworkID,1\nworkID_01_01,\nworkID_01_02,") }
+
+    its(:work_hashes) { is_expected.to contain_exactly('id' => 'workID', 'member_of_collection_ids' => '1') }
+    its(:file_set_hashes) { is_expected.to contain_exactly(
+      { 'id' => 'workID_01_01', 'member_of_collection_ids' => nil },
+      'id' => 'workID_01_02', 'member_of_collection_ids' => nil
+    )}
   end
 end

--- a/spec/cho/work/import/file_set_hash_validator_spec.rb
+++ b/spec/cho/work/import/file_set_hash_validator_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Work::Import::FileSetHashValidator do
+  let(:validator) { described_class.new(file_set_hash) }
+
+  describe '#change_set' do
+    subject(:change_set) { validator.change_set }
+
+    context 'with a new file set' do
+      let(:file_set_hash) do
+        {
+          'title' => 'My Great File',
+          'description' => 'Best description ever.'
+        }
+      end
+
+      it 'is valid' do
+        expect(change_set).to be_a(Work::FileSetChangeSet)
+        expect(change_set).to be_valid
+        expect(change_set.model).to be_a(Work::FileSet)
+        expect(change_set.title).to eq('My Great File')
+        expect(change_set.description).to eq('Best description ever.')
+      end
+    end
+
+    context 'invalid new file set' do
+      let(:file_set_hash) { {} }
+
+      it 'is not valid and has errors' do
+        expect(change_set).not_to be_valid
+        expect(change_set.errors.full_messages).to eq(["Title can't be blank"])
+      end
+    end
+
+    context 'with an existing file set' do
+      let(:file_set) { create(:file_set) }
+
+      let(:file_set_hash) do
+        {
+          'id' => file_set.id,
+          'title' => 'my awesome updated file_set',
+          'description' => 'updated description'
+        }
+      end
+
+      it 'is valid and has an id' do
+        expect(change_set).to be_a(Work::FileSetChangeSet)
+        expect(change_set).to be_valid
+        expect(change_set.model).to be_a(Work::FileSet)
+        expect(change_set.id).to eq(file_set.id)
+      end
+    end
+
+    context 'with a non-existent file_set' do
+      let(:file_set_hash) do
+        {
+          'id' => 'foo',
+          'title' => 'my awesome updated file_set',
+          'description' => 'updated description'
+        }
+      end
+
+      it 'is not valid and has errors' do
+        expect(change_set).not_to be_valid
+        expect(change_set.errors.full_messages).to eq(['Id does not exist'])
+      end
+    end
+  end
+end

--- a/spec/cho/work/submissions/change_set_spec.rb
+++ b/spec/cho/work/submissions/change_set_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe Work::SubmissionChangeSet do
     its(:file_set_ids) { is_expected.to be_empty }
     its(:batch_id) { is_expected.to be_nil }
     its(:import_work) { is_expected.to be_nil }
+    its(:file_set_hashes) { is_expected.to be_empty }
   end
 
   describe '#validate' do


### PR DESCRIPTION
## Description

When importing works that contain file sets, read the metadata for each
file set from the provided csv. We can determine if a row of the csv is
a file set or work and then pass this information on to the transaction
which will apply the metadata when creating the file set.

Connected to #582 

## Changes

1. File sets' member ids are no longer required. This means that we can create a file set without any files, which seems reasonable. In this case, we want to validate the file set's metadata as it's coming our of the csv, so it won't have any files attached to it yet.

2. CsvReader is more domain-specific. Because a line in a csv could either be a work or a file set, it seemed to make sense for the CsvReader to make that distinction. The downside is that the reader now needs to know more specific things about which columns are in the file.

3. SubmissionChangeSet as more virtual properties. This is better than just `attr_accessors` but adds a little more cognitive mass to the change set. It seems like a reasonable addition given that we're already passing import works along as well.

4. `member_of_collection_ids` is no longer required. The determining factor between whether or not a csv row is a work or file set is the presence or absence of the collection id. So, the csv can have empty collection id fields.