### PR TITLE
Fixing Import::File

### DIFF
--- a/spec/cho/import/file_set_spec.rb
+++ b/spec/cho/import/file_set_spec.rb
@@ -17,12 +17,32 @@ RSpec.describe Import::FileSet do
 
       it { is_expected.not_to be_representative }
     end
+
+    context 'with a representative of a multipart work id' do
+      let(:files) { [ImportFactory::File.create('work12_34_0001_preservation.tif', parent: 'work12_34')] }
+
+      it { is_expected.not_to be_representative }
+    end
+
+    context 'with a non-representative of a multipart work id' do
+      let(:files) { [ImportFactory::File.create('work12_34_preservation.tif', parent: 'work12_34')] }
+
+      it { is_expected.to be_representative }
+    end
   end
 
   describe '#id' do
-    let(:files) { [ImportFactory::File.create('work1234_0001_preservation.tif')] }
+    context 'with a simple file' do
+      let(:files) { [ImportFactory::File.create('work1234_0001_preservation.tif')] }
 
-    its(:id) { is_expected.to eq('work1234_0001') }
+      its(:id) { is_expected.to eq('work1234_0001') }
+    end
+
+    context 'with a multipart work id' do
+      let(:files) { [ImportFactory::File.create('work12_34_0001_preservation.tif', parent: 'work12_34')] }
+
+      its(:id) { is_expected.to eq('work12_34_0001') }
+    end
   end
 
   describe '#to_s' do

--- a/spec/cho/import/file_spec.rb
+++ b/spec/cho/import/file_spec.rb
@@ -5,125 +5,131 @@ require 'rails_helper'
 RSpec.describe Import::File do
   describe '#type' do
     context 'with a preservation file' do
-      subject { ImportFactory::File.create('workID_preservation.tif') }
+      subject { ImportFactory::File.create('work_ID_preservation.tif', parent: 'work_ID') }
 
       its(:type) { is_expected.to be(Valkyrie::Vocab::PCDMUse.PreservationMasterFile) }
     end
 
     context 'with an extracted text file' do
-      subject { ImportFactory::File.create('workID_text.txt') }
+      subject { ImportFactory::File.create('work_ID_text.txt', parent: 'work_ID') }
 
       its(:type) { is_expected.to be(Valkyrie::Vocab::PCDMUse.ExtractedText) }
     end
 
     context 'with a redacted preservation file' do
-      subject { ImportFactory::File.create('workID_preservation-redacted.tif') }
+      subject { ImportFactory::File.create('work_ID_preservation-redacted.tif', parent: 'work_ID') }
 
       its(:type) { is_expected.to be(Vocab::FileUse.RedactedPreservationMasterFile) }
     end
 
     context 'with an access file' do
-      subject { ImportFactory::File.create('workID_access.jpg') }
+      subject { ImportFactory::File.create('work_ID_access.jpg', parent: 'work_ID') }
 
       its(:type) { is_expected.to be(Vocab::FileUse.AccessFile) }
     end
 
     context 'with a service file' do
-      subject { ImportFactory::File.create('workID_service.jp2') }
+      subject { ImportFactory::File.create('work_ID_service.jp2', parent: 'work_ID') }
 
       its(:type) { is_expected.to be(Valkyrie::Vocab::PCDMUse.ServiceFile) }
     end
 
     context 'with a thumbnail image file' do
-      subject { ImportFactory::File.create('workID_thumb.jpg') }
+      subject { ImportFactory::File.create('work_ID_thumb.jpg', parent: 'work_ID') }
 
       its(:type) { is_expected.to be(Valkyrie::Vocab::PCDMUse.ThumbnailImage) }
     end
 
     context 'with a front image file' do
-      subject { ImportFactory::File.create('workID_front.jpg') }
+      subject { ImportFactory::File.create('work_ID_front.jpg', parent: 'work_ID') }
 
       its(:type) { is_expected.to be(Vocab::FileUse.FrontImage) }
     end
 
     context 'with a back image file' do
-      subject { ImportFactory::File.create('workID_back.jpg') }
+      subject { ImportFactory::File.create('work_ID_back.jpg', parent: 'work_ID') }
 
       its(:type) { is_expected.to be(Vocab::FileUse.BackImage) }
     end
 
     context 'with an unsupported type' do
-      let(:file) { ImportFactory::File.create('workID_unsupported.jpg') }
+      let(:file) { ImportFactory::File.create('work_ID_unsupported.jpg', parent: 'work_ID') }
 
       it 'raises an error' do
         expect {
           file.type
-        }.to raise_error(Import::File::UnknownFileTypeError, 'workID_unsupported.jpg does not have a valid file type')
+        }.to raise_error(Import::File::UnknownFileTypeError, 'work_ID_unsupported.jpg does not have a valid file type')
       end
     end
   end
 
   describe '#valid?' do
     context 'when the object id does not match the parent directory' do
-      subject { ImportFactory::File.create('wrongID_preservation.tif', parent: 'workID') }
+      subject { ImportFactory::File.create('wrongID_preservation.tif', parent: 'work_ID') }
 
       it { is_expected.not_to be_valid }
     end
 
     context 'when the object does not have a valid file type' do
-      subject { ImportFactory::File.create('workID_unsupported.jpg') }
+      subject { ImportFactory::File.create('work_ID_unsupported.jpg', parent: 'work_ID') }
 
       it { is_expected.not_to be_valid }
     end
   end
 
   describe '#work_id' do
-    subject { ImportFactory::File.create('workID_preservation.tif') }
+    subject { ImportFactory::File.create('work_ID_preservation.tif', parent: 'work_ID') }
 
-    its(:work_id) { is_expected.to eq('workID') }
+    its(:work_id) { is_expected.to eq('work_ID') }
   end
 
   describe '#suffix' do
-    subject { ImportFactory::File.create('workID_preservation.tif') }
+    subject { ImportFactory::File.create('work_ID_preservation.tif', parent: 'work_ID') }
 
     its(:suffix) { is_expected.to eq('preservation') }
   end
 
   describe '#file_set_id' do
     context 'with a simple file' do
-      subject { ImportFactory::File.create('workID_preservation.tif') }
+      subject { ImportFactory::File.create('work_ID_preservation.tif', parent: 'work_ID') }
 
       its(:file_set_id) { is_expected.to be_nil }
     end
 
     context 'with a file in a set' do
-      subject { ImportFactory::File.create('workID_0001_preservation.tif') }
+      subject { ImportFactory::File.create('work_ID_0001_preservation.tif', parent: 'work_ID') }
 
-      its(:file_set_id) { is_expected.to eq('workID_0001') }
+      its(:file_set_id) { is_expected.to eq('work_ID_0001') }
+    end
+
+    context 'with a complex work and file set' do
+      subject { ImportFactory::File.create('xyz_1234_work_ID_0001_03_preservation.tif', parent: 'xyz_1234_work_ID') }
+
+      its(:file_set_id) { is_expected.to eq('xyz_1234_work_ID_0001_03') }
     end
   end
 
   describe '#to_s' do
-    subject { ImportFactory::File.create('workID_0001_preservation.tif') }
+    subject { ImportFactory::File.create('work_ID_0001_preservation.tif', parent: 'work_ID') }
 
-    its(:to_s) { is_expected.to eq('workID_0001_preservation.tif') }
+    its(:to_s) { is_expected.to eq('work_ID_0001_preservation.tif') }
   end
 
   describe '#path' do
-    subject { ImportFactory::File.create('workID_0001_preservation.tif') }
+    subject { ImportFactory::File.create('work_ID_0001_preservation.tif', parent: 'work_ID') }
 
-    its(:path) { is_expected.to eq(Rails.root.join('tmp', 'workID', 'workID_0001_preservation.tif').to_s) }
+    its(:path) { is_expected.to eq(Rails.root.join('tmp', 'work_ID', 'work_ID_0001_preservation.tif').to_s) }
   end
 
   describe '#service?' do
     context 'with a service file' do
-      subject { ImportFactory::File.create('workID_0001_service.jp2') }
+      subject { ImportFactory::File.create('work_ID_0001_service.jp2', parent: 'work_ID') }
 
       it { is_expected.to be_service }
     end
 
     context 'with a non-service file' do
-      subject { ImportFactory::File.create('workID_0001_preservation.tif') }
+      subject { ImportFactory::File.create('work_ID_0001_preservation.tif', parent: 'work_ID') }
 
       it { is_expected.not_to be_service }
     end
@@ -131,13 +137,13 @@ RSpec.describe Import::File do
 
   describe '#preservation?' do
     context 'with a preservation file' do
-      subject { ImportFactory::File.create('workID_0001_preservation.tif') }
+      subject { ImportFactory::File.create('work_ID_0001_preservation.tif', parent: 'work_ID') }
 
       it { is_expected.to be_preservation }
     end
 
     context 'with a non-preservation file' do
-      subject { ImportFactory::File.create('workID_0001_access.jpg') }
+      subject { ImportFactory::File.create('work_ID_0001_access.jpg', parent: 'work_ID') }
 
       it { is_expected.not_to be_preservation }
     end
@@ -145,13 +151,13 @@ RSpec.describe Import::File do
 
   describe '#representative?' do
     context 'with a representative file' do
-      subject { ImportFactory::File.create('workID_preservation.tif') }
+      subject { ImportFactory::File.create('work_ID_preservation.tif', parent: 'work_ID') }
 
       it { is_expected.to be_representative }
     end
 
     context 'with a non-representative file' do
-      subject { ImportFactory::File.create('workID_0001_access.jpg') }
+      subject { ImportFactory::File.create('work_ID_0001_access.jpg', parent: 'work_ID') }
 
       it { is_expected.not_to be_representative }
     end

--- a/spec/cho/import/work_spec.rb
+++ b/spec/cho/import/work_spec.rb
@@ -183,10 +183,10 @@ RSpec.describe Import::Work do
       expect(work.nested_works.count).to eq(2)
       expect(work.nested_works.first.files.count).to eq(3)
       expect(work.nested_works.first.file_sets.count).to eq(1)
-      expect(work.nested_works.first.file_sets.first).not_to be_representative
+      expect(work.nested_works.first.file_sets.first).to be_representative
       expect(work.nested_works.last.files.count).to eq(3)
       expect(work.nested_works.last.file_sets.count).to eq(1)
-      expect(work.nested_works.last.file_sets.first).not_to be_representative
+      expect(work.nested_works.last.file_sets.first).to be_representative
     end
   end
 


### PR DESCRIPTION
## Description

Files in bags will have ids with multiple underscore-delimited segments. In order to determine the use type and file set id, the parent directory name can be used to remove the first N number of segments and the remaining segments can be used to determine file set id and use type.

Fixes #655 