### PR TITLE
Adds revision Info to the Footer

### DIFF
--- a/app/assets/stylesheets/cho.scss
+++ b/app/assets/stylesheets/cho.scss
@@ -1,3 +1,3 @@
 @charset "UTF-8";
 
-@import 'cho/variables', 'cho/blacklight', 'cho/data_dictionary_fields', 'cho/facets', 'cho/form', 'cho/scaffolds';
+@import 'cho/variables', 'cho/blacklight', 'cho/data_dictionary_fields', 'cho/facets', 'cho/footer', 'cho/form', 'cho/scaffolds';

--- a/app/assets/stylesheets/cho/footer.scss
+++ b/app/assets/stylesheets/cho/footer.scss
@@ -1,0 +1,15 @@
+.footer {
+  padding: 1rem;
+
+  a:link,
+  a:visited,
+  a:hover,
+  p,
+  span {
+    color: $primary-white;
+  }
+}
+
+.footer-logo {
+  font-size: 1.5rem;
+}

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,0 +1,7 @@
+<footer class="footer bg-dark">
+  <a href="/" class="footer-logo">Cultural Heritage Objects</a>
+  <p class="footer-service">A service of the University Libraries</p>
+  <% if Git.revision %>
+    <p>Current Revision: <%= link_to Git.revision, "https://github.com/psu-libraries/cho/commit/#{Git.revision}" %></p>
+  <% end %>
+</footer>

--- a/config/initializers/git_revision.rb
+++ b/config/initializers/git_revision.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Git
+  class << self
+    def revision
+      @revision ||= git_revision
+    end
+
+    private
+
+      def git_revision
+        return unless Rails.root.join('REVISION').exist?
+        Rails.root.join('REVISION').read.chomp
+      end
+  end
+end

--- a/spec/views/footer.html.erb_spec.rb
+++ b/spec/views/footer.html.erb_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'shared/_footer', type: :view do
+  before do
+    Rails.root.join('REVISION').write('current_commit')
+    render
+  end
+
+  after do
+    Rails.root.join('REVISION').delete
+  end
+
+  it 'displays the link to the commit in the footer' do
+    expect(rendered).to have_content 'current_commit'
+  end
+end


### PR DESCRIPTION
Adds footer partial and style sheet and a module for the display of the commits in Git. Adds a test for the inclusion of the revision info in the footer.

## Description

Fixes #648

Why was this necessary?

## Changes

Are there any major changes in this PR that will change the release process?

## Checklist

- [ ] i18n enabled
- [ ] adequate test coverage
- [ ] accessible interface
