### PR TITLE
Define resource and change set property types for fields

### DIFF
--- a/app/cho/data_dictionary/field.rb
+++ b/app/cho/data_dictionary/field.rb
@@ -20,13 +20,23 @@ module DataDictionary
     attribute :help_text, Valkyrie::Types::String
     attribute :core_field, Valkyrie::Types::Strict::Bool
 
+    def self.core_fields
+      @core_fields ||= where(core_field: true).sort_by(&:created_at)
+    end
+
     def multiple?
       return false if multiple.nil?
       multiple
     end
 
-    def self.core_fields
-      @core_fields ||= where(core_field: true).sort_by(&:created_at)
+    # @return [Valkyrie::Types] property type for the Valkyrie::ChangeSet
+    def change_set_property_type
+      Valkyrie::Types::Set.optional
+    end
+
+    # @return [Valkyrie::Types] property type for the Valkyrie::Resource
+    def resource_property_type
+      Valkyrie::Types::Set.meta(ordered: true)
     end
 
     # @note This defined how the field should be addressed when creating dynamic methods for access

--- a/app/cho/data_dictionary/fields_for_change_set.rb
+++ b/app/cho/data_dictionary/fields_for_change_set.rb
@@ -11,7 +11,11 @@ module DataDictionary::FieldsForChangeSet
     #   This statement makes sure the rails environment can be loaded even if the database has yet to be created.
     if ActiveRecord::Base.connection.table_exists? 'orm_resources'
       DataDictionary::Field.all.each do |field|
-        property field.label.parameterize.underscore.to_sym, multiple: field.multiple?, required: field.required?
+        property field.label.parameterize.underscore.to_sym,
+                 multiple: field.multiple?,
+                 required: field.required?,
+                 type: field.change_set_property_type
+
         validates field.label.parameterize.underscore.to_sym, presence: field.required?
       end
     end

--- a/app/cho/data_dictionary/fields_for_object.rb
+++ b/app/cho/data_dictionary/fields_for_object.rb
@@ -19,8 +19,9 @@ module DataDictionary::FieldsForObject
         # Code reloading errors may cause this block to be run twice in
         # development - this prevents an error regarding an attribute being
         # defined twice.
+
         next if schema.keys.include?(field.label.parameterize.underscore.to_sym)
-        attribute field.label.parameterize.underscore.to_sym, Valkyrie::Types::Set.meta(ordered: true)
+        attribute field.label.parameterize.underscore.to_sym, field.resource_property_type
       end
     end
   end

--- a/app/cho/work/import/csv_dry_run.rb
+++ b/app/cho/work/import/csv_dry_run.rb
@@ -55,7 +55,7 @@ module Work
           return if bag.failure?
 
           results.each do |change_set|
-            import_work = bag.success.works.select { |work| work.identifier == change_set.identifier }.first
+            import_work = bag.success.works.select { |work| work.identifier == change_set.identifier.first }.first
             change_set.import_work = import_work
             change_set.file_set_hashes = build_import_file_sets(import_work).compact if import_work.present?
           end

--- a/app/views/work/import/csv/_dry_run_result.html.erb
+++ b/app/views/work/import/csv/_dry_run_result.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td><%= dry_run_result.title || 'Title is Missing' %></td>
+  <td><%= (dry_run_result.title || ['Title is Missing']).first %></td>
   <td>
     <% if dry_run_result.errors.present? %>
       <%= render 'dry_run_error_list', errors: dry_run_result.errors.full_messages %>

--- a/spec/cho/work/import/csv_dry_run_spec.rb
+++ b/spec/cho/work/import/csv_dry_run_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Work::Import::CsvDryRun do
         is_expected.to be_a Array
         expect(dry_run_results.count).to eq(1)
         expect(dry_run_results.first).to be_valid
-        expect(dry_run_results.first.title).to eq('My Awesome Work')
+        expect(dry_run_results.first.title).to eq(['My Awesome Work'])
       end
     end
 
@@ -195,8 +195,8 @@ RSpec.describe Work::Import::CsvDryRun do
       it 'adds the import work to the change set' do
         expect(dry_run.results.count).to eq(1)
         expect(dry_run.results.first).to be_valid
-        expect(dry_run.results.first.title).to eq('My Awesome Work')
-        expect(dry_run.results.first.identifier).to eq('work1')
+        expect(dry_run.results.first.title).to eq(['My Awesome Work'])
+        expect(dry_run.results.first.identifier).to eq(['work1'])
         expect(dry_run.bag).to be_a(Dry::Monads::Result::Success)
         expect(dry_run.results.first.import_work.identifier).to eq('work1')
       end
@@ -229,8 +229,8 @@ RSpec.describe Work::Import::CsvDryRun do
       it 'does not have an import work' do
         expect(dry_run.results.count).to eq(1)
         expect(dry_run.results.first).to be_valid
-        expect(dry_run.results.first.title).to eq('My Awesome Work')
-        expect(dry_run.results.first.identifier).to eq('work1')
+        expect(dry_run.results.first.title).to eq(['My Awesome Work'])
+        expect(dry_run.results.first.identifier).to eq(['work1'])
         expect(dry_run.bag).to be_a(Dry::Monads::Result::Success)
         expect(dry_run.results.first.import_work).to be_nil
       end
@@ -252,8 +252,8 @@ RSpec.describe Work::Import::CsvDryRun do
       it 'does not have an import work' do
         expect(dry_run.results.count).to eq(1)
         expect(dry_run.results.first).to be_valid
-        expect(dry_run.results.first.title).to eq('My Awesome Work')
-        expect(dry_run.results.first.identifier).to eq('work1')
+        expect(dry_run.results.first.title).to eq(['My Awesome Work'])
+        expect(dry_run.results.first.identifier).to eq(['work1'])
         expect(dry_run.bag).to be_a(Dry::Monads::Result::Failure)
         expect(dry_run.results.first.import_work).to be_nil
       end

--- a/spec/cho/work/import/file_set_hash_validator_spec.rb
+++ b/spec/cho/work/import/file_set_hash_validator_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe Work::Import::FileSetHashValidator do
         expect(change_set).to be_a(Work::FileSetChangeSet)
         expect(change_set).to be_valid
         expect(change_set.model).to be_a(Work::FileSet)
-        expect(change_set.title).to eq('My Great File')
-        expect(change_set.description).to eq('Best description ever.')
+        expect(change_set.title).to eq(['My Great File'])
+        expect(change_set.description).to eq(['Best description ever.'])
       end
     end
 


### PR DESCRIPTION
## Description

Adds methods to DataDictionary::Field to return the specific Valkyrie::Type for a given field when it is assigned to either a resource or a change set.

Connected to #443

## Changes

* adds `change_set_property_type` and `resource_property_type` methods to DataDictionary::Field
* fixes a latent bug in CsvDryRun where the change sets were returning singular values instead of multiple ones