### PR TITLE
Schema should control determination of required fields

### DIFF
--- a/app/cho/data_dictionary/fields_for_change_set.rb
+++ b/app/cho/data_dictionary/fields_for_change_set.rb
@@ -13,10 +13,16 @@ module DataDictionary::FieldsForChangeSet
       DataDictionary::Field.all.each do |field|
         property field.label.parameterize.underscore.to_sym,
                  multiple: field.multiple?,
-                 required: field.required?,
                  type: field.change_set_property_type
 
-        validates field.label.parameterize.underscore.to_sym, presence: field.required?
+        validates field.label.parameterize.underscore.to_sym, with: :requirement_determination
+      end
+    end
+
+    def requirement_determination(field)
+      schema_field = form_fields.select { |form_field| form_field.label == field.to_s }.first
+      if schema_field.try(:required?) && self[field].blank?
+        errors.add(field, "can't be blank")
       end
     end
   end

--- a/app/cho/schema/none.rb
+++ b/app/cho/schema/none.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Null schema so resources may have a schema present, but without any fields
+module Schema
+  class None
+    def fields
+      []
+    end
+
+    def core_fields
+      []
+    end
+  end
+end

--- a/app/cho/work/file_set_change_set.rb
+++ b/app/cho/work/file_set_change_set.rb
@@ -10,11 +10,18 @@ module Work
 
     include DataDictionary::FieldsForChangeSet
     include WithValidMembers
+    include WithFormFields
 
     delegate :url_helpers, to: 'Rails.application.routes'
 
     def initialize(*args)
       super(*args)
     end
+
+    private
+
+      def metadata_schema
+        @metadata_schema ||= Schema::Metadata.find_using(label: 'FileSet').first
+      end
   end
 end

--- a/app/cho/work/submission_change_set.rb
+++ b/app/cho/work/submission_change_set.rb
@@ -38,6 +38,7 @@ module Work
 
     include DataDictionary::FieldsForChangeSet
     include WithValidMembers
+    include WithFormFields
 
     delegate :url_helpers, to: 'Rails.application.routes'
 
@@ -50,13 +51,6 @@ module Work
       errors.add(field, "#{work_type_id} does not exist") if work_type.blank?
     end
 
-    def form_fields
-      return @form_fields if @form_fields.present?
-      field_ids = metadata_schema.core_fields + metadata_schema.fields
-      unordered_fields = field_ids.map { |id| Schema::MetadataField.find(id) }
-      @form_fields = unordered_fields.sort_by(&:order_index)
-    end
-
     # @param [ActionView::Helpers::FormBuilder] form
     # @return [Array<Schema::InputField>]
     def input_fields(form)
@@ -64,6 +58,7 @@ module Work
     end
 
     def work_type
+      return if work_type_id.nil?
       @work_type ||= Work::Type.find(work_type_id)
     end
 
@@ -86,7 +81,7 @@ module Work
     private
 
       def metadata_schema
-        @metadata_schema ||= work_type.metadata_schema
+        @metadata_schema ||= work_type.present? ? work_type.metadata_schema : Schema::None.new
       end
   end
 end

--- a/app/cho/work/with_form_fields.rb
+++ b/app/cho/work/with_form_fields.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Work::WithFormFields
+  def form_fields
+    return @form_fields if @form_fields.present?
+    field_ids = metadata_schema.core_fields + metadata_schema.fields
+    unordered_fields = field_ids.map { |id| Schema::MetadataField.find(id) }
+    @form_fields = unordered_fields.sort_by(&:order_index)
+  end
+end

--- a/spec/cho/schema/none_spec.rb
+++ b/spec/cho/schema/none_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Schema::None do
+  subject { described_class.new }
+
+  its(:core_fields) { is_expected.to be_empty }
+  its(:fields) { is_expected.to be_empty }
+end

--- a/spec/cho/transaction/operations/shared/validate_spec.rb
+++ b/spec/cho/transaction/operations/shared/validate_spec.rb
@@ -20,8 +20,7 @@ RSpec.describe Transaction::Operations::Shared::Validate do
 
       it 'returns errors' do
         expect(operation_result.failure.errors.messages).to eq(work_type_id: ["can't be blank"],
-                                                               member_of_collection_ids: ["can't be blank"],
-                                                               title: ["can't be blank"])
+                                                               member_of_collection_ids: ["can't be blank"])
       end
     end
   end

--- a/spec/cho/work/file_set_change_set_spec.rb
+++ b/spec/cho/work/file_set_change_set_spec.rb
@@ -13,12 +13,6 @@ RSpec.describe Work::FileSetChangeSet do
     its([:append_id]) { is_expected.to eq(Valkyrie::ID.new('test')) }
   end
 
-  describe '#required?' do
-    it 'has a required title' do
-      expect(change_set).to be_required(:title)
-    end
-  end
-
   describe '#fields=' do
     before { change_set.prepopulate! }
     its(:title) { is_expected.to be_empty }
@@ -55,6 +49,14 @@ RSpec.describe Work::FileSetChangeSet do
 
     it 'casts ids to Valkyrie IDs' do
       expect(change_set.member_ids.first).to be_kind_of(Valkyrie::ID)
+    end
+  end
+
+  describe '#form_fields' do
+    let(:metadata_schema) { Schema::Metadata.find_using(label: 'FileSet').first }
+
+    it 'returns a list of fields from the FileSet metadata schema' do
+      expect(change_set.form_fields.map(&:id)).to eq(metadata_schema.core_fields)
     end
   end
 end

--- a/spec/cho/work/submissions/change_set_spec.rb
+++ b/spec/cho/work/submissions/change_set_spec.rb
@@ -37,10 +37,6 @@ RSpec.describe Work::SubmissionChangeSet do
   end
 
   describe '#required?' do
-    it 'has a required title' do
-      expect(change_set).to be_required(:title)
-    end
-
     it 'has a required work type' do
       expect(change_set).to be_required(:work_type_id)
     end
@@ -184,5 +180,11 @@ RSpec.describe Work::SubmissionChangeSet do
                                                                                    'title')
       end
     end
+  end
+
+  context 'with no work type' do
+    let(:resource) { Work::Submission.new(work_type_id: nil) }
+
+    its(:work_type) { is_expected.to be_nil }
   end
 end


### PR DESCRIPTION
## Description

When a field is required, the Schema::MetadataField object should determine what to do when the field is missing. This allows fields to be required for different kinds of the same objects, such as submissions, and allows a field to be required by different classes.

Connected to #443 