### PR TITLE
Sync file set metadata to resource

### DIFF
--- a/app/cho/transaction/operations/import/work.rb
+++ b/app/cho/transaction/operations/import/work.rb
@@ -25,7 +25,7 @@ module Transaction
           # @return [Array<Work::FileSet>]
           def saved_file_sets(import_work, file_set_hashes:)
             import_work.file_sets.map do |file_set|
-              file_set_change_set = file_set_hashes.select { |hash| hash.identifier == file_set.id }.first
+              file_set_change_set = file_set_hashes.select { |hash| hash.identifier == Array.wrap(file_set.id) }.first
               resource = import_file_set(file_set, file_set_change_set: file_set_change_set)
               metadata_adapter.persister.save(resource: resource)
             end
@@ -42,10 +42,9 @@ module Transaction
                 identifier: file_set.id
               )
             else
-              resource = file_set_change_set.resource
-              resource.member_ids = files.map(&:id)
-              resource.identifier << file_set.id
-              resource
+              file_set_change_set.member_ids = files.map(&:id)
+              file_set_change_set.sync
+              file_set_change_set.resource
             end
           end
 

--- a/spec/cho/work/import/create_spec.rb
+++ b/spec/cho/work/import/create_spec.rb
@@ -147,6 +147,13 @@ RSpec.describe 'Preview of CSV Import', type: :feature do
       expect(file_sets.map(&:identifier)).to contain_exactly(
         ['work1_00001_01'], ['work1_00001_02'], ['work1_00002_01'], ['work1_00002_02'], []
       )
+      expect(file_sets.map(&:title)).to contain_exactly(
+        ['My Work1_00001_01'],
+        ['My Work1_00001_02'],
+        ['work1_service.pdf'],
+        ['My Work1_00002_01'],
+        ['My Work1_00002_02']
+      )
       filenames = file_sets.map do |file_set|
         file_set.member_ids.map { |id| Work::File.find(Valkyrie::ID.new(id)).original_filename }
       end


### PR DESCRIPTION
## Description

The file set's metadata was not being correctly linked from the hash to the import file set. Once it was correctly linked, the metadata needed to be synced from the change set to the resource.

Connected to #582

Why was this necessary?

There was still a bug with importing file set metadata via csv.
