### PR TITLE
Use a Rejection to capture failures from transactions

### DIFF
--- a/app/cho/transaction/operations/import/extract.rb
+++ b/app/cho/transaction/operations/import/extract.rb
@@ -19,7 +19,7 @@ module Transaction
           unzip_bag(zip_path)
           Success(destination)
         rescue StandardError => exception
-          Failure("Error extracting the bag: #{exception.message}")
+          Failure(Transaction::Rejection.new("Error extracting the bag: #{exception.message}"))
         end
 
         private

--- a/app/cho/transaction/rejection.rb
+++ b/app/cho/transaction/rejection.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Transaction
+  class Rejection
+    include ActiveModel::Validations
+
+    attr_reader :message
+
+    def initialize(message)
+      @message = message
+      errors.add(:transaction, message)
+    end
+
+    def to_s
+      message
+    end
+  end
+end

--- a/spec/cho/transaction/operations/import/extract_spec.rb
+++ b/spec/cho/transaction/operations/import/extract_spec.rb
@@ -53,9 +53,7 @@ RSpec.describe Transaction::Operations::Import::Extract do
       it 'returns Failure' do
         result = operation.call(zip_name: 'non-existent zip')
         expect(result).to be_failure
-        expect(result.failure).to eq(
-          "Error extracting the bag: No such file or directory @ rb_sysopen - #{path}"
-        )
+        expect(result.failure).to be_a(Transaction::Rejection)
       end
     end
   end

--- a/spec/cho/transaction/rejection_spec.rb
+++ b/spec/cho/transaction/rejection_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Transaction::Rejection do
+  let(:failure) { described_class.new('An error message from a transaction') }
+
+  describe '#errors' do
+    subject { failure.errors }
+
+    its(:messages) { is_expected.to eq(transaction: ['An error message from a transaction']) }
+  end
+
+  describe '#to_s' do
+    subject { failure.to_s }
+
+    it { is_expected.to eq('An error message from a transaction') }
+  end
+end

--- a/spec/cho/work/import/create_spec.rb
+++ b/spec/cho/work/import/create_spec.rb
@@ -258,4 +258,24 @@ RSpec.describe 'Preview of CSV Import', type: :feature do
       )
     end
   end
+
+  context 'with a missing bag' do
+    let(:csv_file) do
+      CsvFactory::Generic.new(
+        identifier: ['work1'],
+        member_of_collection_ids: [collection.id],
+        work_type: ['Generic'],
+        title: ['My Work 1'],
+        batch_id: ['missingZip_2018-10-08']
+      )
+    end
+
+    it 'displays the missing zip error in the dry run page' do
+      visit(csv_create_path)
+      expect(page).to have_selector('h1', text: 'CSV Import')
+      attach_file('work_import_csv_file_file', csv_file.path)
+      click_button('Preview Import')
+      expect(page).to have_content('Error extracting the bag: No such file or directory')
+    end
+  end
 end


### PR DESCRIPTION
## Description

Return a Transaction::Rejection object so we can add failure errors that are interpretable by the presenter.

Connected to #618 
