### PR TITLE
Default show page for file sets

### DIFF
--- a/app/blacklight/solr_document.rb
+++ b/app/blacklight/solr_document.rb
@@ -44,6 +44,13 @@ class SolrDocument
     end
   end
 
+  # @return [Array<Work::File>]
+  def files
+    Array.wrap(self['member_ids_ssim']).map do |id|
+      Work::File.find(Valkyrie::ID.new(id.sub(/^id-/, '')))
+    end
+  end
+
   # @todo maybe this needs to be some kind of transformation done in the data dictionary?
   # @return [Array<SolrDocument>]
   def member_of_collections

--- a/app/views/catalog/_file_sets.html.erb
+++ b/app/views/catalog/_file_sets.html.erb
@@ -2,6 +2,6 @@
 
 <ul>
   <%- file_sets.each do |file_set| %>
-    <li><%= file_set.title %></li>
+    <li><%= link_to file_set.title.first, solr_document_path(file_set) %></li>
   <%- end %>
 </ul>

--- a/app/views/catalog/_show_work_fileset.html.erb
+++ b/app/views/catalog/_show_work_fileset.html.erb
@@ -1,0 +1,12 @@
+<%# Do the two column thing here %>
+<%= render partial: 'show', locals: { document: @document } %>
+
+<%# write method to grab the files from the file set %>
+<% unless @document.files.empty? %>
+  <h2>Files</h2>
+  <ul>
+    <%- @document.files.each do |file| %>
+      <li><%= file.original_filename %></li>
+    <%- end %>
+  </ul>
+<% end %>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -8,9 +8,9 @@
 <% end %>
 
 <%= render_document_main_content_partial %>
-
-<%= link_to 'Edit', edit_cho_resource_path %>
-
+<% unless @document.internal_resource == Work::FileSet %>
+  <%= link_to 'Edit', edit_cho_resource_path %>
+<% end %>
 <% content_for(:sidebar) do %>
   <%= render_document_sidebar_partial %>
 <% end %>

--- a/spec/cho/work/file_set/show_spec.rb
+++ b/spec/cho/work/file_set/show_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Work::FileSet, type: :feature do
+  let(:file_set) { create(:file_set, :with_member_file) }
+
+  it 'displays the file set' do
+    visit(polymorphic_path([:solr_document], id: file_set.id))
+    within('div#document') do
+      expect(page).to have_blacklight_label('title_tesim').with('Title')
+      expect(page).to have_blacklight_field('title_tesim').with('Original File Name')
+    end
+    expect(page).to have_selector('h2', text: 'Files')
+  end
+end

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     title { 'Original File Name' }
 
     to_create do |resource|
-      Valkyrie.config.metadata_adapter.persister.save(resource: resource)
+      Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: resource)
     end
   end
 
@@ -21,7 +21,7 @@ FactoryBot.define do
       result = Transaction::Operations::File::Create.new.call(file_change_set, temp_file: temp_file)
       raise result.failure if result.failure?
       resource.member_ids = [result.success.id]
-      Valkyrie.config.metadata_adapter.persister.save(resource: resource)
+      Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: resource)
     end
   end
 end


### PR DESCRIPTION
Utilizing solr document to access the link for the file set and hook into the default Blacklight show page.

Updates the file set link in the work show page to link to file set show p[age and starts a test for the file set show page.


## Description

Fixes #63 

Why was this necessary?

Stakeholders would like to be able to see, and in the future, edit file sets.