### PR TITLE
Include file set metadata when exporting collections

### DIFF
--- a/app/blacklight/document/csv.rb
+++ b/app/blacklight/document/csv.rb
@@ -46,7 +46,10 @@ module Document::Csv
     end
 
     def export_model
-      ::CSV.generate { |csv| csv << export_fields(self) }
+      ::CSV.generate do |csv|
+        csv << export_fields(self)
+        export_member_file_sets(self).each { |file_set| csv << file_set }
+      end
     end
 
     def export_members(csv)
@@ -56,9 +59,16 @@ module Document::Csv
         members = document_facade(page).members
         members.each do |member|
           csv << export_fields(member)
+          export_member_file_sets(member).each { |file_set| csv << file_set }
         end
         page += 1
         more_members = members.count >= rows
+      end
+    end
+
+    def export_member_file_sets(member)
+      member.file_set_ids.map do |id|
+        export_fields(SolrDocument.find(id.sub(/^id-/, '')))
       end
     end
 

--- a/app/blacklight/solr_document.rb
+++ b/app/blacklight/solr_document.rb
@@ -44,6 +44,10 @@ class SolrDocument
     end
   end
 
+  def file_set_ids
+    Array.wrap(self['file_set_ids_ssim'])
+  end
+
   # @return [Array<Work::File>]
   def files
     Array.wrap(self['member_ids_ssim']).map do |id|

--- a/spec/blacklight/solr_document_spec.rb
+++ b/spec/blacklight/solr_document_spec.rb
@@ -78,12 +78,14 @@ RSpec.describe SolrDocument, type: :model do
 
     it { is_expected.to eq("abc123,my_title,,,,,,,value1|value2,,xyx789,,\n") }
 
-    context 'a collection' do
+    context 'with a collection containing works and file sets' do
       let(:collection) { create :library_collection }
-      let(:work) { create :work, member_of_collection_ids: [collection.id], title: 'Work One' }
+      let(:work) { create :work, :with_file, member_of_collection_ids: [collection.id], title: 'Work One' }
       let(:work1_csv) { "#{work.id},Work One,,,,,,,,,#{collection.id},," }
-      let(:work2) { create :work, member_of_collection_ids: [collection.id], title: 'Work Two' }
+      let(:file_set1_csv) { "#{work.file_set_ids.first},hello_world.txt,,,,,,,,,,," }
+      let(:work2) { create :work, :with_file, member_of_collection_ids: [collection.id], title: 'Work Two' }
       let(:work2_csv) { "#{work2.id},Work Two,,,,,,,,,#{collection.id},," }
+      let(:file_set2_csv) { "#{work2.file_set_ids.first},hello_world.txt,,,,,,,,,,," }
 
       let(:csv_header) do
         'id,title,subtitle,description,alternate_ids,audio_field,created,document_field,'\
@@ -99,12 +101,35 @@ RSpec.describe SolrDocument, type: :model do
         work2
       end
 
-      it { is_expected.to eq("#{csv_header}\n#{work1_csv}\n#{work2_csv}\n") }
+      it { is_expected.to eq("#{csv_header}\n#{work1_csv}\n#{file_set1_csv}\n#{work2_csv}\n#{file_set2_csv}\n") }
 
       it 'can use multiple pages' do
         expect(solr_document).to receive(:rows).at_least(:once).and_return(1)
-        expect(solr_document.export_as_csv).to eq("#{csv_header}\n#{work1_csv}\n#{work2_csv}\n")
+        expect(solr_document.export_as_csv).to eq(
+          "#{csv_header}\n#{work1_csv}\n#{file_set1_csv}\n#{work2_csv}\n#{file_set2_csv}\n"
+        )
       end
+    end
+
+    context 'with a work containing file sets' do
+      let(:document) do
+        {
+          'internal_resource_tsim' => 'MyResource',
+          id: 'abc123',
+          member_of_collection_ids_ssim: ['xyx789'],
+          file_set_ids_ssim: ["id-#{file_set.id}"],
+          title_tesim: ['my_title'],
+          generic_field_tesim: ['value1', 'value2']
+        }
+      end
+
+      let(:file_set) { create(:file_set) }
+      let(:work_csv) { 'abc123,my_title,,,,,,,value1|value2,,xyx789,,' }
+      let(:file_set_csv) { "#{file_set.id},Original File Name,,,,,,,,,,," }
+
+      before { file_set }
+
+      it { is_expected.to eq("#{work_csv}\n#{file_set_csv}\n") }
     end
   end
 


### PR DESCRIPTION
## Description

Adds additional lines to the csv when exporting collections and works containing file sets.

Connected to #650 
