### PR TITLE
Update transactions to use rejection class

### DIFF
--- a/app/cho/transaction/operations/file/characterize.rb
+++ b/app/cho/transaction/operations/file/characterize.rb
@@ -15,8 +15,8 @@ module Transaction
           change_set.validate(fits_output: xml_string)
 
           Success(change_set)
-        rescue StandardError => e
-          Failure("Error characterizing file: #{e.message}")
+        rescue StandardError => exception
+          Failure(Transaction::Rejection.new("Error characterizing file: #{exception.message}"))
         end
 
         private

--- a/app/cho/transaction/operations/file/create.rb
+++ b/app/cho/transaction/operations/file/create.rb
@@ -11,8 +11,8 @@ module Transaction
         def call(file_change_set, temp_file:)
           saved_work_file = metadata_adapter.persister.save(resource: work_file(file_change_set, temp_file: temp_file))
           Success(file_change_set.class.new(saved_work_file))
-        rescue StandardError => e
-          Failure("Error persisting file: #{e.message}")
+        rescue StandardError => exception
+          Failure(Transaction::Rejection.new("Error persisting file: #{exception.message}"))
         end
 
         private

--- a/app/cho/transaction/operations/file/create_temp_file.rb
+++ b/app/cho/transaction/operations/file/create_temp_file.rb
@@ -13,8 +13,8 @@ module Transaction
           puts temp_file.path
           updated_temp_file = write_file(temp_file: temp_file, io: io)
           Success(updated_temp_file)
-        rescue StandardError => e
-          Failure("Error persisting file: #{e.message}")
+        rescue StandardError => exception
+          Failure(Transaction::Rejection.new("Error persisting file: #{exception.message}"))
         end
 
         private

--- a/app/cho/transaction/operations/file/save.rb
+++ b/app/cho/transaction/operations/file/save.rb
@@ -13,8 +13,8 @@ module Transaction
           saved_work_file_set = metadata_adapter.persister.save(resource: work_file_set(change_set))
           change_set.model.file_set_ids << saved_work_file_set.id
           Success(change_set)
-        rescue StandardError => e
-          Failure("Error persisting file: #{e.message}")
+        rescue StandardError => exception
+          Failure(Transaction::Rejection.new("Error persisting file: #{exception.message}"))
         end
 
         private

--- a/app/cho/transaction/operations/file_set/extract_text.rb
+++ b/app/cho/transaction/operations/file_set/extract_text.rb
@@ -21,8 +21,8 @@ module Transaction
           else
             text_file_result
           end
-        rescue StandardError => e
-          Failure("Error extracting text: #{e.message}")
+        rescue StandardError => exception
+          Failure(Transaction::Rejection.new("Error extracting text: #{exception.message}"))
         end
 
         private

--- a/app/cho/transaction/operations/import/validate.rb
+++ b/app/cho/transaction/operations/import/validate.rb
@@ -14,7 +14,7 @@ module Transaction
           return Success(bag) if bag.valid?
           Failure(bag)
         rescue StandardError => exception
-          Failure("Error validating the bag: #{exception.message}")
+          Failure(Transaction::Rejection.new("Error validating the bag: #{exception.message}"))
         end
       end
     end

--- a/app/cho/transaction/operations/import/work.rb
+++ b/app/cho/transaction/operations/import/work.rb
@@ -16,7 +16,7 @@ module Transaction
           change_set.file_set_ids = file_sets.map(&:id)
           Success(change_set)
         rescue StandardError => exception
-          Failure("Error importing the work: #{exception.message}")
+          Failure(Transaction::Rejection.new("Error importing the work: #{exception.message}"))
         end
 
         private

--- a/app/cho/transaction/operations/import/zip.rb
+++ b/app/cho/transaction/operations/import/zip.rb
@@ -16,7 +16,7 @@ module Transaction
           change_set.import_work = bag.success.works.first
           Success(change_set)
         rescue StandardError => exception
-          Failure("Unable to import zip file from the GUI: #{exception}")
+          Failure(Transaction::Rejection.new("Unable to import zip file from the GUI: #{exception}"))
         end
       end
     end

--- a/spec/cho/transaction/operations/file/characterize_spec.rb
+++ b/spec/cho/transaction/operations/file/characterize_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Transaction::Operations::File::Characterize do
       it 'returns Failure' do
         result = operation.call(change_set)
         expect(result).to be_failure
-        expect(result.failure).to eq('Error characterizing file: Valkyrie::StorageAdapter::FileNotFound')
+        expect(result.failure.message).to eq('Error characterizing file: Valkyrie::StorageAdapter::FileNotFound')
       end
     end
 

--- a/spec/cho/transaction/operations/file/create_spec.rb
+++ b/spec/cho/transaction/operations/file/create_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Transaction::Operations::File::Create do
 
       it 'returns Failure' do
         expect(result).to be_failure
-        expect(result.failure).to eq('Error persisting file: undefined method `path\' for nil:NilClass')
+        expect(result.failure.message).to eq('Error persisting file: undefined method `path\' for nil:NilClass')
       end
     end
   end

--- a/spec/cho/transaction/operations/file/create_temp_file_spec.rb
+++ b/spec/cho/transaction/operations/file/create_temp_file_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Transaction::Operations::File::CreateTempFile do
 
       it 'returns Failure' do
         expect(result).to be_failure
-        expect(result.failure).to eq('Error persisting file: undefined method `eof?\' for nil:NilClass')
+        expect(result.failure.message).to eq('Error persisting file: undefined method `eof?\' for nil:NilClass')
       end
     end
   end

--- a/spec/cho/transaction/operations/file/save_spec.rb
+++ b/spec/cho/transaction/operations/file/save_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Transaction::Operations::File::Save do
         expect {
           result = operation.call(mock_change_set)
           expect(result).to be_failure
-          expect(result.failure).to eq('Error persisting file: unsupported adapter')
+          expect(result.failure.message).to eq('Error persisting file: unsupported adapter')
         }.to change { Work::File.count }.by(0)
       end
     end

--- a/spec/cho/transaction/operations/file_set/extract_text_spec.rb
+++ b/spec/cho/transaction/operations/file_set/extract_text_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Transaction::Operations::FileSet::ExtractText do
         expect {
           result = operation.call(file_set)
           expect(result).to be_failure
-          expect(result.failure).to eq('Error extracting text: unsupported adapter')
+          expect(result.failure.message).to eq('Error extracting text: unsupported adapter')
         }.to change { Work::File.count }.by(0)
       end
     end

--- a/spec/cho/transaction/operations/import/validate_spec.rb
+++ b/spec/cho/transaction/operations/import/validate_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Transaction::Operations::Import::Validate do
       it 'returns a Failure' do
         result = operation.call('bag_path')
         expect(result).to be_failure
-        expect(result.failure).to eq('Error validating the bag: bag_path is malformed')
+        expect(result.failure.message).to eq('Error validating the bag: bag_path is malformed')
       end
     end
   end

--- a/spec/cho/transaction/operations/import/work_spec.rb
+++ b/spec/cho/transaction/operations/import/work_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Transaction::Operations::Import::Work do
         expect {
           result = operation.call(change_set)
           expect(result).to be_failure
-          expect(result.failure).to eq('Error importing the work: unsupported adapter')
+          expect(result.failure.message).to eq('Error importing the work: unsupported adapter')
         }.to change { Work::File.count }.by(0).and change { ::Work::FileSet.count }.by(0)
       end
     end


### PR DESCRIPTION
Updates transaction operations to use the Rejection class for errors including their corresponding tests.

## Description

Fixes #643 
