### PR TITLE
Support for dates, including EDTF date types

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'bootsnap', require: false
 gem 'coffee-rails', '~> 4.2'
 gem 'devise_remote'
 gem 'dry-transaction'
+gem 'edtf'
 gem 'execjs'
 gem 'faker', github: 'stympy/faker', branch: 'master'
 gem 'figaro'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,6 +245,8 @@ GEM
     ebnf (1.1.3)
       rdf (~> 3.0)
       sxp (~> 1.0)
+    edtf (3.0.4)
+      activesupport (>= 3.0, < 6.0)
     erb_lint (0.0.26)
       activesupport
       better_html (~> 1.0.7)
@@ -674,6 +676,7 @@ DEPENDENCIES
   database_cleaner
   devise_remote
   dry-transaction
+  edtf
   execjs
   factory_bot_rails
   faker!
@@ -719,4 +722,4 @@ DEPENDENCIES
   xray-rails
 
 BUNDLED WITH
-   1.16.4
+   1.16.5

--- a/app/cho/data_dictionary/field.rb
+++ b/app/cho/data_dictionary/field.rb
@@ -31,15 +31,7 @@ module DataDictionary
 
     # @return [String] field name used in Solr for indexing
     def solr_field
-      if date?
-        "#{label}_dtsi"
-      elsif valkyrie_id?
-        "#{label}_ssim"
-      elsif alternate_id?
-        "#{label}_ssim"
-      else
-        "#{label}_tesim"
-      end
+      "#{label}_#{suffix}"
     end
 
     # @return [Valkyrie::Types] property type for the Valkyrie::ChangeSet
@@ -50,6 +42,8 @@ module DataDictionary
         Valkyrie::Types::ID.optional
       elsif alternate_id?
         Valkyrie::Types::Set.of(Valkyrie::Types::ID)
+      elsif date?
+        Valkyrie::Types::Set.of(Valkyrie::Types::Date)
       else
         Valkyrie::Types::Set.optional
       end
@@ -63,6 +57,8 @@ module DataDictionary
         Valkyrie::Types::ID.optional
       elsif alternate_id?
         Valkyrie::Types::Set.of(Valkyrie::Types::ID)
+      elsif date?
+        Valkyrie::Types::Set.of(Valkyrie::Types::Date)
       else
         Valkyrie::Types::Set.meta(ordered: true)
       end
@@ -74,5 +70,18 @@ module DataDictionary
     def method_name
       "#{label}_data_dictionary_field"
     end
+
+    private
+
+      def suffix
+        return 'ssim' if valkyrie_id? || alternate_id?
+        return "dtsi#{multiple_suffix}" if date?
+        'tesim'
+      end
+
+      def multiple_suffix
+        return unless multiple?
+        'm'
+      end
   end
 end

--- a/app/cho/data_dictionary/with_index_type.rb
+++ b/app/cho/data_dictionary/with_index_type.rb
@@ -3,7 +3,7 @@
 module DataDictionary::WithIndexType
   extend ActiveSupport::Concern
 
-  IndexTypes = Valkyrie::Types::String.enum('facet', 'no_facet')
+  IndexTypes = Valkyrie::Types::String.enum('facet', 'no_facet', 'date')
 
   included do
     attribute :index_type, IndexTypes
@@ -23,5 +23,13 @@ module DataDictionary::WithIndexType
 
   def no_facet?
     index_type == 'no_facet'
+  end
+
+  def date!
+    self.index_type = 'date'
+  end
+
+  def date?
+    index_type == 'date'
   end
 end

--- a/app/cho/indexing/dates.rb
+++ b/app/cho/indexing/dates.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Indexing
+  class Dates
+    attr_reader :resource
+    def initialize(resource:)
+      @resource = resource
+    end
+
+    def to_solr
+      solr_document = {}
+      date_fields.each do |date|
+        solr_document.merge!(solr_field(date))
+      end
+      solr_document
+    end
+
+    private
+
+      # @note We might need to narrow down the scope of the query to only return fields specifically
+      #   defined for the particular resource.
+      def date_fields
+        @date_fields ||= Schema::MetadataField.where(index_type: 'date').select do |field|
+          resource.attributes[field.label.to_sym].present?
+        end.to_a
+      end
+
+      def solr_field(date)
+        value = solr_date(resource.attributes[date.label.to_sym])
+        { date.solr_field => (date.multiple? ? value : value.first) }
+      rescue ArgumentError
+        {}
+      end
+
+      def solr_date(values)
+        Array.wrap(values).map do |value|
+          converted_date(value)
+        end
+      end
+
+      # @note Valkyrie will attempt to cast Valkyrie::Types::Date types to a Time object. If that
+      #   is unsuccessful, a string is returned.
+      def converted_date(value)
+        if value.is_a?(String)
+          DateTime.iso8601(Date.edtf(value).to_s, Date::ENGLAND).utc.strftime(date_format)
+        else
+          value.utc.strftime(date_format)
+        end
+      end
+
+      def date_format
+        '%Y-%m-%dT%H:%M:%SZ'
+      end
+  end
+end

--- a/app/cho/metrics/collection.rb
+++ b/app/cho/metrics/collection.rb
@@ -81,7 +81,7 @@ module Metrics
           repository: [Faker::Company.bs.titleize],
           rights_statement: [Faker::HowIMetYourMother.quote],
           cataloger: [Faker::SiliconValley.character],
-          date_cataloged: [Faker::Time.between(30.days.ago, Date.today, :day).strftime('%A, %d %b %Y %l:%M %p')],
+          date_cataloged: [Faker::Time.between(30.days.ago, Date.today, :day).strftime('%Y-%m-%d')],
           work_type_id: work_type_id,
           member_of_collection_ids: [collection.id]
         }

--- a/app/cho/validation/factory.rb
+++ b/app/cho/validation/factory.rb
@@ -16,7 +16,8 @@ module Validation
       def default_items
         {
           default_key => Validation::None.new,
-          resource_exists: :validation # placeholder, see https://github.com/psu-libraries/cho/issues/672
+          resource_exists: :validation, # placeholder, see https://github.com/psu-libraries/cho/issues/672
+          edtf_date: :validation # placeholder, see https://github.com/psu-libraries/cho/issues/672
         }
       end
 

--- a/app/cho/validation/methods.rb
+++ b/app/cho/validation/methods.rb
@@ -12,4 +12,12 @@ module Validation::Methods
     member = Validation::Member.new(self[field])
     errors.add(field, "#{member.id} does not exist") unless member.exists?
   end
+
+  def edtf_date(field)
+    return if self[field].blank?
+    Array.wrap(self[field]).each do |value|
+      date = Date.edtf(value)
+      errors.add(field, "#{value} is not a valid EDTF date") unless date
+    end
+  end
 end

--- a/config/data_dictionary/data_dictionary_development.csv
+++ b/config/data_dictionary/data_dictionary_development.csv
@@ -14,7 +14,7 @@ rights_statement,string,required_to_publish,no_validation,false,no_vocabulary,,R
 resource_type,string,required_to_publish,no_validation,true,no_vocabulary,,Resource Type,no_transformation,no_facet,help me,true
 file_format,string,required_to_publish,no_validation,true,no_vocabulary,,File Format,no_transformation,no_facet,help me,true
 cataloger,string,optional,no_validation,true,no_vocabulary,,Cataloger,no_transformation,no_facet,help me,true
-date_cataloged,date,optional,no_validation,true,no_vocabulary,,Date Cataloged,no_transformation,no_facet,help me,true
+date_cataloged,date,optional,edtf_date,true,no_vocabulary,,Date Cataloged,no_transformation,date,help me,true
 contributor,string,optional,no_validation,true,no_vocabulary,,Contributor,no_transformation,no_facet,help me,false
 time_period,string,optional,no_validation,true,no_vocabulary,,Time Period,no_transformation,no_facet,help me,false
 language,string,optional,no_validation,true,no_vocabulary,,Language,no_transformation,no_facet,help me,false

--- a/config/data_dictionary/data_dictionary_production.csv
+++ b/config/data_dictionary/data_dictionary_production.csv
@@ -14,7 +14,7 @@ rights_statement,string,required_to_publish,no_validation,false,no_vocabulary,,R
 resource_type,string,required_to_publish,no_validation,true,no_vocabulary,,Resource Type,no_transformation,no_facet,help me,true
 file_format,string,required_to_publish,no_validation,true,no_vocabulary,,File Format,no_transformation,no_facet,help me,true
 cataloger,string,optional,no_validation,true,no_vocabulary,,Cataloger,no_transformation,no_facet,help me,true
-date_cataloged,date,optional,no_validation,true,no_vocabulary,,Date Cataloged,no_transformation,no_facet,help me,true
+date_cataloged,date,optional,edtf_date,true,no_vocabulary,,Date Cataloged,no_transformation,date,help me,true
 contributor,string,optional,no_validation,true,no_vocabulary,,Contributor,no_transformation,no_facet,help me,false
 time_period,string,optional,no_validation,true,no_vocabulary,,Time Period,no_transformation,no_facet,help me,false
 language,string,optional,no_validation,true,no_vocabulary,,Language,no_transformation,no_facet,help me,false

--- a/config/data_dictionary/data_dictionary_test.csv
+++ b/config/data_dictionary/data_dictionary_test.csv
@@ -3,7 +3,7 @@ title,string,required,no_validation,true,no_vocabulary,,Object Title,no_transfor
 member_of_collection_ids,valkyrie_id,optional,resource_exists,false,cho_collections,,Member of Collection,no_transformation,no_facet,help me,false
 subtitle,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,true
 description,text,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,true
-created,date,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false
+created,date,optional,edtf_date,true,no_vocabulary,,,no_transformation,date,help me,false
 generic_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false
 document_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false
 still_image_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false

--- a/config/data_dictionary/schema_fields.yml
+++ b/config/data_dictionary/schema_fields.yml
@@ -183,6 +183,8 @@ test:
       member_of_collection_ids:
         requirement_designation: 'required'
         order_index: 2
+      created:
+        order_index: 3
   - schema: 'Document'
     fields:
       document_field:

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -21,7 +21,8 @@ Rails.application.config.to_prepare do
         Valkyrie::Indexers::AccessControlsIndexer,
         Work::SubmissionIndexer,
         Work::FileSetIndexer,
-        Collection::TypeIndexer
+        Collection::TypeIndexer,
+        Indexing::Dates
       )
     ),
     :index_solr

--- a/spec/blacklight/solr_document_spec.rb
+++ b/spec/blacklight/solr_document_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe SolrDocument, type: :model do
 
   describe 'data dictionary field accessors' do
     let(:document) do
-      { 'internal_resource_tsim' => 'MyResource', title_tesim: ['my_title'], created_dtsi: ['2018-04-19T15:46:46Z'] }
+      { 'internal_resource_tsim' => 'MyResource', title_tesim: ['my_title'], created_dtsim: ['2018-04-19T15:46:46Z'] }
     end
 
     its(:title_data_dictionary_field) { is_expected.to eq ['my_title'] }

--- a/spec/cho/data_dictionary/field_spec.rb
+++ b/spec/cho/data_dictionary/field_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe DataDictionary::Field, type: :model do
   subject { model }
 
   let(:resource_klass) { described_class }
-  let(:field_type) { 'date' }
   let(:model) { build :data_dictionary_field,
-                      label: 'abc123_label', field_type: field_type,
+                      label: 'abc123_label',
+                      field_type: 'text',
                       requirement_designation: 'recommended',
                       controlled_vocabulary: 'no_vocabulary',
                       default_value: 'abc123',
@@ -77,70 +77,36 @@ RSpec.describe DataDictionary::Field, type: :model do
     end
   end
 
-  describe '#solr_field' do
-    subject { model.solr_field }
+  context 'with a text field' do
+    before { model.text! }
 
-    context 'with a date field' do
-      it { is_expected.to eq('abc123_label_dtsi') }
-    end
-
-    context 'with a valkyrie ID' do
-      let(:field_type) { 'valkyrie_id' }
-
-      it { is_expected.to eq('abc123_label_ssim') }
-    end
-
-    context 'with a valkyrie ID' do
-      let(:field_type) { 'alternate_id' }
-
-      it { is_expected.to eq('abc123_label_ssim') }
-    end
-
-    context 'when the field is not a date' do
-      let(:field_type) { 'text' }
-
-      it { is_expected.to eq('abc123_label_tesim') }
-    end
+    its(:solr_field) { is_expected.to eq('abc123_label_tesim') }
+    its(:change_set_property_type) { is_expected.to eq(Valkyrie::Types::Set.optional) }
+    its(:resource_property_type) { is_expected.to eq(Valkyrie::Types::Set.meta(ordered: true)) }
   end
 
-  describe '#change_set_property_type' do
-    subject { model.change_set_property_type }
+  context 'with a date field' do
+    before { model.date! }
 
-    context 'when the field is not a Valkyrie ID' do
-      it { is_expected.to eq(Valkyrie::Types::Set.optional) }
-    end
-
-    context 'with a Valkyrie ID' do
-      let(:field_type) { 'valkyrie_id' }
-
-      it { is_expected.to eq(Valkyrie::Types::ID.optional) }
-    end
-
-    context 'with a alternate id' do
-      let(:field_type) { 'alternate_id' }
-
-      it { is_expected.to eq(Valkyrie::Types::Set.of(Valkyrie::Types::ID)) }
-    end
+    its(:solr_field) { is_expected.to eq('abc123_label_dtsi') }
+    its(:change_set_property_type) { is_expected.to eq(Valkyrie::Types::Set.of(Valkyrie::Types::Date)) }
+    its(:resource_property_type) { is_expected.to eq(Valkyrie::Types::Set.of(Valkyrie::Types::Date)) }
   end
 
-  describe '#resource_property_type' do
-    subject { model.resource_property_type }
+  context 'with an alternate ID field' do
+    before { model.alternate_id! }
 
-    context 'when the field is not a Valkyrie ID' do
-      it { is_expected.to eq(Valkyrie::Types::Set.meta(ordered: true)) }
-    end
+    its(:solr_field) { is_expected.to eq('abc123_label_ssim') }
+    its(:change_set_property_type) { is_expected.to eq(Valkyrie::Types::Set.of(Valkyrie::Types::ID)) }
+    its(:resource_property_type) { is_expected.to eq(Valkyrie::Types::Set.of(Valkyrie::Types::ID)) }
+  end
 
-    context 'with a Valkyrie ID' do
-      let(:field_type) { 'valkyrie_id' }
+  context 'with a Valkyrie ID field' do
+    before { model.valkyrie_id! }
 
-      it { is_expected.to eq(Valkyrie::Types::ID.optional) }
-    end
-
-    context 'with a alternate id' do
-      let(:field_type) { 'alternate_id' }
-
-      it { is_expected.to eq(Valkyrie::Types::Set.of(Valkyrie::Types::ID)) }
-    end
+    its(:solr_field) { is_expected.to eq('abc123_label_ssim') }
+    its(:change_set_property_type) { is_expected.to eq(Valkyrie::Types::ID.optional) }
+    its(:resource_property_type) { is_expected.to eq(Valkyrie::Types::ID.optional) }
   end
 
   context 'when saving with metadata' do
@@ -152,7 +118,7 @@ RSpec.describe DataDictionary::Field, type: :model do
                                 default_value: 'abc123',
                                 display_name: 'My Abc123',
                                 display_transformation: 'no_transformation',
-                                field_type: 'date',
+                                field_type: 'text',
                                 help_text: 'help me',
                                 id: saved_model.id,
                                 index_type: 'no_facet',

--- a/spec/cho/data_dictionary/with_index_type_spec.rb
+++ b/spec/cho/data_dictionary/with_index_type_spec.rb
@@ -13,54 +13,43 @@ RSpec.describe DataDictionary::WithIndexType, type: :model do
     ActiveSupport::Dependencies.remove_constant('MyFieldModel')
   end
 
-  subject { model.index_type }
+  subject { model }
 
-  let(:index_type) { 'facet' }
-  let(:model) { MyFieldModel.new(index_type: index_type) }
+  let(:model) { MyFieldModel.new }
 
-  it { is_expected.to eq('facet') }
-
-  it 'is facet' do
-    expect(model).to be_facet
+  context 'when there is no index type' do
+    it { is_expected.not_to be_facet }
+    it { is_expected.not_to be_no_facet }
+    it { is_expected.not_to be_date }
   end
 
-  it 'is not no_facet' do
-    expect(model).not_to be_no_facet
+  context 'when the index type is a facet' do
+    before { model.facet! }
+
+    it { is_expected.to be_facet }
+    it { is_expected.not_to be_no_facet }
+    it { is_expected.not_to be_date }
   end
 
-  context 'index_type is set to none' do
-    before do
-      model.no_facet!
-    end
+  context 'when the index type is no facet' do
+    before { model.no_facet! }
 
-    it 'is no facet' do
-      expect(model).to be_no_facet
-    end
+    it { is_expected.not_to be_facet }
+    it { is_expected.to be_no_facet }
+    it { is_expected.not_to be_date }
+  end
 
-    it 'is not facet' do
-      expect(model).not_to be_facet
-    end
+  context 'when the index type is a date' do
+    before { model.date! }
 
-    context 'and then set to facet' do
-      before do
-        model.facet!
-      end
-
-      it 'is not no facet' do
-        expect(model).not_to be_no_facet
-      end
-
-      it 'is facet' do
-        expect(model).to be_facet
-      end
-    end
+    it { is_expected.not_to be_facet }
+    it { is_expected.not_to be_no_facet }
+    it { is_expected.to be_date }
   end
 
   context 'index_type is bogus' do
-    let(:index_type) { 'bogus' }
-
     it 'raises an error' do
-      expect { model }.to raise_error(Dry::Struct::Error)
+      expect { MyFieldModel.new(index_type: 'bogus') }.to raise_error(Dry::Struct::Error)
     end
   end
 end

--- a/spec/cho/indexing/dates_spec.rb
+++ b/spec/cho/indexing/dates_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Indexing::Dates, type: :model do
+  let(:resource) { Work::Submission.new }
+  let(:indexer) { described_class.new(resource: resource) }
+
+  describe '#to_solr' do
+    subject { indexer.to_solr }
+
+    context 'when the field is empty' do
+      it { is_expected.to eq({}) }
+    end
+
+    context 'when the field has a full date' do
+      before { resource.created = ['2001-01-02'] }
+
+      it { is_expected.to eq('created_dtsim' => ['2001-01-02T00:00:00Z']) }
+    end
+
+    context 'when the field has multiple full dates' do
+      before { resource.created = ['2001-01-02', '1967-12-31'] }
+
+      it { is_expected.to eq('created_dtsim' => ['2001-01-02T00:00:00Z', '1967-12-31T00:00:00Z']) }
+    end
+
+    context 'with an unspecified month and day' do
+      before { resource.created = ['1992-uu-uu'] }
+
+      it { is_expected.to eq('created_dtsim' => ['1992-01-01T00:00:00Z']) }
+    end
+
+    context 'with an uncertain year' do
+      before { resource.created = ['1938?'] }
+
+      it { is_expected.to eq('created_dtsim' => ['1938-01-01T00:00:00Z']) }
+    end
+
+    context 'with an approximate year and month' do
+      before { resource.created = ['1984?-06~'] }
+
+      it { is_expected.to eq('created_dtsim' => ['1984-06-01T00:00:00Z']) }
+    end
+
+    context 'with only year and month' do
+      before { resource.created = ['2006-11'] }
+
+      it { is_expected.to eq('created_dtsim' => ['2006-11-01T00:00:00Z']) }
+    end
+
+    context 'with only a year' do
+      before { resource.created = ['2002'] }
+
+      it { is_expected.to eq('created_dtsim' => ['2002-01-01T00:00:00Z']) }
+    end
+
+    context 'with an unparseable date' do
+      before { resource.created = ['asdf'] }
+
+      it { is_expected.to eq({}) }
+    end
+
+    context 'with Time object' do
+      let(:converted_time) { Time.new('2010-05-05').utc.strftime('%Y-%m-%dT%H:%M:%SZ') }
+
+      before { resource.created = [Time.new('2010-05-05')] }
+
+      it { is_expected.to eq('created_dtsim' => [converted_time]) }
+    end
+
+    context 'with a singular field' do
+      let(:resource) { SingleDateResource.new }
+
+      before do
+        class SingleDateResource < Valkyrie::Resource
+          attribute :single_date
+        end
+
+        create(:schema_metadata_field, label: 'single_date', index_type: 'date', multiple: false)
+        resource.single_date = '1960'
+      end
+
+      after { ActiveSupport::Dependencies.remove_constant('SingleDateResource') }
+
+      it { is_expected.to eq('single_date_dtsi' => '1960-01-01T00:00:00Z') }
+    end
+  end
+end

--- a/spec/cho/schema/configuration_spec.rb
+++ b/spec/cho/schema/configuration_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe Schema::Configuration, type: :model do
         {
           'schema' => 'Generic', 'fields' => {
             'member_of_collection_ids' => { 'order_index' => 2, 'requirement_designation' => 'required' },
-            'generic_field' => { 'order_index' => 1 }
+            'generic_field' => { 'order_index' => 1 },
+            'created' => { 'order_index' => 3 }
           }
         },
         {

--- a/spec/cho/schema/work_type_configuration_spec.rb
+++ b/spec/cho/schema/work_type_configuration_spec.rb
@@ -45,15 +45,15 @@ RSpec.describe Schema::WorkTypeConfiguration, type: :model do
     let(:work_type) { 'Generic' }
 
     it 'creates a field based on the work type' do
-      expect(schema_fields.count).to eq(2)
-      expect(schema_fields.first.order_index).to eq(5)
-      expect(schema_fields.first.label).to eq('generic_field')
-      expect(schema_fields.first.work_type).to eq(work_type)
-      expect(schema_fields.first.requirement_designation).to eq('optional')
-      expect(schema_fields.last.order_index).to eq(6)
-      expect(schema_fields.last.label).to eq('member_of_collection_ids')
-      expect(schema_fields.last.work_type).to eq(work_type)
-      expect(schema_fields.last.requirement_designation).to eq('required')
+      expect(schema_fields.count).to eq(3)
+      expect(schema_fields[0].order_index).to eq(5)
+      expect(schema_fields[0].label).to eq('generic_field')
+      expect(schema_fields[0].work_type).to eq(work_type)
+      expect(schema_fields[0].requirement_designation).to eq('optional')
+      expect(schema_fields[1].order_index).to eq(6)
+      expect(schema_fields[1].label).to eq('member_of_collection_ids')
+      expect(schema_fields[1].work_type).to eq(work_type)
+      expect(schema_fields[1].requirement_designation).to eq('required')
     end
 
     context 'a non existing work type' do
@@ -100,7 +100,7 @@ RSpec.describe Schema::WorkTypeConfiguration, type: :model do
     it 'creates a field based on the work type' do
       expect(metadata_schema).to be_a(Schema::Metadata)
       expect(metadata_schema.label).to eq(work_type)
-      expect(metadata_schema.fields.count).to eq(2)
+      expect(metadata_schema.fields.count).to eq(3)
     end
 
     context 'a non existing work type' do

--- a/spec/cho/validation/factory_spec.rb
+++ b/spec/cho/validation/factory_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Validation::Factory, type: :model do
     describe '#validator_names' do
       subject { described_class.validator_names }
 
-      it { is_expected.to contain_exactly('my_validator', 'no_validation', 'resource_exists') }
+      it { is_expected.to contain_exactly('my_validator', 'no_validation', 'resource_exists', 'edtf_date') }
     end
   end
 
@@ -60,7 +60,9 @@ RSpec.describe Validation::Factory, type: :model do
     describe '#validator_names' do
       subject { described_class.validator_names }
 
-      it { is_expected.to contain_exactly('my_validator', 'other_validator', 'no_validation', 'resource_exists') }
+      it { is_expected.to contain_exactly(
+        'my_validator', 'other_validator', 'no_validation', 'resource_exists', 'edtf_date'
+      ) }
     end
   end
 end

--- a/spec/cho/validation/methods_spec.rb
+++ b/spec/cho/validation/methods_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Validation::Methods do
+  describe '#edtf_date' do
+    before do
+      class EdtfDateTest < Valkyrie::Resource
+        attribute :date
+      end
+
+      class EdtfDateTestChangeSet < Valkyrie::ChangeSet
+        include Validation::Methods
+
+        property :date, multiple: true
+        validates :date, with: :edtf_date
+      end
+    end
+
+    after do
+      ActiveSupport::Dependencies.remove_constant('EdtfDateTest')
+      ActiveSupport::Dependencies.remove_constant('EdtfDateTestChangeSet')
+    end
+
+    subject(:change_set) { EdtfDateTestChangeSet.new(EdtfDateTest.new) }
+
+    context 'with a single valid EDTF date' do
+      before { change_set.validate(date: '1999-uu-uu') }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'with multiple valid EDTF dates' do
+      before { change_set.validate(date: ['1999-uu-uu', '2001-02-uu']) }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'with a single invalid EDTF date' do
+      before { change_set.validate(date: 'asdf') }
+
+      it { is_expected.not_to be_valid }
+      its(:errors) { is_expected.to include(date: ['asdf is not a valid EDTF date']) }
+    end
+
+    context 'with a multiple invalid EDTF dates' do
+      before { change_set.validate(date: ['asdf', '2']) }
+
+      it { is_expected.not_to be_valid }
+      its(:errors) { is_expected.to include(date: ['asdf is not a valid EDTF date', '2 is not a valid EDTF date']) }
+    end
+
+    context 'with both valid and invalid dates' do
+      before { change_set.validate(date: ['1984?-01~', 'btw']) }
+
+      it { is_expected.not_to be_valid }
+      its(:errors) { is_expected.to include(date: ['btw is not a valid EDTF date']) }
+    end
+
+    context 'with a nil date' do
+      before { change_set.validate(date: nil) }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'with an empty set of dates' do
+      before { change_set.validate(date: []) }
+
+      it { is_expected.to be_valid }
+    end
+  end
+end

--- a/spec/cho/work/submissions/change_set_spec.rb
+++ b/spec/cho/work/submissions/change_set_spec.rb
@@ -163,11 +163,19 @@ RSpec.describe Work::SubmissionChangeSet do
 
       let(:work_field) { Schema::MetadataField.find_using(label: 'generic_field').first }
 
-      its(:count) { is_expected.to eq(6) }
+      its(:count) { is_expected.to eq(7) }
 
       it 'is ordered' do
         expect(fields.map(&:label)).to eq(
-          ['title', 'subtitle', 'description', 'alternate_ids', 'generic_field', 'member_of_collection_ids']
+          [
+            'title',
+            'subtitle',
+            'description',
+            'alternate_ids',
+            'generic_field',
+            'member_of_collection_ids',
+            'created'
+          ]
         )
       end
 
@@ -179,7 +187,15 @@ RSpec.describe Work::SubmissionChangeSet do
 
         it 'is ordered' do
           expect(fields.map(&:label)).to eq(
-            ['generic_field', 'title', 'subtitle', 'description', 'alternate_ids', 'member_of_collection_ids']
+            [
+              'generic_field',
+              'title',
+              'subtitle',
+              'description',
+              'alternate_ids',
+              'member_of_collection_ids',
+              'created'
+            ]
           )
         end
       end
@@ -194,6 +210,7 @@ RSpec.describe Work::SubmissionChangeSet do
                                                                                    'generic_field',
                                                                                    'alternate_ids',
                                                                                    'member_of_collection_ids',
+                                                                                   'created',
                                                                                    'title')
       end
     end

--- a/spec/cho/work/submissions/new_spec.rb
+++ b/spec/cho/work/submissions/new_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Work::Submission, type: :feature do
     end
   end
 
-  context 'when filling in all the required fields' do
+  context 'when filling in all the fields' do
     let!(:archival_collection) { create(:archival_collection, title: 'Sample Collection') }
 
     it 'creates a new work object without a file' do
@@ -19,11 +19,34 @@ RSpec.describe Work::Submission, type: :feature do
       click_link('Generic')
       expect(page).to have_content('New Generic Work')
       fill_in('work_submission[title]', with: 'New Title')
+      fill_in('work_submission[subtitle]', with: 'New subtitle')
+      fill_in('work_submission[description]', with: 'Description of new generic work.')
+      fill_in('work_submission[alternate_ids]', with: 'asdf_1234')
+      fill_in('work_submission[generic_field]', with: 'Sample generic field value')
+      fill_in('work_submission[created]', with: '2018-10-22')
       fill_in('work_submission[member_of_collection_ids]', with: archival_collection.id)
       click_button('Create Work')
-      expect(page).to have_content('New Title')
-      expect(page).to have_content('Generic')
-      expect(page).to have_content(archival_collection.id)
+      expect(page).to have_selector('h1', text: 'New Title')
+      within('#document') do
+        expect(page).to have_blacklight_label(:title_tesim, 'Object Title')
+        expect(page).to have_blacklight_field(:title_tesim, 'New Title')
+        expect(page).to have_blacklight_label(:subtitle_tesim, 'Subtitle')
+        expect(page).to have_blacklight_field(:subtitle_tesim, 'New subtitle')
+        expect(page).to have_blacklight_label(:description_tesim, 'Description')
+        expect(page).to have_blacklight_field(:description_tesim, 'Description of new generic work')
+        expect(page).to have_blacklight_label(:created_tesim, 'Created')
+        expect(page).to have_blacklight_field(:created_tesim, 'datetime-2018-10-22T00:00:00.000Z')
+        expect(page).to have_blacklight_label(:generic_field_tesim, 'Generic Field')
+        expect(page).to have_blacklight_field(:generic_field_tesim, 'Sample generic field value')
+        expect(page).to have_blacklight_label(:alternate_ids_tesim, 'Identifier')
+        expect(page).to have_blacklight_field(:alternate_ids_tesim, 'id-asdf_1234')
+        expect(page).to have_blacklight_label(:work_type_ssim, 'Work Type')
+        expect(page).to have_blacklight_field(:work_type_ssim, 'Generic')
+        expect(page).to have_blacklight_label(:member_of_collection_ids_ssim, 'Member of Collection')
+        expect(page).to have_blacklight_field(:member_of_collection_ids_ssim, 'Sample Collection')
+        expect(page).to have_blacklight_field(:member_of_collection_ids_ssim, archival_collection.id)
+        expect(page).to have_link('Sample Collection')
+      end
       expect(page).to have_link('Edit')
     end
   end

--- a/spec/support/matchers/blacklight.rb
+++ b/spec/support/matchers/blacklight.rb
@@ -2,7 +2,7 @@
 
 RSpec::Matchers.define :have_blacklight_field do |field|
   match do |_actual|
-    page.has_selector?('dd.blacklight-' + field, text: @value)
+    page.has_selector?("dd.blacklight-#{field}", text: @value)
   end
 
   chain :with do |value|
@@ -12,7 +12,7 @@ end
 
 RSpec::Matchers.define :have_blacklight_label do |field|
   match do |_actual|
-    page.has_selector?('dt.blacklight-' + field, text: @value)
+    page.has_selector?("dt.blacklight-#{field}", text: @value)
   end
 
   chain :with do |value|


### PR DESCRIPTION
## Description

Field types designated as "date" can now be validated as EDTF dates, as well as indexed as dates in Solr. The default is to index imprecise dates to midnight of the first day of their earliest range.

Valkyrie will store the value of the date as a string, according to how it was initially entered by the user; however, it will be cast to a Time object if it can be. EDTF dates will not be cast to Date objects, and will only come back as the same strings as they were entered.

Connected to #267 