### PR TITLE
Add facet fields based on the data dictionary

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,3 +39,4 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
     - 'config/initializers/valkyrie.rb'
+    - 'app/blacklight/catalog_controller.rb'

--- a/app/blacklight/catalog_controller.rb
+++ b/app/blacklight/catalog_controller.rb
@@ -90,6 +90,11 @@ class CatalogController < ApplicationController
     config.add_facet_field 'work_type_ssim', label: I18n.t('cho.field_label.work_type')
     config.add_facet_field 'collection_type_ssim', label: I18n.t('cho.field_label.collection_type')
     config.add_facet_field 'member_of_collection_ssim', label: I18n.t('cho.field_label.member_of_collections')
+
+    DataDictionary::Field.all.sort_by(&:created_at).select(&:facet?).each do |field|
+      config.add_facet_field field.facet_field, label: (field.display_name || field.label.titleize)
+    end
+
     # config.add_facet_field 'pub_date', label: 'Publication Year', single: true
     # config.add_facet_field 'subject_topic_facet', label: 'Topic', limit: 20, index_range: 'A'..'Z'
     # config.add_facet_field 'language_facet', label: 'Language', limit: true

--- a/app/cho/data_dictionary/field.rb
+++ b/app/cho/data_dictionary/field.rb
@@ -34,6 +34,11 @@ module DataDictionary
       "#{label}_#{suffix}"
     end
 
+    # @return [String] field name used when this field is used for faceting
+    def facet_field
+      "#{label}_ssim"
+    end
+
     # @return [Valkyrie::Types] property type for the Valkyrie::ChangeSet
     # @note This does not address multiple: valkyrie_id field types are singular, alternate_id types must be
     #    multiple; everything else is multiple.

--- a/config/data_dictionary/data_dictionary_test.csv
+++ b/config/data_dictionary/data_dictionary_test.csv
@@ -4,7 +4,7 @@ member_of_collection_ids,valkyrie_id,optional,resource_exists,false,cho_collecti
 subtitle,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,true
 description,text,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,true
 created,date,optional,edtf_date,true,no_vocabulary,,,no_transformation,date,help me,false
-generic_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false
+generic_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,facet,help me,false
 document_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false
 still_image_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false
 moving_image_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false

--- a/spec/blacklight/catalog_spec.rb
+++ b/spec/blacklight/catalog_spec.rb
@@ -6,10 +6,33 @@ RSpec.describe CatalogController, type: :feature do
   it_behaves_like 'a search form', '/catalog'
 
   context 'when searching for works' do
-    before { create(:work_submission, :with_file) }
+    before do
+      create(:work_submission, :with_file,
+        collection_title: 'Searching Collection',
+        generic_field: 'Faceted Value')
+    end
 
     it 'returns the work and excludes file sets and files' do
       visit(root_path)
+
+      # Check facets
+      within('div.blacklight-member_of_collection_ssim') do
+        expect(page).to have_selector('h3', text: 'Collections')
+        expect(page).to have_link('Searching Collection')
+      end
+      within('div.blacklight-work_type_ssim') do
+        expect(page).to have_selector('h3', text: 'Work Type')
+        expect(page).to have_link('Generic')
+      end
+      within('div.blacklight-collection_type_ssim') do
+        expect(page).to have_selector('h3', text: 'Collection Type')
+        expect(page).to have_link('Archival Collection')
+      end
+      within('div.blacklight-generic_field_ssim') do
+        expect(page).to have_selector('h3', text: 'Generic Field')
+        expect(page).to have_link('Faceted Value')
+      end
+
       click_button('Search')
       within('#documents') do
         expect(page).to have_link('Sample Generic Work')

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -9,11 +9,15 @@ FactoryBot.define do
     title { 'Sample Generic Work' }
     work_type_id { Work::Type.find_using(label: 'Generic').first.id }
 
+    transient do
+      collection_title { 'Sample Archival Collection' }
+    end
+
     member_of_collection_ids do
       if @build_strategy.is_a? FactoryBot::Strategy::Build
-        build(:collection).id
+        build(:collection, title: collection_title).id
       else
-        create(:collection).id
+        create(:collection, title: collection_title).id
       end
     end
 


### PR DESCRIPTION
## Description

Adds a faceted field based on its index type in the data dictionary. This doesn't address custom facets for collections and work types. Collections could be made to work with this setup, but we'd need to explore using transformations, which haven't been implemented yet.

Connected to #459 

