### PR TITLE
Explicit sorting by name when reading from the file system

### DIFF
--- a/app/cho/import/work.rb
+++ b/app/cho/import/work.rb
@@ -10,8 +10,8 @@ class Import::Work
   # @param [Pathname]
   def initialize(path)
     @path = path
-    @files = path.children.select(&:file?).map { |file| Import::File.new(file) }
-    @nested_works = path.children.select(&:directory?).map { |directory| self.class.new(directory) }
+    @files = sorted_files
+    @nested_works = sorted_works
   end
 
   def file_sets
@@ -53,5 +53,19 @@ class Import::Work
       else
         "#{file_set} does not have a service or preservation file"
       end
+    end
+
+    def sorted_works
+      children = path.children.select(&:directory?).map do |directory|
+        self.class.new(directory)
+      end
+      children.sort! { |a, b| a.identifier <=> b.identifier }
+    end
+
+    def sorted_files
+      children = path.children.select(&:file?).map do |file|
+        Import::File.new(file)
+      end
+      children.sort! { |a, b| a.original_filename <=> b.original_filename }
     end
 end


### PR DESCRIPTION
## Description

When reading bags off the disk, the order of file sets and any nested
works is dependent on the order in which they are read off of the file
system. In some cases, Travis was reading these in a different order
than our local machines. To make this explicit, the files and
directories within a bag are sorted on their identifiers, in the case of
works, or their filenames, in the case of file sets.
