### PR TITLE
Display thumbnails in search results and show views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 .rubocop-http*
 config/database.yml
 config/hydra-ldap.yml
+public/files

--- a/app/blacklight/catalog_controller.rb
+++ b/app/blacklight/catalog_controller.rb
@@ -7,6 +7,8 @@ class CatalogController < ApplicationController
 
   helper LocalHelperBehavior, LayoutHelperBehavior
 
+  Blacklight::IndexPresenter.thumbnail_presenter = ::ThumbnailPresenter
+
   configure_blacklight do |config|
     ## Class for sending and receiving requests from a search index
     # config.repository_class = Blacklight::Solr::Repository
@@ -43,6 +45,8 @@ class CatalogController < ApplicationController
     config.index.title_field = 'title_tesim'
     config.show.title_field = 'title_tesim'
 
+    config.show.document_presenter_class = ShowPresenter
+
     DataDictionary::Field.all.sort_by(&:created_at).each do |map_field|
       catalog_field = "#{map_field.label.parameterize.underscore.to_sym}_tesim"
       catalog_label = map_field.label.titleize
@@ -56,11 +60,11 @@ class CatalogController < ApplicationController
 
     # solr field configuration for search results/index views
     config.index.display_type_field = 'work_type_ssim'
-    # config.index.thumbnail_field = 'thumbnail_path_ss'
+    config.index.thumbnail_field = 'thumbnail_path_ss'
 
     # solr field configuration for document/show views
     config.show.display_type_field = 'internal_resource_ssim'
-    # config.show.thumbnail_field = 'thumbnail_path_ss'
+    config.show.thumbnail_field = 'thumbnail_path_ss'
 
     # solr fields that will be treated as facets by the blacklight application
     #   The ordering of the field names is the order of the display

--- a/app/blacklight/show_presenter.rb
+++ b/app/blacklight/show_presenter.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ShowPresenter < Blacklight::ShowPresenter
+  def thumbnail
+    @thumbnail ||= ThumbnailPresenter.new(document, view_context, view_config)
+  end
+end

--- a/app/blacklight/thumbnail_presenter.rb
+++ b/app/blacklight/thumbnail_presenter.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ThumbnailPresenter < Blacklight::ThumbnailPresenter
+  private
+
+    def thumbnail_value_from_document(document)
+      path = Array(thumbnail_field).lazy.map { |field| document.first(field) }.reject(&:blank?).first
+      return if path.nil?
+      "/files/#{Pathname.new(path).basename}"
+    end
+end

--- a/app/cho/metrics/repository.rb
+++ b/app/cho/metrics/repository.rb
@@ -17,9 +17,14 @@ module Metrics
       end
 
       def reset_directories
-        reset_directory(Rails.root.join('tmp', 'files'))
+        reset_directory(Rails.root.join(storage_directory))
         reset_directory(Rails.root.join(network_ingest_directory))
         reset_directory(Rails.root.join(extraction_directory))
+      end
+
+      # @return [Pathname] absolute path to the location of stored files
+      def storage_directory
+        Pathname.new(ENV['storage_directory']).expand_path
       end
 
       private

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -1,0 +1,18 @@
+<%# Removes the pagination code from here to the app/views/catalog/show partial for better responsive pages  %>
+<% @page_title = t('blacklight.search.show.title', document_title: document_show_html_title, application_name: application_name).html_safe %>
+<% content_for(:head) { render_link_rel_alternates } %>
+
+<div id="document" class="document <%= render_document_class %>" itemscope itemtype="<%= @document.itemtype %>">
+  <div id="doc_<%= @document.id.to_s.parameterize %>">
+    <%= render_document_partials @document, blacklight_config.view_config(:show).partials %>
+  </div>
+</div>
+
+<% if @document.respond_to?(:export_as_openurl_ctx_kev) %>
+  <!--
+       // COinS, for Zotero among others.
+       // This document_partial_name(@document) business is not quite right,
+       // but has been there for a while.
+  -->
+  <span class="Z3988" title="<%= @document.export_as_openurl_ctx_kev(document_partial_name(@document)) %>"></span>
+<% end %>

--- a/app/views/catalog/_thumbnail.html.erb
+++ b/app/views/catalog/_thumbnail.html.erb
@@ -1,0 +1,5 @@
+<% if presenter(document).thumbnail.exists? && tn = presenter(document).thumbnail.thumbnail_tag({class: 'w-100'}, counter: document_counter_with_offset(document_counter)) %>
+  <div class="document-thumbnail">
+    <%= tn %>
+  </div>
+<% end %>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,13 +1,24 @@
 <%# Overriding Blacklight to render edit link %>
 
 <% if current_search_session %>
-  <div id="appliedParams" class="clearfix constraints-container">
-    <%= link_to t('blacklight.search.start_over'), start_over_path, class: 'catalog_startOverLink btn btn-primary' %>
-    <%= link_back_to_catalog class: 'btn btn-outline-secondary' %>
+  <div id="appliedParams" class="clearfix constraints-container ml-3">
+    <%= link_back_to_catalog(label: 'Back to Search Results', class: 'btn btn-outline-secondary') %>
+    <%= render 'previous_next_doc' if @search_context %>
   </div>
 <% end %>
 
-<%= render_document_main_content_partial %>
+<%# Use Bootstrap columns to position the thumbnail on the left and the content partials on the right %>
+<div class="container mt-4">
+  <div class="row">
+    <div class="col-xs-12 col-md-4">
+      <%= render 'thumbnail', document: @document, document_counter: 0 %>
+    </div>
+    <div class="col-xs-12 col-md-8">
+      <%= render_document_main_content_partial %>
+    </div>
+  </div>
+</div>
+
 <% unless @document.internal_resource == Work::FileSet %>
   <%= link_to 'Edit', edit_cho_resource_path %>
 <% end %>

--- a/config/application.yml
+++ b/config/application.yml
@@ -7,11 +7,13 @@ development:
   virtual_host: "http://localhost:3000/"
   network_ingest_directory: 'tmp/ingest-development'
   extraction_directory: 'tmp/extract-development'
+  storage_directory: 'public/files'
 test:
   service_name: "example-test"
   service_instance: "example-test"
   virtual_host: "http://test.com/"
   network_ingest_directory: 'tmp/ingest-test'
   extraction_directory: 'tmp/extract-test'
+  storage_directory: 'public/files'
 
 production:

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -67,7 +67,7 @@ set :linked_dirs, fetch(:linked_dirs, []).push(
   'tmp/pids',
   'tmp/sockets',
   'tmp/uploads',
-  'tmp/files',
+  'public/files',
   'vendor/bundle'
 )
 

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -39,7 +39,7 @@ Rails.application.config.to_prepare do
   # Storage Adapters
 
   Valkyrie::StorageAdapter.register(
-    Valkyrie::Storage::Disk.new(base_path: Rails.root.join('tmp', 'files')),
+    Valkyrie::Storage::Disk.new(base_path: Metrics::Repository.storage_directory),
     :disk
   )
 

--- a/spec/blacklight/show_presenter_spec.rb
+++ b/spec/blacklight/show_presenter_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ShowPresenter do
+  let(:presenter) { described_class.new(document, request_context, config) }
+  let(:document) { {} }
+  let(:request_context) { double }
+  let(:config) { Blacklight::Configuration.new }
+
+  describe '#thumbnail' do
+    subject { presenter.thumbnail }
+
+    it { is_expected.to be_instance_of ThumbnailPresenter }
+  end
+end

--- a/spec/cho/work/file_spec.rb
+++ b/spec/cho/work/file_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Work::File do
 
     context 'with a file' do
       before { file.file_identifier = binary_content.id }
-      its(:path) { is_expected.to end_with('cho/tmp/files/My File.txt') }
+      its(:path) { is_expected.to eq(Metrics::Repository.storage_directory.join('My File.txt').to_s) }
     end
   end
 end

--- a/spec/cho/work/submissions/new_spec.rb
+++ b/spec/cho/work/submissions/new_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe Work::Submission, type: :feature do
 
     let(:zip_file) { ImportFactory::Zip.create(bag) }
 
-    it 'creates a new work object with file sets and files from the zip' do
+    it 'creates a new work object with file sets, files, and a thumbnail from the zip' do
       visit(root_path)
       click_link('Create Work')
       click_link('Generic')
@@ -170,13 +170,20 @@ RSpec.describe Work::Submission, type: :feature do
       click_button('Create Work')
       expect(page).to have_content('Work and file sets with attached zip')
       expect(page).to have_content('Generic')
+      expect(page).to have_xpath("//img[@src='/files/work1_thumb.jpg']")
+      expect(page).to have_xpath("//img[@alt='Work1 thumb']")
       expect(page).to have_link('Edit')
       expect(page).to have_selector('h2', text: 'Files')
       expect(page).to have_content('work1_00001_01_preservation.tif')
       expect(page).to have_content('work1_00001_02_preservation.tif')
       expect(page).to have_content('work1_00002_01_preservation.tif')
       expect(page).to have_content('work1_00002_02_preservation.tif')
-      expect(page).to have_content('work1_service.pdf')
+
+      # Check thumbnail display on the file set
+      click_link('work1_service.pdf')
+      expect(page).to have_selector('h1', text: 'work1_service.pdf')
+      expect(page).to have_xpath("//img[@src='/files/work1_thumb.jpg']")
+      expect(page).to have_xpath("//img[@alt='Work1 thumb']")
     end
   end
 end

--- a/spec/valkyrie/change_set_persister_spec.rb
+++ b/spec/valkyrie/change_set_persister_spec.rb
@@ -119,14 +119,14 @@ RSpec.describe ChangeSetPersister do
       expect(Work::Submission.all.count).to eq(1)
       expect(Work::File.all.count).to eq(2)
       expect(metadata_adapter.index_adapter.query_service.find_all.count).to eq(5)
-      expect(File.exists?('tmp/files/hello_world.txt')).to be(true)
-      expect(File.exists?('tmp/files/hello_world.txt_text.txt')).to be(true)
+      expect(Metrics::Repository.storage_directory.join('hello_world.txt')).to be_exist
+      expect(Metrics::Repository.storage_directory.join('hello_world.txt_text.txt')).to be_exist
       change_set_persister.delete(change_set: change_set)
       expect(Work::Submission.all.count).to eq(0)
       expect(Work::File.all.count).to eq(0)
       expect(metadata_adapter.index_adapter.query_service.find_all.count).to eq(1)
-      expect(File.exists?('tmp/files/hello_world.txt')).to be(false)
-      expect(File.exists?('tmp/files/hello_world.txt_text.txt')).to be(false)
+      expect(Metrics::Repository.storage_directory.join('hello_world.txt')).not_to be_exist
+      expect(Metrics::Repository.storage_directory.join('hello_world.txt_text.txt')).not_to be_exist
     end
   end
 


### PR DESCRIPTION
## Description

Using Blacklight's features and overriding them where needed, we're displaying thumbnails on search results and show views for works and file sets.

Connected to #740 

## Changes

* creates custom Blacklight presenters
* moves files storage to the public directory for easier linking
* indexes a thumbnail's path in the work and file set
* identifies representative file sets for works