### PR TITLE
Refactor InputField

### DIFF
--- a/app/cho/controlled_vocabulary/base.rb
+++ b/app/cho/controlled_vocabulary/base.rb
@@ -2,8 +2,8 @@
 
 module ControlledVocabulary
   class Base
-    def lookup(_value)
-      raise Error.new('ControlledVocabulary.lookup is abstract. Children must implement.')
+    def self.list
+      raise Error.new('ControlledVocabulary.list is abstract. Children must implement.')
     end
   end
 end

--- a/app/cho/controlled_vocabulary/factory.rb
+++ b/app/cho/controlled_vocabulary/factory.rb
@@ -15,7 +15,7 @@ module ControlledVocabulary
 
         def default_items
           {
-            default_key => ControlledVocabulary::None.new,
+            default_key => ControlledVocabulary::None,
             cho_collections: ControlledVocabulary::Collections
           }
         end

--- a/app/cho/controlled_vocabulary/none.rb
+++ b/app/cho/controlled_vocabulary/none.rb
@@ -2,7 +2,7 @@
 
 module ControlledVocabulary
   class None < Base
-    def lookup(_value)
+    def self.list
       []
     end
   end

--- a/app/views/shared/_form_fields.html.erb
+++ b/app/views/shared/_form_fields.html.erb
@@ -1,18 +1,10 @@
-<%- resource.input_fields(form).each do |input| %>
-  <%= input.label do %>
-    <%= input.display_label %>
-    <% if input.required? %>
+<%- resource.input_fields(form).each do |input_field| %>
+  <%= form.label input_field.label do %>
+    <%= input_field.display_label %>
+    <% if input_field.required? %>
       <span class="required no-bold"> required</span>
     <% end %>
   <% end %>
 
-  <%= input.field %>
-
-  <% if input.metadata_field.controlled_vocabulary == "cho_collections" %>
-    <datalist id="<%= input.metadata_field.label %>">
-      <% ControlledVocabulary::Collections.list.each do |collection| %>
-        <option value="<%= collection.id %>"><%= collection.title %></option>
-      <% end %>
-    </datalist>
-  <% end %>
+  <%= render "/shared/input_partials/#{input_field.partial}", field: input_field, form: form %>
 <%- end %>

--- a/app/views/shared/input_partials/_string.html.erb
+++ b/app/views/shared/input_partials/_string.html.erb
@@ -1,0 +1,1 @@
+<%= form.text_field field.label, field.options %>

--- a/app/views/shared/input_partials/_text.html.erb
+++ b/app/views/shared/input_partials/_text.html.erb
@@ -1,0 +1,1 @@
+<%= form.text_area field.label, field.options.merge!(value: field.value) %>

--- a/app/views/shared/input_partials/_valkyrie_id.html.erb
+++ b/app/views/shared/input_partials/_valkyrie_id.html.erb
@@ -1,0 +1,7 @@
+<%= form.text_field field.label, field.options.merge!(list: field.label) %>
+
+<datalist id="<%= field.label %>">
+  <% field.datalist.each do |item| %>
+    <option value="<%= item.id %>"><%= item.title %></option>
+  <% end %>
+</datalist>

--- a/spec/cho/collection/change_set_behaviors_spec.rb
+++ b/spec/cho/collection/change_set_behaviors_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Collection::ChangeSetBehaviors do
     let(:form) { double }
 
     it 'contains an array of Schema::InputFields' do
-      expect(change_set.input_fields(form).map(&:label_text)).to contain_exactly(
+      expect(change_set.input_fields(form).map(&:label)).to contain_exactly(
         'subtitle', 'description', 'title', 'alternate_ids'
       )
     end

--- a/spec/cho/controlled_vocabulary/base_spec.rb
+++ b/spec/cho/controlled_vocabulary/base_spec.rb
@@ -3,11 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe ControlledVocabulary::Base, type: :model do
-  describe '#lookup' do
-    let(:error) { 'ControlledVocabulary.lookup is abstract. Children must implement.' }
+  describe '#list' do
+    let(:error) { 'ControlledVocabulary.list is abstract. Children must implement.' }
 
     it 'raises an error' do
-      expect { described_class.new.lookup('value') }.to raise_error(ControlledVocabulary::Error, error)
+      expect { described_class.list }.to raise_error(ControlledVocabulary::Error, error)
     end
   end
 end

--- a/spec/cho/controlled_vocabulary/none_spec.rb
+++ b/spec/cho/controlled_vocabulary/none_spec.rb
@@ -3,12 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe ControlledVocabulary::None, type: :model do
-  subject { described_class.new }
-
-  it { within_block_is_expected.not_to raise_exception }
-
-  describe '#transform' do
-    subject { described_class.new.lookup('abc') }
+  describe '#list' do
+    subject { described_class.list }
 
     it { is_expected.to eq([]) }
   end

--- a/spec/cho/schema/input_field_spec.rb
+++ b/spec/cho/schema/input_field_spec.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'valkyrie/specs/shared_specs'
+
+RSpec.describe Schema::InputField, type: :model do
+  subject { model }
+
+  let(:model) { described_class.new(form: form, metadata_field: metadata_field) }
+  let(:metadata_field) do
+    build :schema_metadata_field,
+      label: 'abc123_label',
+      field_type: 'date',
+      requirement_designation: 'recommended',
+      controlled_vocabulary: 'no_vocabulary',
+      default_value: 'abc123',
+      display_name: 'My Abc123',
+      display_transformation: 'no_transformation',
+      multiple: false, validation: 'no_validation',
+      core_field: false, order_index: 0,
+      work_type: 'something'
+  end
+
+  let(:form) { instance_double ActionView::Helpers::FormBuilder }
+
+  it { is_expected.to respond_to(:text?) }
+  it { is_expected.to respond_to(:required?) }
+  it { is_expected.to respond_to(:valkyrie_id?) }
+  it { is_expected.to respond_to(:label) }
+
+  describe '#display_label' do
+    subject { model.display_label }
+
+    context 'when there is a display label' do
+      it { is_expected.to eq('My Abc123') }
+    end
+
+    context 'when there is no display name' do
+      before { metadata_field.display_name = nil }
+
+      it { is_expected.to eq('Abc123 Label') }
+    end
+  end
+
+  describe '#partial' do
+    subject { model.partial }
+
+    before { metadata_field.field_type = type }
+
+    context 'with the default string type' do
+      let(:type) { 'string' }
+
+      it { is_expected.to eq('string') }
+    end
+
+    context 'text field type' do
+      let(:type) { 'text' }
+
+      it { is_expected.to eq('text') }
+    end
+
+    context 'numeric field type' do
+      let(:type) { 'numeric' }
+
+      it { is_expected.to eq('string') }
+    end
+
+    context 'date field type' do
+      let(:type) { 'date' }
+
+      it { is_expected.to eq('string') }
+    end
+
+    context 'valkyrie_id field type' do
+      let(:type) { 'valkyrie_id' }
+
+      it { is_expected.to eq('valkyrie_id') }
+    end
+
+    context 'alternate_id field type' do
+      let(:type) { 'alternate_id' }
+
+      it { is_expected.to eq('string') }
+    end
+  end
+
+  describe '#options' do
+    subject { model.options }
+
+    context 'when the field is not required' do
+      it { is_expected.to include("aria-required": false, required: false) }
+    end
+
+    context 'when the field is required' do
+      before { metadata_field.requirement_designation = 'required' }
+
+      it { is_expected.to include("aria-required": true, required: true) }
+    end
+  end
+
+  describe '#datalist' do
+    subject { model.datalist }
+
+    before { metadata_field.field_type = type }
+
+    context 'with the default string type' do
+      let(:type) { 'string' }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'text field type' do
+      let(:type) { 'text' }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'numeric field type' do
+      let(:type) { 'numeric' }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'date field type' do
+      let(:type) { 'date' }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'valkyrie_id field type' do
+      let(:type) { 'valkyrie_id' }
+
+      it { is_expected.to eq(ControlledVocabulary::Collections.list) }
+    end
+
+    context 'alternate_id field type' do
+      let(:type) { 'alternate_id' }
+
+      it { is_expected.to be_empty }
+    end
+  end
+
+  describe '#value' do
+    let(:resource) { instance_double('Resource', abc123_label: ['value']) }
+
+    before { allow(form).to receive(:object).and_return(resource) }
+
+    its(:value) { is_expected.to eq('value') }
+  end
+end

--- a/spec/cho/work/submissions/change_set_spec.rb
+++ b/spec/cho/work/submissions/change_set_spec.rb
@@ -205,13 +205,13 @@ RSpec.describe Work::SubmissionChangeSet do
       let(:form) { double }
 
       it 'contains an array of Schema::InputFields' do
-        expect(change_set.input_fields(form).map(&:label_text)).to contain_exactly('subtitle',
-                                                                                   'description',
-                                                                                   'generic_field',
-                                                                                   'alternate_ids',
-                                                                                   'member_of_collection_ids',
-                                                                                   'created',
-                                                                                   'title')
+        expect(change_set.input_fields(form).map(&:label)).to contain_exactly('subtitle',
+                                                                              'description',
+                                                                              'generic_field',
+                                                                              'alternate_ids',
+                                                                              'member_of_collection_ids',
+                                                                              'created',
+                                                                              'title')
       end
     end
   end

--- a/spec/views/work_submissions/edit.html.erb_spec.rb
+++ b/spec/views/work_submissions/edit.html.erb_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'work/submissions/edit', type: :view do
     display_label ||= specific_field.titleize
     subtitle_label ||= 'Subtitle'
     assert_select 'form[action=?][method=?]', work_path(@work.model), 'post' do
-      assert_select 'label[for=?]', 'work_submission_title', text: "Object Title\n       required"
+      assert_select 'label[for=?]', 'work_submission_title', text: /Object Title(\s*)required/
       assert_select 'input[name=?]', 'work_submission[title]'
       assert_select 'label[for=?]', 'work_submission_subtitle', text: subtitle_label
       assert_select 'input[name=?]', 'work_submission[subtitle]'


### PR DESCRIPTION
## Description

Delegates different field types to partials, placing the logic for
determining options, display names, and controlled vocabulary lists on
the input field.

The partials allow more complex rendering which will be needed in
forthcoming field types, such as the creator which has multiple inputs.

Connected to #730