### PR TITLE
Form for adding creators to works or collections

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,3 +40,9 @@ Metrics/BlockLength:
     - 'spec/**/*'
     - 'config/initializers/valkyrie.rb'
     - 'app/blacklight/catalog_controller.rb'
+
+# This is due to a bug in Rubocop. A future version of Niftany, which will include an updated
+# version of Rubocop, should fix this.
+Rails/Presence:
+  Exclude:
+    - 'app/cho/indexing/creator.rb'

--- a/app/blacklight/catalog_controller.rb
+++ b/app/blacklight/catalog_controller.rb
@@ -95,6 +95,9 @@ class CatalogController < ApplicationController
     config.add_facet_field 'collection_type_ssim', label: I18n.t('cho.field_label.collection_type')
     config.add_facet_field 'member_of_collection_ssim', label: I18n.t('cho.field_label.member_of_collections')
 
+    # @todo configuration of linked field indexing
+    config.add_facet_field 'creator_role_ssim', label: I18n.t('cho.field_label.role')
+
     DataDictionary::Field.all.sort_by(&:created_at).select(&:facet?).each do |field|
       config.add_facet_field field.facet_field, label: (field.display_name || field.label.titleize)
     end

--- a/app/cho/agent/resource.rb
+++ b/app/cho/agent/resource.rb
@@ -6,5 +6,9 @@ module Agent
 
     attribute :given_name, Valkyrie::Types::String
     attribute :surname, Valkyrie::Types::String
+
+    def to_s
+      "#{given_name} #{surname}"
+    end
   end
 end

--- a/app/cho/data_dictionary/with_index_type.rb
+++ b/app/cho/data_dictionary/with_index_type.rb
@@ -3,7 +3,7 @@
 module DataDictionary::WithIndexType
   extend ActiveSupport::Concern
 
-  IndexTypes = Valkyrie::Types::String.enum('facet', 'no_facet', 'date')
+  IndexTypes = Valkyrie::Types::String.enum('facet', 'no_facet', 'date', 'linked_field')
 
   included do
     attribute :index_type, IndexTypes
@@ -31,5 +31,13 @@ module DataDictionary::WithIndexType
 
   def date?
     index_type == 'date'
+  end
+
+  def linked_field!
+    self.index_type = 'linked_field'
+  end
+
+  def linked_field?
+    index_type == 'linked_field'
   end
 end

--- a/app/cho/indexing/creator.rb
+++ b/app/cho/indexing/creator.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Indexing
+  class Creator
+    attr_reader :hash_values, :solr_field
+
+    def initialize(values:, solr_field:)
+      @hash_values = values.map { |hash| HashCreator.new(hash) }
+      @solr_field = solr_field
+    end
+
+    def to_solr
+      {
+        solr_field => hash_values.map(&:display_name).compact,
+        'creator_role_tesim' => hash_values.map(&:role).compact,
+        'creator_role_ssim' => hash_values.map(&:role).compact,
+        'creator_agent_tesim' => hash_values.map(&:agent_display).compact,
+        'creator_role_id_ssim' => hash_values.map(&:role_id).compact,
+        'creator_agent_id_ssim' => hash_values.map(&:agent_id).compact.map(&:to_s)
+      }
+    end
+
+    class HashCreator
+      attr_reader :role_id, :agent_id
+
+      def initialize(arg)
+        @role_id = arg.fetch(:role)
+        @agent_id = arg.fetch(:agent)
+      end
+
+      # @todo RDF::Vocab might have a more efficient way of searching through terms to retrieve one
+      #       based on its uri.
+      # @return [String]
+      def role
+        return if role_id.blank?
+        RDF::Vocab::MARCRelators.to_a.select { |relator| relator.to_uri == role_id }.first.label.to_s
+      end
+
+      # @return [String]
+      def agent
+        return if agent_id.blank?
+        Agent::Resource.find(Valkyrie::ID.new(agent_id))
+      end
+
+      def agent_display
+        return if blank?
+        agent.to_s
+      end
+
+      def blank?
+        role.blank? && agent.blank?
+      end
+
+      def display_name
+        return if blank?
+        "#{agent.surname}, #{agent.given_name}, #{role}"
+      end
+    end
+  end
+end

--- a/app/cho/indexing/linked_fields.rb
+++ b/app/cho/indexing/linked_fields.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Indexing
+  class LinkedFields
+    attr_reader :resource
+    def initialize(resource:)
+      @resource = resource
+    end
+
+    def to_solr
+      solr_document = {}
+      linked_fields.each do |field|
+        solr_document.merge!(solr_fields(field))
+      end
+      solr_document
+    end
+
+    private
+
+      # @note Creators are the only kinds of linked fields at the moment, so this needs to be
+      #       make more generic to handle different kinds of linked fields in the future.
+      def linked_fields
+        @linked_fields ||= Schema::MetadataField.where(index_type: 'linked_field').select do |field|
+          resource.attributes[field.label.to_sym].present?
+        end.to_a
+      end
+
+      def solr_fields(field)
+        solrizer_class = Indexing.const_get(field.label.capitalize)
+        solrizer_class.new(solr_field: field.solr_field, values: resource.attributes[field.label.to_sym]).to_solr
+      rescue NameError
+        {}
+      end
+  end
+end

--- a/app/cho/metrics/collection.rb
+++ b/app/cho/metrics/collection.rb
@@ -73,7 +73,7 @@ module Metrics
       def work_params(count)
         {
           title: [I18n.t("#{i18n_key}.work_title", count: count)],
-          creator: [Faker::Name.name],
+          creator: [{ agent: agent.id.to_s, role: role }],
           date_created: [Faker::Date.between(10.years.ago, 1.year.ago).strftime('%A, %b %d, %Y')],
           subject: Faker::Lorem.words(4, true),
           location: [Faker::StarTrek.location],
@@ -101,6 +101,19 @@ module Metrics
 
       def i18n_key
         "cho.#{self.class.to_s.gsub(/::/, '.').downcase}"
+      end
+
+      def agent
+        resource = Agent::Resource.new(given_name: Faker::Name.first_name, surname: Faker::Name.last_name)
+        Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: resource)
+      end
+
+      def role
+        relators.sample
+      end
+
+      def relators
+        @relators ||= RDF::Vocab::MARCRelators.to_a
       end
   end
 end

--- a/app/cho/schema/input_field.rb
+++ b/app/cho/schema/input_field.rb
@@ -6,7 +6,7 @@ module Schema
 
     attr_reader :form, :metadata_field
 
-    delegate :text?, :required?, :valkyrie_id?, :label, to: :metadata_field
+    delegate :text?, :required?, :valkyrie_id?, :creator?, :label, to: :metadata_field
 
     # @param [ActionView::Helpers::FormBuilder] form
     # @param [Schema::MetadataField] metadata_field
@@ -20,7 +20,7 @@ module Schema
     end
 
     def partial
-      if text? || valkyrie_id?
+      if text? || valkyrie_id? || creator?
         metadata_field.field_type
       else
         'string'
@@ -31,8 +31,8 @@ module Schema
       { required: required?, 'aria-required': required? }
     end
 
-    def datalist
-      ControlledVocabulary::Factory.lookup(metadata_field.controlled_vocabulary.to_sym).list
+    def datalist(component: nil)
+      ControlledVocabulary::Factory.lookup(metadata_field.controlled_vocabulary.to_sym).list(component: component)
     end
 
     def value

--- a/app/views/shared/input_partials/_creator.html.erb
+++ b/app/views/shared/input_partials/_creator.html.erb
@@ -1,0 +1,28 @@
+<%= form.fields_for :creator do |creator_form| %>
+  <% field_value = field.value || {} %>
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12 col-lg-3">
+        <%= form.label :role %>
+        <%= creator_form.text_field :role,
+            field.options.merge!(list: "#{field.label}_role", value: field_value.fetch(:role, nil)) %>
+        <datalist id="<%= "#{field.label}_role" %>">
+          <% field.datalist(component: :roles).each do |item| %>
+            <option value="<%= item %>"><%= item.label %></option>
+          <% end %>
+        </datalist>
+      </div>
+
+      <div class="col-md-12 col-lg-3">
+        <%= form.label :agent %>
+        <%= creator_form.text_field :agent,
+            field.options.merge!(list: "#{field.label}_agent", value: field_value.fetch(:agent, nil)) %>
+        <datalist id="<%= "#{field.label}_agent" %>">
+          <% field.datalist(component: :agents).each do |item| %>
+            <option value="<%= item.id %>"><%= item %></option>
+          <% end %>
+        </datalist>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/config/data_dictionary/data_dictionary_development.csv
+++ b/config/data_dictionary/data_dictionary_development.csv
@@ -2,7 +2,7 @@ Label,Field Type,Requirement Designation,Validation,Multiple,Controlled Vocabula
 title,string,required,no_validation,false,no_vocabulary,,Title,no_transformation,no_facet,help me,true
 member_of_collection_ids,valkyrie_id,optional,resource_exists,false,cho_collections,,Member of Collection,no_transformation,no_facet,help me,false
 alternate_ids,alternate_id,required_to_publish,no_validation,true,no_vocabulary,,Identifier,no_transformation,no_facet,help me,true
-creator,creator,optional,no_validation,true,no_vocabulary,,Creator,no_transformation,no_facet,help me,true
+creator,creator,optional,no_validation,true,creator_vocabulary,,Creator,no_transformation,linked_field,help me,true
 date_created,string,required_to_publish,no_validation,true,no_vocabulary,,Date Created,no_transformation,no_facet,help me,true
 subject,string,optional,no_validation,true,no_vocabulary,,Subject,no_transformation,no_facet,help me,true
 location,string,optional,no_validation,true,no_vocabulary,,Location,no_transformation,no_facet,help me,true

--- a/config/data_dictionary/data_dictionary_test.csv
+++ b/config/data_dictionary/data_dictionary_test.csv
@@ -11,4 +11,4 @@ moving_image_field,string,optional,no_validation,true,no_vocabulary,,,no_transfo
 map_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false
 audio_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false
 alternate_ids,alternate_id,required_to_publish,no_validation,true,no_vocabulary,,Identifier,no_transformation,no_facet,help me,true
-creator,creator,optional,creator,true,creator_vocabulary,,Creator,no_transformation,no_facet,help me,true
+creator,creator,optional,creator,true,creator_vocabulary,,Creator,no_transformation,linked_field,help me,true

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -22,7 +22,8 @@ Rails.application.config.to_prepare do
         Work::SubmissionIndexer,
         Work::FileSetIndexer,
         Collection::TypeIndexer,
-        Indexing::Dates
+        Indexing::Dates,
+        Indexing::LinkedFields
       )
     ),
     :index_solr

--- a/config/locales/cho.yml
+++ b/config/locales/cho.yml
@@ -19,6 +19,7 @@ en:
       title: "Title"
       required: "required"
       member_of_collections: "Collections"
+      role: "Role"
     header_links:
       create_collection: "Create Collection"
       create_submission: "Create Work"

--- a/spec/blacklight/catalog_spec.rb
+++ b/spec/blacklight/catalog_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CatalogController, type: :feature do
 
   context 'when searching for works' do
     before do
-      create(:work_submission, :with_file,
+      create(:work_submission, :with_file, :with_creator,
         collection_title: 'Searching Collection',
         generic_field: 'Faceted Value')
     end
@@ -31,6 +31,10 @@ RSpec.describe CatalogController, type: :feature do
       within('div.blacklight-generic_field_ssim') do
         expect(page).to have_selector('h3', text: 'Generic Field')
         expect(page).to have_link('Faceted Value')
+      end
+      within('div.blacklight-creator_role_ssim') do
+        expect(page).to have_selector('h3', text: 'Role')
+        expect(page).to have_link('blasting')
       end
 
       click_button('Search')

--- a/spec/cho/controlled_vocabulary/creators_spec.rb
+++ b/spec/cho/controlled_vocabulary/creators_spec.rb
@@ -16,17 +16,7 @@ RSpec.describe ControlledVocabulary::Creators, type: :model do
     context 'with roles' do
       subject { described_class.list(component: :roles) }
 
-      let(:relator_list) do
-        [
-          RDF::Vocabulary::Term.new('http://id.loc.gov/vocabulary/relators/bsl'),
-          RDF::Vocabulary::Term.new('http://id.loc.gov/vocabulary/relators/cli')
-        ]
-      end
-
-      # @note We mock this response because calling it takes 10 seconds to build the full list
-      before { allow(RDF::Vocab::MARCRelators).to receive(:to_a).and_return(relator_list) }
-
-      it { is_expected.to eq(relator_list) }
+      it { is_expected.to eq(MockRDF.relators) }
     end
 
     context 'with a bogus component' do

--- a/spec/cho/data_dictionary/with_index_type_spec.rb
+++ b/spec/cho/data_dictionary/with_index_type_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe DataDictionary::WithIndexType, type: :model do
     it { is_expected.not_to be_facet }
     it { is_expected.not_to be_no_facet }
     it { is_expected.not_to be_date }
+    it { is_expected.not_to be_linked_field }
   end
 
   context 'when the index type is a facet' do
@@ -29,6 +30,7 @@ RSpec.describe DataDictionary::WithIndexType, type: :model do
     it { is_expected.to be_facet }
     it { is_expected.not_to be_no_facet }
     it { is_expected.not_to be_date }
+    it { is_expected.not_to be_linked_field }
   end
 
   context 'when the index type is no facet' do
@@ -37,6 +39,7 @@ RSpec.describe DataDictionary::WithIndexType, type: :model do
     it { is_expected.not_to be_facet }
     it { is_expected.to be_no_facet }
     it { is_expected.not_to be_date }
+    it { is_expected.not_to be_linked_field }
   end
 
   context 'when the index type is a date' do
@@ -45,6 +48,16 @@ RSpec.describe DataDictionary::WithIndexType, type: :model do
     it { is_expected.not_to be_facet }
     it { is_expected.not_to be_no_facet }
     it { is_expected.to be_date }
+    it { is_expected.not_to be_linked_field }
+  end
+
+  context 'when the index type is a linked_field' do
+    before { model.linked_field! }
+
+    it { is_expected.not_to be_facet }
+    it { is_expected.not_to be_no_facet }
+    it { is_expected.not_to be_date }
+    it { is_expected.to be_linked_field }
   end
 
   context 'index_type is bogus' do

--- a/spec/cho/indexing/linked_fields_spec.rb
+++ b/spec/cho/indexing/linked_fields_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Indexing::LinkedFields do
+  let(:resource) { Work::Submission.new }
+  let(:indexer) { described_class.new(resource: resource) }
+
+  describe '#to_solr' do
+    subject { indexer.to_solr }
+
+    context 'when the field is empty' do
+      it { is_expected.to eq({}) }
+    end
+
+    context 'with null creator values' do
+      before { resource.creator = [{ role: '', agent: '' }] }
+
+      it do
+        is_expected.to eq(
+          'creator_tesim' => [],
+          'creator_agent_tesim' => [],
+          'creator_role_tesim' => [],
+          'creator_role_ssim' => [],
+          'creator_agent_id_ssim' => [''],
+          'creator_role_id_ssim' => ['']
+        )
+      end
+    end
+
+    context 'when specifying a creator' do
+      let(:agent) { create(:agent, given_name: 'Bud', surname: 'Fox') }
+
+      before { resource.creator = [{ role: MockRDF.relators.first.to_uri.to_s, agent: agent.id }] }
+
+      it do
+        is_expected.to eq(
+          'creator_tesim' => ['Fox, Bud, blasting'],
+          'creator_agent_tesim' => ['Bud Fox'],
+          'creator_role_tesim' => ['blasting'],
+          'creator_role_ssim' => ['blasting'],
+          'creator_agent_id_ssim' => [agent.id.to_s],
+          'creator_role_id_ssim' => [MockRDF.relators.first.to_uri.to_s]
+        )
+      end
+    end
+
+    context 'when a solrizer class does not exist' do
+      let(:mock_field) { instance_double(Schema::MetadataField, label: 'foo') }
+
+      before { allow(indexer).to receive(:linked_fields).and_return([mock_field]) }
+
+      it { is_expected.to eq({}) }
+    end
+  end
+end

--- a/spec/cho/schema/input_field_spec.rb
+++ b/spec/cho/schema/input_field_spec.rb
@@ -82,6 +82,12 @@ RSpec.describe Schema::InputField, type: :model do
 
       it { is_expected.to eq('string') }
     end
+
+    context 'creator field type' do
+      let(:type) { 'creator' }
+
+      it { is_expected.to eq('creator') }
+    end
   end
 
   describe '#options' do
@@ -99,44 +105,37 @@ RSpec.describe Schema::InputField, type: :model do
   end
 
   describe '#datalist' do
-    subject { model.datalist }
+    subject { model.datalist.map(&:id) }
 
-    before { metadata_field.field_type = type }
+    let!(:agent) { create :agent }
+    let!(:collection) { create :collection }
 
-    context 'with the default string type' do
-      let(:type) { 'string' }
+    before { metadata_field.controlled_vocabulary = controlled_vocabulary }
 
-      it { is_expected.to be_empty }
-    end
-
-    context 'text field type' do
-      let(:type) { 'text' }
+    context 'with the default vocabulary' do
+      let(:controlled_vocabulary) { 'no_vocabulary' }
 
       it { is_expected.to be_empty }
     end
 
-    context 'numeric field type' do
-      let(:type) { 'numeric' }
+    context 'collections vocabulary' do
+      let(:controlled_vocabulary) { 'cho_collections' }
 
-      it { is_expected.to be_empty }
+      it { is_expected.to contain_exactly(collection.id) }
     end
 
-    context 'date field type' do
-      let(:type) { 'date' }
+    context 'agent vocabulary' do
+      let(:controlled_vocabulary) { 'cho_agents' }
 
-      it { is_expected.to be_empty }
+      it { is_expected.to contain_exactly(agent.id) }
     end
 
-    context 'valkyrie_id field type' do
-      let(:type) { 'valkyrie_id' }
+    context 'creator vocabulary' do
+      subject { model.datalist(component: :agents).map(&:id) }
 
-      it { is_expected.to eq(ControlledVocabulary::Collections.list) }
-    end
+      let(:controlled_vocabulary) { 'creator_vocabulary' }
 
-    context 'alternate_id field type' do
-      let(:type) { 'alternate_id' }
-
-      it { is_expected.to be_empty }
+      it { is_expected.to contain_exactly(agent.id) }
     end
   end
 

--- a/spec/cho/work/submissions/edit_spec.rb
+++ b/spec/cho/work/submissions/edit_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Editing works', type: :feature do
-  let(:resource) { create(:work, title: 'Work to edit', work_type_id: work_type.id) }
+  let(:resource) { create(:work, :with_creator, title: 'Work to edit', work_type_id: work_type.id) }
   let(:work_type)  { Work::Type.where(label: 'Document').first }
   let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
   let(:solr_document) { SolrDocument.find(resource.id) }
@@ -11,6 +11,8 @@ RSpec.describe 'Editing works', type: :feature do
   context 'with all the required metadata' do
     it 'updates an existing work with new metadata' do
       visit(edit_work_path(resource))
+      expect(page).to have_field('work_submission_creator_role', with: resource.creator.first[:role])
+      expect(page).to have_field('work_submission_creator_agent', with: resource.creator.first[:agent])
       expect(page).to have_content('Editing Work')
       expect(page).to have_selector('h2', text: 'Work to edit')
       expect(page).to have_link('Show')

--- a/spec/cho/work/submissions/new_spec.rb
+++ b/spec/cho/work/submissions/new_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Work::Submission, type: :feature do
 
   context 'when filling in all the fields' do
     let!(:archival_collection) { create(:archival_collection, title: 'Sample Collection') }
+    let!(:agent) { create(:agent, given_name: 'Christopher', surname: 'Kringle') }
 
     it 'creates a new work object without a file' do
       visit(root_path)
@@ -25,6 +26,8 @@ RSpec.describe Work::Submission, type: :feature do
       fill_in('work_submission[generic_field]', with: 'Sample generic field value')
       fill_in('work_submission[created]', with: '2018-10-22')
       fill_in('work_submission[member_of_collection_ids]', with: archival_collection.id)
+      fill_in('work_submission[creator][role]', with: MockRDF.relators.first)
+      fill_in('work_submission[creator][agent]', with: agent.id)
       click_button('Create Work')
       expect(page).to have_selector('h1', text: 'New Title')
       within('#document') do
@@ -46,6 +49,8 @@ RSpec.describe Work::Submission, type: :feature do
         expect(page).to have_blacklight_field(:member_of_collection_ids_ssim, 'Sample Collection')
         expect(page).to have_blacklight_field(:member_of_collection_ids_ssim, archival_collection.id)
         expect(page).to have_link('Sample Collection')
+        expect(page).to have_blacklight_label(:creator_tesim, 'Creator')
+        expect(page).to have_blacklight_field(:creator_tesim, 'Christopher Kringle (climbing)')
       end
       expect(page).to have_link('Edit')
     end

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -40,4 +40,14 @@ FactoryBot.define do
       ).validate_and_save(change_set: change_set, resource_params: { file: file })
     end
   end
+
+  trait :with_creator do
+    creator do
+      if @build_strategy.is_a? FactoryBot::Strategy::Build
+        { agent: build(:agent).id, role: MockRDF.relators.first.to_uri.to_s }
+      else
+        { agent: create(:agent).id, role: MockRDF.relators.first.to_uri.to_s }
+      end
+    end
+  end
 end

--- a/spec/support/mock_rdf.rb
+++ b/spec/support/mock_rdf.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# @note Class used for mocking sets of RDF terms that are usually very large and can take a long time
+#       to initially load. By mocking them, we can reduce testing time.
+class MockRDF
+  def self.relators
+    [
+      RDF::Vocabulary::Term.new('http://id.loc.gov/vocabulary/relators/bsl', attributes: { label: 'blasting' }),
+      RDF::Vocabulary::Term.new('http://id.loc.gov/vocabulary/relators/cli', attributes: { label: 'climbing' })
+    ]
+  end
+end
+
+RSpec.configure do |config|
+  config.before do
+    allow(RDF::Vocab::MARCRelators).to receive(:to_a).and_return(MockRDF.relators)
+  end
+end

--- a/spec/support/shared/views.rb
+++ b/spec/support/shared/views.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'a creator form' do
+  it 'renders the new form' do
+    assert_select 'input[name=?]', "#{resource.model_name.param_key}[creator][agent]"
+    assert_select 'input[name=?]', "#{resource.model_name.param_key}[creator][role]"
+
+    if creator_hash.present?
+      assert_select 'input[value=?]', agent1.id.to_s
+      assert_select 'input[value=?]', MockRDF.relators.first.to_uri.to_s
+    end
+
+    assert_select 'datalist[id=?]', 'creator_role'
+    assert_select 'option[value=?]', 'http://id.loc.gov/vocabulary/relators/bsl'
+    assert_select 'option', 'blasting'
+    assert_select 'option[value=?]', 'http://id.loc.gov/vocabulary/relators/cli'
+    assert_select 'option', 'climbing'
+
+    assert_select 'datalist[id=?]', 'creator_agent'
+    assert_select 'option[value=?]', agent1.id.to_s
+    assert_select 'option', 'Jane Doe'
+    assert_select 'option[value=?]', agent2.id.to_s
+    assert_select 'option', 'John Doe'
+  end
+end

--- a/spec/views/shared/_creator.html.erb_spec.rb
+++ b/spec/views/shared/_creator.html.erb_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'shared/input_partials/creator', type: :view do
+  let!(:agent1) { create :agent, given_name: 'Jane', surname: 'Doe' }
+  let!(:agent2) { create :agent }
+  let(:field) { instance_double Schema::InputField, options: {}, label: 'creator' }
+
+  before do
+    allow(field).to receive(:datalist).with(component: :roles).and_return(MockRDF.relators)
+    allow(field).to receive(:datalist).with(component: :agents).and_return([agent1, agent2])
+    allow(field).to receive(:value).and_return(creator_hash)
+    view.form_for(resource, url: 'blah') do |form|
+      render 'shared/input_partials/creator', form: form, field: field
+    end
+  end
+
+  context 'with a work' do
+    let(:resource) { build :work }
+
+    context 'without roles or agents' do
+      let(:creator_hash) { {} }
+
+      it_behaves_like 'a creator form'
+    end
+
+    context 'with a role and agent' do
+      let(:creator_hash) { { role: MockRDF.relators.first.to_uri.to_s, agent: agent1.id } }
+
+      it_behaves_like 'a creator form'
+    end
+  end
+
+  context 'with an archival collection' do
+    let(:resource) { build :archival_collection }
+
+    context 'without roles or agents' do
+      let(:creator_hash) { {} }
+
+      it_behaves_like 'a creator form'
+    end
+
+    context 'with a role and agent' do
+      let(:creator_hash) { { role: MockRDF.relators.first.to_uri.to_s, agent: agent1.id } }
+
+      it_behaves_like 'a creator form'
+    end
+  end
+
+  context 'with an library collection' do
+    let(:resource) { build :library_collection }
+
+    context 'without roles or agents' do
+      let(:creator_hash) { {} }
+
+      it_behaves_like 'a creator form'
+    end
+
+    context 'with a role and agent' do
+      let(:creator_hash) { { role: MockRDF.relators.first.to_uri.to_s, agent: agent1.id } }
+
+      it_behaves_like 'a creator form'
+    end
+  end
+
+  context 'with an curated collection' do
+    let(:resource) { build :curated_collection }
+
+    context 'without roles or agents' do
+      let(:creator_hash) { {} }
+
+      it_behaves_like 'a creator form'
+    end
+
+    context 'with a role and agent' do
+      let(:creator_hash) { { role: MockRDF.relators.first.to_uri.to_s, agent: agent1.id } }
+
+      it_behaves_like 'a creator form'
+    end
+  end
+end

--- a/spec/views/work_submissions/new.html.erb_spec.rb
+++ b/spec/views/work_submissions/new.html.erb_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe 'work/submissions/new', type: :view do
     assert_select 'form[action=?][method=?]', works_path, 'post' do
       assert_select 'input[name=?]', 'work_submission[title]'
       assert_select 'input[name=?]', 'work_submission[member_of_collection_ids]'
+      assert_select 'input[name=?]', 'work_submission[creator][agent]'
+      assert_select 'input[name=?]', 'work_submission[creator][role]'
       assert_select 'label', 'File Selection'
     end
   end


### PR DESCRIPTION
## Description

Enables adding a creator to a work or collection via the GUI.

Connected to #733 

## Changes

* includes a MockRDF class for mocking large RDF vocabularies across the entire test suite
