### PR TITLE
Delete contained works from collections

### DIFF
--- a/app/cho/batch/delete_presenter.rb
+++ b/app/cho/batch/delete_presenter.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Batch
+  class DeletePresenter
+    attr_reader :resource, :children
+
+    delegate :id, :title, to: :resource
+
+    def initialize(resource)
+      @resource = resource
+      @children = (titles_for(:members) + titles_for(:file_sets) + titles_for(:files)).flatten
+    end
+
+    def confirmation_title
+      I18n.t('cho.batch.delete.title', title: title.first, count: children.count)
+    end
+
+    private
+
+      def titles_for(type)
+        contained_resources(type).map do |member|
+          if type == :files
+            "File: #{member.original_filename}"
+          else
+            ["#{member.model_name.human}: #{member.title.first}"] + self.class.new(member).children
+          end
+        end
+      end
+
+      def contained_resources(type)
+        return [] unless resource.try(type)
+        resource.send(type)
+      end
+  end
+end

--- a/app/cho/work/submission.rb
+++ b/app/cho/work/submission.rb
@@ -27,10 +27,14 @@ module Work
       Name.new(self)
     end
 
-    # @note Use a custom Name class just to override i18n_key
+    # @note Use a custom Name class to preserve default behaviors while overriding others
     class Name < ActiveModel::Name
       def i18n_key
         'work'
+      end
+
+      def human
+        'Work'
       end
     end
 

--- a/app/views/batch/confirm.html.erb
+++ b/app/views/batch/confirm.html.erb
@@ -3,14 +3,18 @@
 <p><%= t('cho.batch.delete.message') %></p>
 
 <%= form_for(:delete, url: batch_delete_path, method: :delete) do |form| %>
-  <ul>
-    <% @resources.each do |resource| %>
-      <li>
-        <%= resource.title.first %>
-        <%= form.hidden_field :ids, multiple: true, value: resource.id %>
-      </li>
+
+    <% @presenters.each do |presenter| %>
+      <h2><%= presenter.confirmation_title %></h2>
+      <%= form.hidden_field :ids, multiple: true, value: presenter.id %>
+      <% if presenter.children.present? %>
+        <ul>
+          <% presenter.children.each do |child| %>
+            <li><%= child %></li>
+          <% end %>
+        </ul>
+      <% end %>
     <% end %>
-  </ul>
   <%= form.submit t('cho.batch.delete.continue') %>
   <%= link_to t('cho.batch.delete.cancel'), :back %>
 <% end %>

--- a/config/locales/cho.yml
+++ b/config/locales/cho.yml
@@ -106,5 +106,6 @@ en:
         success: "You have successfully deleted the following items: %{list}"
         cancel: "Cancel"
         submit: "Delete Selected Resources"
+        title: "%{title} (%{count} items)"
     stale_object_error: ": the %{object_name} object you tried to save is stale.  Please reload the form to see the latest data."
 

--- a/spec/cho/batch/delete_controller_spec.rb
+++ b/spec/cho/batch/delete_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Batch::DeleteController, type: :controller do
         delete :destroy, params: { delete: { ids: [work.to_param, collection.to_param] } }
       }.to change { metadata_adapter.query_service.find_all.to_a.count }.by(-2)
       expect(flash[:success]).to eq(
-        "You have successfully deleted the following items: #{[work.title.first, collection.title.first].join(', ')}"
+        I18n.t('cho.batch.delete.success', list: 'Sample Generic Work (0 items), Archival Collection (0 items)')
       )
     end
   end

--- a/spec/cho/batch/delete_presenter_spec.rb
+++ b/spec/cho/batch/delete_presenter_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Batch::DeletePresenter, type: :model do
+  describe '#id' do
+    subject(:presenter) { Batch::DeletePresenter.new(double) }
+
+    it { is_expected.to delegate_method(:id).to(:resource) }
+  end
+
+  describe '#confirmation_title' do
+    subject(:presenter) { Batch::DeletePresenter.new(work) }
+
+    let(:work) { build(:work) }
+
+    its(:confirmation_title) { is_expected.to eq('Sample Generic Work (0 items)') }
+  end
+
+  describe '#children' do
+    let(:work) { create(:work, :with_file) }
+
+    context 'with an empty collection' do
+      subject(:presenter) { Batch::DeletePresenter.new(create(:collection)) }
+
+      its(:children) { is_expected.to be_empty }
+    end
+
+    context 'with a collection containing works with files' do
+      it 'lists all works, file sets, and files' do
+        collection = Collection::Archival.find(work.member_of_collection_ids)
+        presenter = Batch::DeletePresenter.new(collection)
+        expect(presenter.children).to contain_exactly(
+          'Work: Sample Generic Work',
+          'File set: hello_world.txt',
+          'File: hello_world.txt',
+          'File: hello_world.txt_text.txt'
+        )
+      end
+    end
+
+    context 'with a work with no files' do
+      subject(:presenter) { Batch::DeletePresenter.new(create(:work)) }
+
+      its(:children) { is_expected.to be_empty }
+    end
+
+    context 'with a works containing files' do
+      it 'lists file sets and files' do
+        presenter = Batch::DeletePresenter.new(work.model)
+        expect(presenter.children).to contain_exactly(
+          'File set: hello_world.txt',
+          'File: hello_world.txt',
+          'File: hello_world.txt_text.txt'
+        )
+      end
+    end
+
+    context 'with file sets containing files' do
+      it 'lists the files' do
+        presenter = Batch::DeletePresenter.new(work.model.file_sets.first)
+        expect(presenter.children).to contain_exactly(
+          'File: hello_world.txt',
+          'File: hello_world.txt_text.txt'
+        )
+      end
+    end
+  end
+end

--- a/spec/cho/batch/select_spec.rb
+++ b/spec/cho/batch/select_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Batch::SelectController, type: :feature do
       find("input[type='checkbox']").click
       click_button('Delete Selected Resources')
       expect(page).to have_content('The following resources will be deleted')
-      expect(page).to have_selector('li', text: 'Resource to delete')
+      expect(page).to have_selector('h2', text: 'Resource to delete (0 items)')
       click_button('Continue')
       expect(page).to have_content('You have successfully deleted the following items: Resource to delete ')
     end

--- a/spec/cho/work/submissions/delete_spec.rb
+++ b/spec/cho/work/submissions/delete_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Deleting works', type: :feature do
     expect(page).to have_content(resource.title.first)
     click_button('Continue')
     expect(page).to have_content('You have successfully deleted the following items')
-    expect(page).to have_content(resource.title.first)
+    expect(page).to have_content('Work to delete (3 items)')
     expect(Work::Submission.all.count).to eq(0)
     expect(Work::File.all.count).to eq(0)
     expect(Collection::Archival.all.count).to eq(1)

--- a/spec/cho/work/submissions/submission_spec.rb
+++ b/spec/cho/work/submissions/submission_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe Work::Submission do
       subject { described_class.model_name }
 
       its(:i18n_key) { is_expected.to eq('work') }
+      its(:human) { is_expected.to eq('Work') }
     end
   end
 


### PR DESCRIPTION
## Description

Presents a confirmation message with a list of contained items when deleting works or collections and includes the counts of those items in the success message.

Fixes #509