### PR TITLE
Fileset Show Page - Part 1

### DIFF
--- a/app/blacklight/solr_document.rb
+++ b/app/blacklight/solr_document.rb
@@ -56,6 +56,18 @@ class SolrDocument
     end
   end
 
+  def work
+    query_service.find_inverse_references_by(resource: self, property: 'file_set_ids').to_a.first
+  end
+
+  def query_service
+    @query_service ||= Valkyrie::MetadataAdapter.find(:index_solr).query_service
+  end
+
+  def work_title
+    work.title.first
+  end
+
   # @todo maybe this needs to be some kind of transformation done in the data dictionary?
   # @return [Array<SolrDocument>]
   def member_of_collections

--- a/app/views/catalog/_show_work_fileset.html.erb
+++ b/app/views/catalog/_show_work_fileset.html.erb
@@ -1,4 +1,5 @@
 <%# Do the two column thing here %>
+<p>Fileset | Part of: <%= link_to @document.work_title, solr_document_path(@document.work) %></p>
 <%= render partial: 'show', locals: { document: @document } %>
 
 <%# write method to grab the files from the file set %>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -10,12 +10,18 @@
 <%# Use Bootstrap columns to position the thumbnail on the left and the content partials on the right %>
 <div class="container mt-4">
   <div class="row">
-    <div class="col-xs-12 col-md-4">
-      <%= render 'thumbnail', document: @document, document_counter: 0 %>
-    </div>
-    <div class="col-xs-12 col-md-8">
-      <%= render_document_main_content_partial %>
-    </div>
+    <% if presenter(@document).thumbnail.exists? %>
+      <div class="col-xs-12 col-md-4">
+        <%= render 'thumbnail', document: @document, document_counter: 0 %>
+      </div>
+      <div class="col-xs-12 col-md-8">
+        <%= render_document_main_content_partial %>
+      </div>
+    <% else %>
+      <div class="col-xs-12">
+        <%= render_document_main_content_partial %>
+      </div>
+    <% end %>
   </div>
 </div>
 

--- a/spec/cho/work/file_set/show_spec.rb
+++ b/spec/cho/work/file_set/show_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Work::FileSet, type: :feature do
 
   it 'displays the file set' do
     visit(polymorphic_path([:solr_document], id: file_set.id))
+    expect(page).to have_content 'Part of: Sample Generic Work'
     within('div#document') do
       expect(page).to have_blacklight_label('title_tesim').with('Title')
       expect(page).to have_blacklight_field('title_tesim').with('Original File Name')

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -7,14 +7,22 @@ require Rails.root.join('spec', 'support', 'seed_map')
 FactoryBot.define do
   factory :file_set, class: Work::FileSet do
     title { 'Original File Name' }
+    transient do
+      work { nil }
+    end
 
-    to_create do |resource|
-      Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: resource)
+    to_create do |resource, attributes|
+      fileset = Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: resource)
+      work = attributes.work
+      work ||= FactoryBot.build(:work_submission)
+      work.file_set_ids << fileset.id
+      Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: work)
+      fileset
     end
   end
 
   trait :with_member_file do
-    to_create do |resource|
+    to_create do |resource, attributes|
       temp_file = Rack::Test::UploadedFile.new(Rails.root.join('spec', 'fixtures', 'hello_world.txt'))
       file = Work::File.new(original_filename: temp_file.original_filename)
       file_change_set = Work::FileChangeSet.new(file)
@@ -22,7 +30,12 @@ FactoryBot.define do
       raise result.failure if result.failure?
 
       resource.member_ids = [result.success.id]
-      Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: resource)
+      fileset = Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: resource)
+      work = attributes.work
+      work ||= FactoryBot.build(:work_submission)
+      work.file_set_ids << fileset.id
+      Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: work)
+      fileset
     end
   end
 end


### PR DESCRIPTION
## Description

Gets work title using inverse references and a query service via the Solr document because it is "easier" this way than trying to create a two directional relationship between the fileset and the work. Checks to see if there is a thumbnail since we are using the same show partial for filesets and works and displays one or two columns.

Connected to #633 
