### PR TITLE
Changing to solr 7.4.0

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -1,5 +1,5 @@
 # .solr_wrapper
-version: 7.1.0
+version: 7.4.0
 port: 8983
 instance_dir: tmp/solr-development
 download_dir: tmp

--- a/config/solr_wrapper_test.yml
+++ b/config/solr_wrapper_test.yml
@@ -1,5 +1,5 @@
 # config/solr_wrapper_test.yml
-version: 7.1.0
+version: 7.4.0
 port: 8985
 instance_dir: tmp/solr-test
 download_dir: tmp


### PR DESCRIPTION
## Description

   Updating solr version so it works with java 11

The error you get is that solr_wrapper never starts up and just times out with the newer java and solr 7.1.0