### PR TITLE
Changing to use path instead of entire URL to avoid apache error

### DIFF
--- a/app/views/shared/input_partials/_creator.html.erb
+++ b/app/views/shared/input_partials/_creator.html.erb
@@ -8,7 +8,7 @@
             field.options.merge!(list: "#{field.label}_role", value: field_value.fetch(:role, nil)) %>
         <datalist id="<%= "#{field.label}_role" %>">
           <% field.datalist(component: :roles).each do |item| %>
-            <option value="<%= item %>"><%= item.label %></option>
+            <option value="<%= item.path %>"><%= item.label %></option>
           <% end %>
         </datalist>
       </div>

--- a/spec/support/shared/views.rb
+++ b/spec/support/shared/views.rb
@@ -11,9 +11,9 @@ RSpec.shared_examples 'a creator form' do
     end
 
     assert_select 'datalist[id=?]', 'creator_role'
-    assert_select 'option[value=?]', 'http://id.loc.gov/vocabulary/relators/bsl'
+    assert_select 'option[value=?]', '/vocabulary/relators/bsl'
     assert_select 'option', 'blasting'
-    assert_select 'option[value=?]', 'http://id.loc.gov/vocabulary/relators/cli'
+    assert_select 'option[value=?]', '/vocabulary/relators/cli'
     assert_select 'option', 'climbing'
 
     assert_select 'datalist[id=?]', 'creator_agent'


### PR DESCRIPTION
refs #773

@awead this is a simple option to avoid the apache issue.  It may also make the UI look cleaner by removing the http junk from the front.
![screen shot 2019-01-11 at 3 45 32 pm](https://user-images.githubusercontent.com/1599081/51058809-fe3b2c00-15b7-11e9-8451-28b0990bf4e3.png)

I have yet to deploy this to QA to see if it solves the problem, but I believe it would.

Connected to #773 