### PR TITLE
Improve test suite speed by limiting text extraction

### DIFF
--- a/spec/blacklight/catalog_spec.rb
+++ b/spec/blacklight/catalog_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe CatalogController, type: :feature do
 
   context 'when searching extracted text' do
     before do
-      create(:work_submission, :with_file,
+      create(:work_submission, :with_file_and_extracted_text,
         filename: 'example_extracted_text.txt',
         title: 'Sample Extracted Text Work')
     end

--- a/spec/cho/batch/delete_presenter_spec.rb
+++ b/spec/cho/batch/delete_presenter_spec.rb
@@ -33,8 +33,7 @@ RSpec.describe Batch::DeletePresenter, type: :model do
         expect(presenter.children).to contain_exactly(
           'Work: Sample Generic Work',
           'File set: hello_world.txt',
-          'File: hello_world.txt',
-          'File: hello_world.txt_text.txt'
+          'File: hello_world.txt'
         )
       end
     end
@@ -47,21 +46,19 @@ RSpec.describe Batch::DeletePresenter, type: :model do
 
     context 'with a works containing files' do
       it 'lists file sets and files' do
-        presenter = Batch::DeletePresenter.new(work.model)
+        presenter = Batch::DeletePresenter.new(work)
         expect(presenter.children).to contain_exactly(
           'File set: hello_world.txt',
-          'File: hello_world.txt',
-          'File: hello_world.txt_text.txt'
+          'File: hello_world.txt'
         )
       end
     end
 
     context 'with file sets containing files' do
       it 'lists the files' do
-        presenter = Batch::DeletePresenter.new(work.model.file_sets.first)
+        presenter = Batch::DeletePresenter.new(work.file_sets.first)
         expect(presenter.children).to contain_exactly(
-          'File: hello_world.txt',
-          'File: hello_world.txt_text.txt'
+          'File: hello_world.txt'
         )
       end
     end

--- a/spec/cho/batch/select_spec.rb
+++ b/spec/cho/batch/select_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Batch::SelectController, type: :feature do
   it_behaves_like 'a search form', '/select'
 
   context 'when deleting items' do
-    let!(:work) { create(:work, :with_file, title: 'Resource to delete') }
+    let!(:work) { create(:work, :with_file_and_extracted_text, title: 'Resource to delete') }
 
     it 'selects items from the repository and removes them' do
       visit(root_path)

--- a/spec/cho/work/submissions/delete_spec.rb
+++ b/spec/cho/work/submissions/delete_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Deleting works', type: :feature do
-  let(:resource) { create(:work, :with_file, title: 'Work to delete') }
+  let(:resource) { create(:work, :with_file_and_extracted_text, title: 'Work to delete') }
   let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
 
   it 'removes the work and file from the system but retains its parent collection' do
@@ -13,6 +13,9 @@ RSpec.describe 'Deleting works', type: :feature do
     click_button('Delete Work')
     expect(page).to have_content('The following resources will be deleted')
     expect(page).to have_content(resource.title.first)
+    expect(page).to have_selector('li', text: 'File set: hello_world.txt')
+    expect(page).to have_selector('li', text: 'File: hello_world.txt')
+    expect(page).to have_selector('li', text: 'File: hello_world.txt_text.txt')
     click_button('Continue')
     expect(page).to have_content('You have successfully deleted the following items')
     expect(page).to have_content('Work to delete (3 items)')

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -26,7 +26,7 @@ FactoryBot.define do
     end
   end
 
-  trait :with_file do
+  trait :with_file_and_extracted_text do
     transient do
       filename { 'hello_world.txt' }
     end
@@ -38,6 +38,18 @@ FactoryBot.define do
         metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister),
         storage_adapter: Valkyrie.config.storage_adapter
       ).validate_and_save(change_set: change_set, resource_params: { file: file })
+    end
+  end
+
+  trait :with_file do
+    transient do
+      filename { 'hello_world.txt' }
+    end
+
+    to_create do |resource, evaluator|
+      saved_resource = Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: resource)
+      FactoryBot.create(:file_set, :with_member_file, work: saved_resource, title: evaluator.filename)
+      saved_resource
     end
   end
 

--- a/spec/valkyrie/change_set_persister_spec.rb
+++ b/spec/valkyrie/change_set_persister_spec.rb
@@ -114,20 +114,18 @@ RSpec.describe ChangeSetPersister do
 
   describe '#delete' do
     context 'with a work containing files' do
-      let!(:change_set) { create(:work, :with_file) }
-
       it "deletes all the resources from Postgres and Solr, the files from disk, and retains the work's collection" do
+        work = create(:work, :with_file)
+        change_set = Work::SubmissionChangeSet.new(work)
         expect(Work::Submission.all.count).to eq(1)
-        expect(Work::File.all.count).to eq(2)
-        expect(metadata_adapter.index_adapter.query_service.find_all.count).to eq(5)
+        expect(Work::File.all.count).to eq(1)
+        expect(metadata_adapter.index_adapter.query_service.find_all.count).to eq(4)
         expect(Metrics::Repository.storage_directory.join('hello_world.txt')).to be_exist
-        expect(Metrics::Repository.storage_directory.join('hello_world.txt_text.txt')).to be_exist
         change_set_persister.delete(change_set: change_set)
         expect(Work::Submission.all.count).to eq(0)
         expect(Work::File.all.count).to eq(0)
         expect(metadata_adapter.index_adapter.query_service.find_all.count).to eq(1)
         expect(Metrics::Repository.storage_directory.join('hello_world.txt')).not_to be_exist
-        expect(Metrics::Repository.storage_directory.join('hello_world.txt_text.txt')).not_to be_exist
       end
     end
 


### PR DESCRIPTION
## Description

By only extracting text from sample file when needed for explicit testing, we can reduce test suite times. Two traits are available to a work, the typical one will add a file but not extract any text or perform other post-processing. The other trait will validate the file as well as extract text.

In the future, this will also comprise characterization and derivative creation as well.