### PR TITLE
Prefer rm_f over unlink

### DIFF
--- a/spec/support/csv_factory/generic.rb
+++ b/spec/support/csv_factory/generic.rb
@@ -32,7 +32,7 @@ module CsvFactory
     end
 
     def unlink
-      File.unlink(path)
+      FileUtils.rm_f(path)
     end
 
     private

--- a/spec/support/csv_factory/update.rb
+++ b/spec/support/csv_factory/update.rb
@@ -16,7 +16,7 @@ module CsvFactory
     end
 
     def unlink
-      File.unlink(path)
+      FileUtils.rm_f(path)
     end
 
     private


### PR DESCRIPTION
## Description

Calling .unlink on tempfiles was causing some failures because sometimes the file will have been deleted by another process. Using rm_f ignores any errors, and ensures the file is deleted.
