### PR TITLE
Cleaning dependencies and tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'devise_remote'
 gem 'dry-transaction'
 gem 'edtf'
 gem 'execjs'
-gem 'faker', github: 'stympy/faker', branch: 'master'
+gem 'faker'
 gem 'figaro'
 gem 'hydra-derivatives'
 gem 'hydra-file_characterization', '~> 0.3.3'
@@ -50,7 +50,7 @@ group :development, :test do
   gem 'niftany'
   gem 'pry-byebug'
   gem 'pry-rails'
-  gem 'solr_wrapper', github: 'cbeer/solr_wrapper', branch: 'master'
+  gem 'solr_wrapper'
   gem 'sqlite3'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,3 @@
-GIT
-  remote: https://github.com/cbeer/solr_wrapper.git
-  revision: 4c412aba182a33c28fddf77736f86d7c8c304102
-  branch: master
-  specs:
-    solr_wrapper (2.0.0)
-      faraday
-      retriable
-      ruby-progressbar
-      rubyzip
-
-GIT
-  remote: https://github.com/stympy/faker.git
-  revision: aca03bed6918ece830a62fd73085de5db20282b6
-  branch: master
-  specs:
-    faker (1.9.1)
-      i18n (>= 0.7)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -267,6 +248,8 @@ GEM
     factory_bot_rails (4.11.1)
       factory_bot (~> 4.11.1)
       railties (>= 3.0.0)
+    faker (1.9.1)
+      i18n (>= 0.7)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
     faraday-encoding (0.0.4)
@@ -310,7 +293,7 @@ GEM
     hydra-ldap (0.1.0)
       net-ldap
       rails
-    i18n (1.5.1)
+    i18n (1.5.2)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     inflecto (0.0.2)
@@ -569,6 +552,11 @@ GEM
       tilt (~> 2.0)
     slop (4.6.2)
     smart_properties (1.13.1)
+    solr_wrapper (2.1.0)
+      faraday
+      retriable
+      ruby-progressbar
+      rubyzip
     solrizer (4.1.0)
       activesupport
       nokogiri
@@ -683,7 +671,7 @@ DEPENDENCIES
   edtf
   execjs
   factory_bot_rails
-  faker!
+  faker
   figaro
   flog
   hydra-derivatives
@@ -713,7 +701,7 @@ DEPENDENCIES
   selenium-webdriver
   shoulda-matchers (~> 3.1)
   shrine
-  solr_wrapper!
+  solr_wrapper
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3
@@ -726,4 +714,4 @@ DEPENDENCIES
   xray-rails
 
 BUNDLED WITH
-   1.16.5
+   1.17.1

--- a/app/cho/transaction/operations/file/create_temp_file.rb
+++ b/app/cho/transaction/operations/file/create_temp_file.rb
@@ -10,7 +10,6 @@ module Transaction
 
         def call(io)
           temp_file = Tempfile.new('cho_temp_file')
-          puts temp_file.path
           updated_temp_file = write_file(temp_file: temp_file, io: io)
           Success(updated_temp_file)
         rescue StandardError => exception


### PR DESCRIPTION
## Description

Use released versions of gems, as opposed to tracking master branches, and remove an unneeded puts in the transaction code.
