### PR TITLE
Bug fixes for system usability

### DIFF
--- a/app/cho/transaction/shared/save_with_change_set.rb
+++ b/app/cho/transaction/shared/save_with_change_set.rb
@@ -14,7 +14,7 @@ module Transaction
       private
 
         def process_file(change_set)
-          return Success(change_set) if change_set.try(:file).nil?
+          return Success(change_set) if change_set.try(:file).blank?
 
           mime_type = Mime::Type.lookup(change_set.file.content_type)
           if mime_type.symbol == :zip

--- a/app/cho/validation/edtf_date.rb
+++ b/app/cho/validation/edtf_date.rb
@@ -7,10 +7,18 @@ module Validation
       return true if field_value.blank?
 
       Array.wrap(field_value).each do |value|
-        date = Date.edtf(value)
+        date = parse(value) || Date.edtf(value)
         errors << "Date #{value} is not a valid EDTF date" unless date
       end
       errors.empty?
     end
+
+    private
+
+      def parse(date)
+        Date.parse(date)
+      rescue ArgumentError
+        nil
+      end
   end
 end

--- a/spec/cho/validation/edtf_date_spec.rb
+++ b/spec/cho/validation/edtf_date_spec.rb
@@ -67,5 +67,14 @@ RSpec.describe Validation::EDTFDate, type: :model do
 
       it { is_expected.to be_truthy }
     end
+
+    context 'with a valid Ruby date' do
+      let(:dates) { 'January 21, 2019' }
+
+      it 'is valid' do
+        expect(validation_instance.validate(dates)).to be_truthy
+        expect(validation_instance.errors).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description

Fixes two minor problems:

* allow non-EDTF dates that can be parsed as actual dates
* allow works without files

These allow CHO to function with existing works. Prior to this change, any edits to existing works would not work.

Connected to #782