### PR TITLE
Changes to bag requirements

### DIFF
--- a/app/cho/import/file.rb
+++ b/app/cho/import/file.rb
@@ -60,6 +60,12 @@ class Import::File
     false
   end
 
+  def access?
+    type == Vocab::FileUse.AccessFile
+  rescue UnknownFileTypeError
+    false
+  end
+
   def preservation?
     type == Valkyrie::Vocab::PCDMUse.PreservationMasterFile
   rescue UnknownFileTypeError

--- a/app/cho/import/file_set.rb
+++ b/app/cho/import/file_set.rb
@@ -8,14 +8,14 @@ class Import::FileSet
   end
 
   def representative?
-    files.select(&:representative?).count == files.count
+    files.select(&:representative?).count == files.count && preservation.nil?
   end
 
   def title
     if preservation
       preservation.original_filename
-    elsif service
-      service.original_filename
+    elsif access
+      access.original_filename
     end
   end
 
@@ -24,13 +24,15 @@ class Import::FileSet
   end
   alias_method :to_s, :id
 
-  private
+  def preservation
+    @preservation ||= files.select(&:preservation?).first
+  end
 
-    def preservation
-      @preservation ||= files.select(&:preservation?).first
-    end
+  def access
+    @access ||= files.select(&:access?).first
+  end
 
-    def service
-      @service ||= files.select(&:service?).first
-    end
+  def service
+    @service ||= files.select(&:service?).first
+  end
 end

--- a/app/cho/import/work.rb
+++ b/app/cho/import/work.rb
@@ -41,18 +41,22 @@ class Import::Work
 
     def must_have_valid_file_sets
       file_sets.each do |file_set|
-        if file_set.files.select(&:service?).empty? && file_set.files.select(&:preservation?).empty?
-          errors.add(:file_sets, file_set_error(file_set))
+        if file_set.representative?
+          validate_representative_file_set(file_set)
+        else
+          validate_file_set(file_set)
         end
       end
     end
 
-    def file_set_error(file_set)
-      if file_set.representative?
-        'representative does not have a service file'
-      else
-        "#{file_set} does not have a service or preservation file"
-      end
+    def validate_representative_file_set(file_set)
+      return if file_set.access.present?
+      errors.add(:file_sets, 'representative does not have an access file')
+    end
+
+    def validate_file_set(file_set)
+      return if file_set.preservation.present? || file_set.service.present?
+      errors.add(:file_sets, "#{file_set} does not have a service or preservation file")
     end
 
     def sorted_works

--- a/app/cho/metrics/repository.rb
+++ b/app/cho/metrics/repository.rb
@@ -19,7 +19,7 @@ module Metrics
 
       def reset_directories
         reset_directory(Rails.root.join(storage_directory))
-        reset_directory(Rails.root.join(network_ingest_directory))
+        reset_directory(Rails.root.join(network_ingest_directory)) if Rails.env.test?
         reset_directory(Rails.root.join(extraction_directory))
       end
 

--- a/app/cho/work/file_set.rb
+++ b/app/cho/work/file_set.rb
@@ -46,9 +46,9 @@ class Work::FileSet < Valkyrie::Resource
   end
 
   # @return [Work::File] file from which we extract the text
-  # Prefer the redacted preservation file; otherwise, chose either the preservation or service file.
+  # Prefer the redacted preservation file; otherwise, chose either the preservation, access, or service file.
   def text_source
-    (preservation_redacted || preservation) || service
+    (preservation_redacted || preservation) || access || service
   end
 
   def representative?

--- a/spec/cho/import/bag_spec.rb
+++ b/spec/cho/import/bag_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Import::Bag do
       expect(bag).to be_valid
       expect(bag.errors).to be_empty
       expect(bag.date).to eq('2008-06-23')
-      expect(bag.batch_id).to eq('batchID')
+      expect(bag.batch_id).to eq('batchID_2008-06-23')
       expect(bag.works.first).to be_a(Import::Work)
     end
   end
@@ -42,20 +42,44 @@ RSpec.describe Import::Bag do
   end
 
   describe 'a bag with a missing a date' do
-    subject(:bag) { ImportFactory::Bag.create(batch_id: 'batchNoDate', data: {}) }
+    subject(:bag) do
+      ImportFactory::Bag.create(
+        batch_id: 'batchNoDate',
+        data: {
+          workID: [
+            'workID_preservation.tif',
+            'workID_text.txt',
+            'workID_thumb.jpg'
+          ]
+        }
+      )
+    end
 
     it do
-      expect(bag).not_to be_valid
-      expect(bag.errors.messages).to include(date: ['cannot be blank'])
+      expect(bag).to be_valid
+      expect(bag.date).to be_nil
+      expect(bag.batch_id).to eq('batchNoDate')
     end
   end
 
   describe 'a bag with an invalid date' do
-    subject(:bag) { ImportFactory::Bag.create(batch_id: 'batchBadDate_06-12', data: {}) }
+    subject(:bag) do
+      ImportFactory::Bag.create(
+        batch_id: 'batchBadDate_06-12',
+        data: {
+          workID: [
+            'workID_preservation.tif',
+            'workID_text.txt',
+            'workID_thumb.jpg'
+          ]
+        }
+      )
+    end
 
     it do
-      expect(bag).not_to be_valid
-      expect(bag.errors.messages).to include(date: ['06-12 is not in YYYY-MM-DD format'])
+      expect(bag).to be_valid
+      expect(bag.date).to be_nil
+      expect(bag.batch_id).to eq('batchBadDate_06-12')
     end
   end
 
@@ -115,6 +139,139 @@ RSpec.describe Import::Bag do
 
     it 'raises an error' do
       expect { described_class.new(path) }.to raise_error(IOError, 'path to bag does not exist or is not readable')
+    end
+  end
+
+  describe 'a user-submitted example' do
+    subject(:bag) do
+      ImportFactory::Bag.create(
+        batch_id: 'pst_1028552845_2019-02-21',
+        data: {
+          pst_1028552845: [
+            'pst_1028552845_00001_preservation.tif',
+            'pst_1028552845_00001_service.jp2',
+            'pst_1028552845_00001_text.txt',
+            'pst_1028552845_00001_thumb.jpg',
+            'pst_1028552845_00002_preservation.tif',
+            'pst_1028552845_00002_service.jp2',
+            'pst_1028552845_00002_text.txt',
+            'pst_1028552845_00002_thumb.jpg',
+            'pst_1028552845_00003_preservation.tif',
+            'pst_1028552845_00003_service.jp2',
+            'pst_1028552845_00003_text.txt',
+            'pst_1028552845_00003_thumb.jpg',
+            'pst_1028552845_access.pdf',
+            'pst_1028552845_text.txt',
+            'pst_1028552845_thumb.jpg'
+          ]
+        }
+      )
+    end
+
+    it do
+      expect(bag).to be_valid
+      expect(bag.errors).to be_empty
+      expect(bag.date).to eq('2019-02-21')
+      expect(bag.batch_id).to eq('pst_1028552845_2019-02-21')
+      expect(bag.works.first).to be_a(Import::Work)
+    end
+  end
+
+  describe 'works with varied file set ids' do
+    let(:batch_a) do
+      ImportFactory::Bag.create(
+        batch_id: 'batch_a',
+        data: {
+          workID: [
+            'workID_00001_01_preservation.tif',
+            'workID_00001_01_preservation-redacted.tif',
+            'workID_00001_01_service.jp2',
+            'workID_00001_01_text.txt',
+            'workID_00001_01_thumb.jpg',
+            'workID_00001_02_preservation.tif',
+            'workID_00001_02_service.jp2',
+            'workID_00001_02_text.txt',
+            'workID_00001_02_thumb.jpg',
+            'workID_00002_01_preservation.tif',
+            'workID_00002_01_service.jp2',
+            'workID_00002_01_text.txt',
+            'workID_00002_01_thumb.jpg',
+            'workID_00002_02_preservation.tif',
+            'workID_00002_02_service.jp2',
+            'workID_00002_02_text.txt',
+            'workID_00002_02_thumb.jpg'
+          ]
+        }
+      )
+    end
+
+    let(:batch_b) do
+      ImportFactory::Bag.create(
+        batch_id: 'batch_b',
+        data: {
+          workID: [
+            'workID_00001_preservation.tif',
+            'workID_00001_preservation-redacted.tif',
+            'workID_00001_service.jp2',
+            'workID_00001_text.txt',
+            'workID_00001_thumb.jpg',
+            'workID_00002_preservation.tif',
+            'workID_00002_service.jp2',
+            'workID_00002_text.txt',
+            'workID_00002_thumb.jpg',
+            'workID_00003_preservation.tif',
+            'workID_00003_service.jp2',
+            'workID_00003_text.txt',
+            'workID_00003_thumb.jpg',
+            'workID_00004_preservation.tif',
+            'workID_00004_service.jp2',
+            'workID_00004_text.txt',
+            'workID_00004_thumb.jpg'
+          ]
+        }
+      )
+    end
+
+    let(:batch_c) do
+      ImportFactory::Bag.create(
+        batch_id: 'batch_c',
+        data: {
+          workID: [
+            'workID_00001_01_preservation.tif',
+            'workID_00001_01_preservation-redacted.tif',
+            'workID_00001_01_service.jp2',
+            'workID_00001_01_text.txt',
+            'workID_00001_01_thumb.jpg',
+            'workID_00001_02_preservation.tif',
+            'workID_00001_02_service.jp2',
+            'workID_00001_02_text.txt',
+            'workID_00001_02_thumb.jpg',
+            'workID_00003_preservation.tif',
+            'workID_00003_service.jp2',
+            'workID_00003_text.txt',
+            'workID_00003_thumb.jpg',
+            'workID_00004_preservation.tif',
+            'workID_00004_service.jp2',
+            'workID_00004_text.txt',
+            'workID_00004_thumb.jpg'
+          ]
+        }
+      )
+    end
+
+    it do
+      expect(batch_a).to be_valid
+      expect(batch_b).to be_valid
+      expect(batch_c).to be_valid
+      expect(batch_a.works.first.file_sets.map(&:id).sort).to eq(
+        ['workID_00001_01', 'workID_00001_02', 'workID_00002_01', 'workID_00002_02']
+      )
+      expect(batch_b.works.first.file_sets.map(&:id).sort).to eq(
+        ['workID_00001', 'workID_00002', 'workID_00003', 'workID_00004']
+      )
+      expect(batch_c.works.first.file_sets.map(&:id).sort).to eq(
+        ['workID_00001_01', 'workID_00001_02', 'workID_00003', 'workID_00004']
+      )
     end
   end
 end

--- a/spec/cho/import/file_set_spec.rb
+++ b/spec/cho/import/file_set_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Import::FileSet do
     context 'with a non-representative of a multipart work id' do
       let(:files) { [ImportFactory::File.create('work12_34_preservation.tif', parent: 'work12_34')] }
 
-      it { is_expected.to be_representative }
+      it { is_expected.not_to be_representative }
     end
   end
 
@@ -60,14 +60,14 @@ RSpec.describe Import::FileSet do
       its(:title) { is_expected.to eq('work1234_0001_preservation.tif') }
     end
 
-    context 'with a service file' do
-      let(:files) { [ImportFactory::File.create('work1234_0001_service.jpg')] }
+    context 'with an access file' do
+      let(:files) { [ImportFactory::File.create('work1234_0001_access.jpg')] }
 
-      its(:title) { is_expected.to eq('work1234_0001_service.jpg') }
+      its(:title) { is_expected.to eq('work1234_0001_access.jpg') }
     end
 
     context 'with neither access nor preservation files' do
-      let(:files) { [ImportFactory::File.create('work1234_0001_access.jpg')] }
+      let(:files) { [ImportFactory::File.create('work1234_0001_service.jpg')] }
 
       its(:title) { is_expected.to be_nil }
     end

--- a/spec/cho/import/file_spec.rb
+++ b/spec/cho/import/file_spec.rb
@@ -133,6 +133,32 @@ RSpec.describe Import::File do
 
       it { is_expected.not_to be_service }
     end
+
+    context 'with an unsupported file type' do
+      subject { ImportFactory::File.create('work_ID_0001_foo.tif', parent: 'work_ID') }
+
+      it { is_expected.not_to be_service }
+    end
+  end
+
+  describe '#access?' do
+    context 'with an access file' do
+      subject { ImportFactory::File.create('work_ID_0001_access.jp2', parent: 'work_ID') }
+
+      it { is_expected.to be_access }
+    end
+
+    context 'with a non-access file' do
+      subject { ImportFactory::File.create('work_ID_0001_preservation.tif', parent: 'work_ID') }
+
+      it { is_expected.not_to be_access }
+    end
+
+    context 'with an unsupported file type' do
+      subject { ImportFactory::File.create('work_ID_0001_foo.tif', parent: 'work_ID') }
+
+      it { is_expected.not_to be_access }
+    end
   end
 
   describe '#preservation?' do
@@ -144,6 +170,12 @@ RSpec.describe Import::File do
 
     context 'with a non-preservation file' do
       subject { ImportFactory::File.create('work_ID_0001_access.jpg', parent: 'work_ID') }
+
+      it { is_expected.not_to be_preservation }
+    end
+
+    context 'with an unsupported file type' do
+      subject { ImportFactory::File.create('work_ID_0001_foo.tif', parent: 'work_ID') }
 
       it { is_expected.not_to be_preservation }
     end

--- a/spec/cho/import/work_spec.rb
+++ b/spec/cho/import/work_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Import::Work do
       expect(work.files.count).to eq(5)
       expect(work.nested_works.count).to eq(0)
       expect(work.file_sets.count).to eq(1)
-      expect(work.file_sets.first).to be_representative
+      expect(work.file_sets.first).not_to be_representative
       expect(work.path).to eq(ImportFactory::Bag.root.join('workID'))
       expect(work.identifier).to eq('workID')
     end
@@ -41,7 +41,7 @@ RSpec.describe Import::Work do
           'workID_00002_01_service.jp2',
           'workID_00002_02_preservation.tif',
           'workID_00002_02_service.jp2',
-          'workID_service.pdf',
+          'workID_access.pdf',
           'workID_text.txt',
           'workID_thumb.jpg'
         ]
@@ -62,7 +62,7 @@ RSpec.describe Import::Work do
       )
       expect(work.representative).to be_representative
       expect(work.representative.files.map(&:original_filename)).to include(
-        'workID_service.pdf', 'workID_text.txt', 'workID_thumb.jpg'
+        'workID_access.pdf', 'workID_text.txt', 'workID_thumb.jpg'
       )
     end
   end
@@ -121,7 +121,7 @@ RSpec.describe Import::Work do
               'workID_00002_02_thumb.jpg'
             ]
           },
-          'workID_service.pdf',
+          'workID_access.pdf',
           'workID_text.txt',
           'workID_thumb.jpg'
         ]
@@ -183,10 +183,10 @@ RSpec.describe Import::Work do
       expect(work.nested_works.count).to eq(2)
       expect(work.nested_works.first.files.count).to eq(3)
       expect(work.nested_works.first.file_sets.count).to eq(1)
-      expect(work.nested_works.first.file_sets.first).to be_representative
+      expect(work.nested_works.first.file_sets.first).not_to be_representative
       expect(work.nested_works.last.files.count).to eq(3)
       expect(work.nested_works.last.file_sets.count).to eq(1)
-      expect(work.nested_works.last.file_sets.first).to be_representative
+      expect(work.nested_works.last.file_sets.first).not_to be_representative
     end
   end
 
@@ -254,7 +254,7 @@ RSpec.describe Import::Work do
 
     it do
       expect(work).not_to be_valid
-      expect(work.errors.messages).to include(file_sets: ['representative does not have a service file'])
+      expect(work.errors.messages).to include(file_sets: ['representative does not have an access file'])
     end
   end
 
@@ -266,7 +266,7 @@ RSpec.describe Import::Work do
           'workID_00001_01_access.jp2',
           'workID_00001_02_preservation.tif',
           'workID_00001_02_service.jp2',
-          'workID_service.pdf',
+          'workID_access.pdf',
           'workID_text.txt',
           'workID_thumb.jpg'
         ]

--- a/spec/cho/work/file_set_spec.rb
+++ b/spec/cho/work/file_set_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Work::FileSet do
     its(:access) { is_expected.to eq(file) }
     its(:service) { is_expected.to be_nil }
     its(:thumbnail) { is_expected.to be_nil }
-    its(:text_source) { is_expected.to be_nil }
+    its(:text_source) { is_expected.to eq(file) }
   end
 
   context 'with a service file' do

--- a/spec/cho/work/import/create_spec.rb
+++ b/spec/cho/work/import/create_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe 'Preview of CSV Import', type: :feature do
             'work1_00002_01_service.jp2',
             'work1_00002_02_preservation.tif',
             'work1_00002_02_service.jp2',
-            'work1_service.pdf',
+            'work1_access.pdf',
             'work1_text.txt',
             'work1_thumb.jpg'
           ]
@@ -150,7 +150,7 @@ RSpec.describe 'Preview of CSV Import', type: :feature do
       expect(file_sets.map(&:title)).to contain_exactly(
         ['My Work1_00001_01'],
         ['My Work1_00001_02'],
-        ['work1_service.pdf'],
+        ['work1_access.pdf'],
         ['My Work1_00002_01'],
         ['My Work1_00002_02']
       )
@@ -167,7 +167,7 @@ RSpec.describe 'Preview of CSV Import', type: :feature do
         'work1_00002_01_service.jp2',
         'work1_00002_02_preservation.tif',
         'work1_00002_02_service.jp2',
-        'work1_service.pdf',
+        'work1_access.pdf',
         'work1_text.txt',
         'work1_thumb.jpg'
       )
@@ -203,7 +203,7 @@ RSpec.describe 'Preview of CSV Import', type: :feature do
             'work1_00001_01_service.jp2',
             'work1_00002_01_preservation.tif',
             'work1_00002_01_service.jp2',
-            { name: 'work1_service.pdf', file: 'test.pdf' },
+            { name: 'work1_access.pdf', file: 'test.pdf' },
             'work1_thumb.jpg'
           ]
         }

--- a/spec/cho/work/submissions/new_spec.rb
+++ b/spec/cho/work/submissions/new_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Work::Submission, type: :feature do
             'work1_00002_01_service.jp2',
             'work1_00002_02_preservation.tif',
             'work1_00002_02_service.jp2',
-            'work1_service.pdf',
+            'work1_access.pdf',
             'work1_text.txt',
             'work1_thumb.jpg'
           ]
@@ -185,8 +185,8 @@ RSpec.describe Work::Submission, type: :feature do
       expect(page).to have_content('work1_00002_02_preservation.tif')
 
       # Check thumbnail display on the file set
-      click_link('work1_service.pdf')
-      expect(page).to have_selector('h1', text: 'work1_service.pdf')
+      click_link('work1_access.pdf')
+      expect(page).to have_selector('h1', text: 'work1_access.pdf')
       expect(page).to have_xpath("//img[@src='/files/work1_thumb.jpg']")
       expect(page).to have_xpath("//img[@alt='Work1 thumb']")
     end


### PR DESCRIPTION
## Description

This makes some changes to the bag validation based on some feedback from @ntallman using some _real world_ zip files for import.

Additionally, files in the ingest directory are no longer cleaned out automatically with the `reset` task. This was causing problems with existing zip files that need to be retained for continued use.

Related to #750 

## Changes

* dates are no longer required in batch ids but will still be parsed and returned if they're in the right format
* access files are required for representative file sets instead of service files
* file sets with preservation files are no longer considered "representative" file sets
* the ingest directory will only be cleaned out in the test environment