### PR TITLE
Delete extracted bags after validation and import

### DIFF
--- a/app/cho/csv/controller_behavior.rb
+++ b/app/cho/csv/controller_behavior.rb
@@ -33,19 +33,24 @@ module Csv::ControllerBehavior
 
   # POST /csv/import
   def import
-    file_name = params[:file_name]
-    dry_run =  csv_dry_run.new(file_name, update: update?)
-    importer = Csv::Importer.new(dry_run.results)
-    if importer.run
-      @created = importer.created
+    if import_csv.success?
+      @created = import_csv.success
       render :import_success
     else
-      @errors = importer.errors
+      @errors = import_csv.failure
       render :import_failure
     end
   end
 
   private
+
+    def import_csv
+      @import_csv ||= Transaction::Operations::Import::Csv.new.call(
+        csv_dry_run: csv_dry_run,
+        file: params[:file_name],
+        update: update?
+      )
+    end
 
     def update?
       if params.key?(:update)

--- a/app/cho/csv/dry_run_behavior.rb
+++ b/app/cho/csv/dry_run_behavior.rb
@@ -7,6 +7,10 @@ module Csv::DryRunBehavior
     update
   end
 
+  def bag
+    Dry::Monads::Result::Failure.new('This dry run class does not implement bags')
+  end
+
   private
 
     def validate_structure

--- a/app/cho/transaction/operations/import/csv.rb
+++ b/app/cho/transaction/operations/import/csv.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Transaction
+  module Operations
+    module Import
+      class Csv
+        include Dry::Transaction::Operation
+
+        def call(csv_dry_run:, file:, update:)
+          dry_run = csv_dry_run.new(file, update: update)
+          importer = ::Csv::Importer.new(dry_run.results)
+          importer.run
+          delete_bag(dry_run)
+
+          if importer.errors.present?
+            Failure(importer.errors)
+          else
+            Success(importer.created)
+          end
+        rescue StandardError => exception
+          Failure(Array.wrap(exception.message))
+        end
+
+        private
+
+          def delete_bag(dry_run)
+            return unless dry_run.bag.success?
+            FileUtils.rm_rf(dry_run.bag.success.path)
+          end
+      end
+    end
+  end
+end

--- a/app/cho/transaction/operations/import/extract.rb
+++ b/app/cho/transaction/operations/import/extract.rb
@@ -15,7 +15,7 @@ module Transaction
           zip_name ||= zip_path.basename('.zip')
           zip_path ||= network_ingest_directory.join("#{zip_name}.zip")
           destination = extraction_directory.join(zip_name)
-          return Success(destination) if destination.exist?
+          FileUtils.rm_rf(destination)
 
           unzip_bag(zip_path)
           Success(destination)

--- a/spec/cho/agent/import/csv_dry_run_spec.rb
+++ b/spec/cho/agent/import/csv_dry_run_spec.rb
@@ -28,6 +28,25 @@ RSpec.describe Agent::Import::CsvDryRun do
     end
   end
 
+  describe '#bag?' do
+    before do
+      allow(File).to receive(:new).with('path', 'r')
+      allow(Csv::Reader).to receive(:new).with(any_args).and_return(mock_reader)
+    end
+
+    context 'by default' do
+      subject(:dry_run) { described_class.new('path') }
+
+      let(:mock_reader) { instance_double(Csv::Reader, headers: [], map: []) }
+
+      it 'returns a Failure for a bag' do
+        expect(dry_run.bag).to eq(
+          Dry::Monads::Result::Failure.new('This dry run class does not implement bags')
+        )
+      end
+    end
+  end
+
   describe '#results' do
     subject(:dry_run_results) { described_class.new(csv_file.path, update: update).results }
 

--- a/spec/cho/transaction/operations/import/csv_spec.rb
+++ b/spec/cho/transaction/operations/import/csv_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Transaction::Operations::Import::Csv do
+  describe '#call' do
+    context 'when the csv import fails for an unexpected reason' do
+      before do
+        allow(Work::Import::CsvDryRun).to receive(:new).and_raise(StandardError, 'Something unexpected occurred')
+      end
+
+      it 'returns a failure' do
+        result = described_class.new.call(csv_dry_run: Work::Import::CsvDryRun, file: 'file', update: false)
+        expect(result).to be_failure
+        expect(result.failure).to eq(['Something unexpected occurred'])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

Deletes extracted bags from the extraction directory after they are
validated or imported. Refactors the existing csv import process into a transaction for better
maintainability and error handling.

Connected to #829