### PR TITLE
Update to the latest new_relic_rpm gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -365,7 +365,7 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (5.0.2)
-    newrelic_rpm (5.5.0.348)
+    newrelic_rpm (6.1.0.352)
     niftany (0.3.0)
       colorize (~> 0.8.1)
       erb_lint (~> 0.0.22)


### PR DESCRIPTION
Update to the latest new_relic_rpm gem.

Enables continued access to the New Relic suite of performance monitoring tools.