### PR TITLE
Validate creator input

### DIFF
--- a/app/cho/validation/base.rb
+++ b/app/cho/validation/base.rb
@@ -5,7 +5,6 @@ module Validation
     attr_accessor :errors
 
     def validate(_field)
-      @errors
       raise Error, 'Validation.validate is abstract. Children must implement.'
     end
   end

--- a/app/cho/validation/creator.rb
+++ b/app/cho/validation/creator.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Validation
+  class Creator < Base
+    def validate(field_value)
+      self.errors = []
+      Array.wrap(field_value).each do |value|
+        self.errors += CreatorHashValidator.new(value).errors
+      end
+      self.errors.empty?
+    end
+
+    class CreatorHashValidator
+      attr_reader :value
+
+      def initialize(value)
+        @value = value
+      end
+
+      def errors
+        creator_hash.assert_valid_keys('role', 'agent')
+        error_messages
+      rescue ArgumentError
+        [I18n.t('cho.validation.creator.hash_keys')]
+      end
+
+      private
+
+        def creator_hash
+          @creator_hash ||= ActiveSupport::HashWithIndifferentAccess.new(value).stringify_keys
+        end
+
+        def error_messages
+          messages = []
+          messages << I18n.t('cho.validation.creator.role', role: role) unless valid_role?
+          messages << I18n.t('cho.validation.creator.agent', agent: agent) unless valid_agent?
+          messages
+        end
+
+        def role
+          creator_hash['role']
+        end
+
+        def agent
+          creator_hash['agent']
+        end
+
+        def valid_agent?
+          return true if agent.blank?
+          Validation::Member.new(agent).exists?
+        end
+
+        def valid_role?
+          return true if role.blank?
+          RDF::Vocab::MARCRelators.to_a.map(&:to_s).include?(role)
+        end
+    end
+  end
+end

--- a/app/cho/validation/factory.rb
+++ b/app/cho/validation/factory.rb
@@ -18,7 +18,7 @@ module Validation
             default_key => Validation::None.new,
             resource_exists: Validation::ResourceExists.new,
             edtf_date: Validation::EDTFDate.new,
-            creator: Validation::None.new
+            creator: Validation::Creator.new
           }
         end
 

--- a/config/locales/cho.yml
+++ b/config/locales/cho.yml
@@ -147,4 +147,8 @@ en:
         submit: "Delete Selected Resources"
         title: "%{title} (%{count} items)"
     stale_object_error: ": the %{object_name} object you tried to save is stale.  Please reload the form to see the latest data."
-
+    validation:
+      creator:
+        hash_keys: "must contain an agent and a role"
+        role: "role '%{role}' does not exist"
+        agent: "agent '%{agent}' does not exist"

--- a/spec/cho/validation/creator_spec.rb
+++ b/spec/cho/validation/creator_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Validation::Creator, type: :model do
+  describe '#validate' do
+    subject { validation_instance.validate(creators) }
+
+    let(:validation_instance) { described_class.new }
+    let(:agent) { create(:agent) }
+
+    context 'with an existing agent and role' do
+      let(:creators) { { role: MockRDF.relators.first.to_uri.to_s, agent: agent.id } }
+
+      specify do
+        expect(validation_instance.validate(creators)).to be_truthy
+        expect(validation_instance.errors).to be_empty
+      end
+    end
+
+    context 'with multiple existing agents and roles' do
+      let(:creators) do
+        [
+          { role: MockRDF.relators.first.to_uri.to_s, agent: agent.id },
+          { role: MockRDF.relators.last.to_uri.to_s, agent: agent.id }
+        ]
+      end
+
+      specify do
+        expect(validation_instance.validate(creators)).to be_truthy
+        expect(validation_instance.errors).to be_empty
+      end
+    end
+
+    context 'with an agent and no role' do
+      let(:creators) { { role: '', agent: agent.id } }
+
+      specify do
+        expect(validation_instance.validate(creators)).to be_truthy
+        expect(validation_instance.errors).to be_empty
+      end
+    end
+
+    context 'with a nil value' do
+      let(:creators) { {} }
+
+      specify do
+        expect(validation_instance.validate(creators)).to be_truthy
+        expect(validation_instance.errors).to be_empty
+      end
+    end
+
+    context 'with an empty value' do
+      let(:creators) { '' }
+
+      specify do
+        expect(validation_instance.validate(creators)).to be_truthy
+        expect(validation_instance.errors).to be_empty
+      end
+    end
+
+    context 'with blank values' do
+      let(:creators) { { role: '', agent: '' } }
+
+      specify do
+        expect(validation_instance.validate(creators)).to be_truthy
+        expect(validation_instance.errors).to be_empty
+      end
+    end
+
+    context 'when the value is not a hash' do
+      let(:creators) { 'Joe Smith' }
+
+      specify do
+        expect(validation_instance.validate(creators)).to be_falsey
+        expect(validation_instance.errors).to contain_exactly(
+          "agent 'Joe Smith' does not exist",
+          "role 'Joe Smith' does not exist"
+        )
+      end
+    end
+
+    context 'when the required keys are missing' do
+      let(:creators) { { not_roll: 'author', not_agent: 'Smith, John' } }
+
+      specify do
+        expect(validation_instance.validate(creators)).to be_falsey
+        expect(validation_instance.errors).to contain_exactly('must contain an agent and a role')
+      end
+    end
+
+    context 'when the role does not exist' do
+      let(:creators) { { role: 'curler', agent: agent.id } }
+
+      specify do
+        expect(validation_instance.validate(creators)).to be_falsey
+        expect(validation_instance.errors).to contain_exactly("role 'curler' does not exist")
+      end
+    end
+
+    context 'when the agent does not exist' do
+      let(:creators) { { role: '', agent: 'Smith, Joe' } }
+
+      specify do
+        expect(validation_instance.validate(creators)).to be_falsey
+        expect(validation_instance.errors).to contain_exactly("agent 'Smith, Joe' does not exist")
+      end
+    end
+
+    context 'with multiple missing agents and roles' do
+      let(:creators) do
+        [
+          { role: 'faker', agent: agent.id },
+          { role: MockRDF.relators.last.to_uri.to_s, agent: 'Mr. Magoo' }
+        ]
+      end
+
+      specify do
+        expect(validation_instance.validate(creators)).to be_falsey
+        expect(validation_instance.errors).to contain_exactly(
+          "role 'faker' does not exist",
+          "agent 'Mr. Magoo' does not exist"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

Checks the validity of the hashes used for creators, including the presence of the agent and role keys, as well as verifying that their respective resources exist.

This work will be used in validating the agents submitted via csv for work import.

Connected to #736 
