### PR TITLE
Ensure csv values are correctly escaped

### DIFF
--- a/spec/cho/work/import/create_spec.rb
+++ b/spec/cho/work/import/create_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe 'Preview of CSV Import', type: :feature do
         member_of_collection_ids: ['xyz_1234', 'xyz_1234', collection.id],
         work_type: ['Generic', 'Generic', 'Generic'],
         title: ['My Work 1', 'My Work 2', 'My Work 3'],
+        subtitle: [MetadataFactory.fancy_title, MetadataFactory.fancy_title, MetadataFactory.fancy_title],
         batch_id: ['batch1_2018-07-12', 'batch1_2018-07-12', 'batch1_2018-07-12']
       )
     end

--- a/spec/support/csv_factory/agent_update.rb
+++ b/spec/support/csv_factory/agent_update.rb
@@ -8,7 +8,7 @@ module CsvFactory
 
       def work(hash)
         agent = FactoryBot.create(:agent)
-        "#{agent.id},#{values(hash).join(',')}\n"
+        values(hash).unshift(agent.id).to_csv
       end
 
       def fields

--- a/spec/support/csv_factory/generic.rb
+++ b/spec/support/csv_factory/generic.rb
@@ -25,8 +25,8 @@ module CsvFactory
     #
     def initialize(data)
       Tempfile.open do |csv_file|
-        csv_file.write(line(data.keys.join(',')))
-        data.values.transpose.each { |array| csv_file.write(line(array.join(','))) }
+        csv_file.write(data.keys.to_csv)
+        data.values.transpose.each { |array| csv_file.write(array.to_csv) }
         @path = csv_file.path
       end
     end

--- a/spec/support/csv_factory/update.rb
+++ b/spec/support/csv_factory/update.rb
@@ -22,13 +22,13 @@ module CsvFactory
     private
 
       def header
-        "id,#{fields.join(',')}\n"
+        fields.unshift('id').to_csv
       end
 
       def work(hash)
         work = FactoryBot.create(:work)
         hash[:member_of_collection_ids] = work.member_of_collection_ids.to_s
-        "#{work.id},#{values(hash).join(',')}\n"
+        values(hash).unshift(work.id).to_csv
       end
 
       def fields

--- a/spec/support/metadata_factory.rb
+++ b/spec/support/metadata_factory.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class MetadataFactory
+  # Generates an academic-like title with a variety of punctuation using lorem text.
+  # @example
+  #  Et: "unde, odio, nihil; dolorum's vero's animi"
+  def self.fancy_title
+    "#{Faker::Lorem.words(rand(1..5)).join(' ').capitalize}: " \
+    "\"#{Faker::Lorem.words.join(', ')}; #{Faker::Lorem.words.join("'s ")}\""
+  end
+end


### PR DESCRIPTION
## Description

In the process of working on #736, our generated csv files were not allowing commas or other punctuation within a field. This was blocking the ability to split first and last names using a comma.

Using the `to_csv` method will can correctly escape quotes, commas, and other punctuation that we want to keep within a field. Also creates a MetadataFactory class to generate random fields with punctuation to ensure a csv will be correctly imported.

Connected to #736 
