### PR TITLE
ChangeSetPersister#delete should update parent resources

### DIFF
--- a/app/blacklight/catalog_search_behavior.rb
+++ b/app/blacklight/catalog_search_behavior.rb
@@ -41,14 +41,14 @@ module CatalogSearchBehavior
 
     # @note Extends the search to include the fields from file sets attached to work.
     def search_metadata_from_file_sets
-      "{!join from=join_id_ssi to=file_set_ids_ssim}#{query_all_query_fields}"
+      "{!join from=join_id_ssi to=member_ids_ssim}#{query_all_query_fields}"
     end
 
     # @note Extends to search to include text content extracted from files in the work. This is functionally
     #   equivalent to:
-    #     q={!join from=join_id_ssi to=file_set_ids_ssim}all_text_timv:user_query
+    #     q={!join from=join_id_ssi to=member_ids_ssim}all_text_timv:user_query
     #   where user_query is the query string submitted by the user.
     def search_extracted_text_from_files
-      '{!join from=join_id_ssi to=file_set_ids_ssim}{!dismax qf=all_text_timv v=$user_query}'
+      '{!join from=join_id_ssi to=member_ids_ssim}{!dismax qf=all_text_timv v=$user_query}'
     end
 end

--- a/app/blacklight/document/csv.rb
+++ b/app/blacklight/document/csv.rb
@@ -67,7 +67,7 @@ module Document::Csv
     end
 
     def export_member_file_sets(member)
-      member.file_set_ids.map do |id|
+      member.member_ids.map do |id|
         export_fields(SolrDocument.find(id.sub(/^id-/, '')))
       end
     end

--- a/app/blacklight/solr_document.rb
+++ b/app/blacklight/solr_document.rb
@@ -40,13 +40,13 @@ class SolrDocument
 
   # @return [Array<Work::FileSet>]
   def file_sets
-    Array.wrap(self['file_set_ids_ssim']).map do |id|
+    Array.wrap(self['member_ids_ssim']).map do |id|
       Work::FileSet.find(Valkyrie::ID.new(id.sub(/^id-/, '')))
     end
   end
 
-  def file_set_ids
-    Array.wrap(self['file_set_ids_ssim'])
+  def member_ids
+    Array.wrap(self['member_ids_ssim'])
   end
 
   # @return [Array<Work::File>]
@@ -57,7 +57,7 @@ class SolrDocument
   end
 
   def work
-    query_service.find_inverse_references_by(resource: self, property: 'file_set_ids').to_a.first
+    query_service.find_inverse_references_by(resource: self, property: 'member_ids').to_a.first
   end
 
   def query_service

--- a/app/cho/collection/with_members.rb
+++ b/app/cho/collection/with_members.rb
@@ -7,6 +7,11 @@ module Collection
       query_service.find_inverse_references_by(resource: self, property: 'member_of_collection_ids').to_a
     end
 
+    # @return [Array<Valkyrie::ID]
+    def member_ids
+      members.map(&:id)
+    end
+
     private
 
       def query_service

--- a/app/cho/import/work.rb
+++ b/app/cho/import/work.rb
@@ -15,8 +15,8 @@ class Import::Work
   end
 
   def file_sets
-    file_set_ids = files.map(&:file_set_id).uniq
-    file_set_ids.map do |id|
+    member_ids = files.map(&:file_set_id).uniq
+    member_ids.map do |id|
       Import::FileSet.new(files.select { |file| file.file_set_id == id })
     end
   end

--- a/app/cho/transaction/operations/file/save.rb
+++ b/app/cho/transaction/operations/file/save.rb
@@ -12,7 +12,7 @@ module Transaction
           return Success(change_set) unless change_set.respond_to?(:file) && change_set.file.present?
 
           saved_work_file_set = metadata_adapter.persister.save(resource: work_file_set(change_set))
-          change_set.model.file_set_ids << saved_work_file_set.id
+          change_set.model.member_ids << saved_work_file_set.id
           Success(change_set)
         rescue StandardError => exception
           Failure(Transaction::Rejection.new("Error persisting file: #{exception.message}"))

--- a/app/cho/transaction/operations/import/work.rb
+++ b/app/cho/transaction/operations/import/work.rb
@@ -14,7 +14,7 @@ module Transaction
 
           @model = change_set.model
           file_sets = saved_file_sets(change_set.import_work, file_set_hashes: change_set.file_set_hashes)
-          change_set.file_set_ids = file_sets.map(&:id)
+          change_set.member_ids = file_sets.map(&:id)
           Success(change_set)
         rescue StandardError => exception
           Failure(Transaction::Rejection.new("Error importing the work: #{exception.message}"))

--- a/app/cho/work/submission.rb
+++ b/app/cho/work/submission.rb
@@ -14,7 +14,7 @@ module Work
 
     # A list of Work::FileSet resources.
     #  The stored valkyrie ids for file sets attached to the submission
-    attribute :file_set_ids, Valkyrie::Types::Set.of(Valkyrie::Types::ID)
+    attribute :member_ids, Valkyrie::Types::Set.of(Valkyrie::Types::ID)
 
     attribute :batch_id, Valkyrie::Types::String.optional
 
@@ -39,7 +39,7 @@ module Work
     end
 
     def file_sets
-      @file_sets ||= file_set_ids.map { |id| Work::FileSet.find(id) }
+      @file_sets ||= member_ids.map { |id| Work::FileSet.find(id) }
     end
 
     def representative_file_set

--- a/app/cho/work/submission_change_set.rb
+++ b/app/cho/work/submission_change_set.rb
@@ -9,8 +9,8 @@ module Work
     validates :work_type_id, with: :validate_work_type_id!
     property :work_type_id, multiple: false, required: true, type: Valkyrie::Types::ID
 
-    validates :file_set_ids, with: :validate_members!
-    property :file_set_ids,
+    validates :member_ids, with: :validate_members!
+    property :member_ids,
              multiple: true,
              required: false,
              type: Types::Strict::Array.of(Valkyrie::Types::ID)

--- a/spec/blacklight/solr_document_spec.rb
+++ b/spec/blacklight/solr_document_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe SolrDocument, type: :model do
     subject { solr_document.file_sets.first }
 
     let(:file_set) { create :file_set }
-    let(:document) { { 'internal_resource_tsim' => 'MyResource', file_set_ids_ssim: [file_set.id.to_s] } }
+    let(:document) { { 'internal_resource_tsim' => 'MyResource', member_ids_ssim: [file_set.id.to_s] } }
 
     its(:to_h) { is_expected.to include(title: ['Original File Name'],
                                         internal_resource: 'Work::FileSet',
@@ -82,10 +82,10 @@ RSpec.describe SolrDocument, type: :model do
       let(:collection) { create :library_collection }
       let(:work) { create :work, :with_file, member_of_collection_ids: [collection.id], title: 'Work One' }
       let(:work1_csv) { "#{work.id},Work One,,,,,,,,,,#{collection.id},," }
-      let(:file_set1_csv) { "#{work.file_set_ids.first},hello_world.txt,,,,,,,,,,,," }
+      let(:file_set1_csv) { "#{work.member_ids.first},hello_world.txt,,,,,,,,,,,," }
       let(:work2) { create :work, :with_file, member_of_collection_ids: [collection.id], title: 'Work Two' }
       let(:work2_csv) { "#{work2.id},Work Two,,,,,,,,,,#{collection.id},," }
-      let(:file_set2_csv) { "#{work2.file_set_ids.first},hello_world.txt,,,,,,,,,,,," }
+      let(:file_set2_csv) { "#{work2.member_ids.first},hello_world.txt,,,,,,,,,,,," }
 
       let(:csv_header) do
         'id,title,subtitle,description,alternate_ids,creator,audio_field,created,document_field,'\
@@ -115,7 +115,7 @@ RSpec.describe SolrDocument, type: :model do
           'internal_resource_tsim' => 'MyResource',
           id: 'abc123',
           member_of_collection_ids_ssim: ['xyx789'],
-          file_set_ids_ssim: ["id-#{file_set.id}"],
+          member_ids_ssim: ["id-#{file_set.id}"],
           title_tesim: ['my_title'],
           generic_field_tesim: ['value1', 'value2']
         }

--- a/spec/cho/metrics/work_spec.rb
+++ b/spec/cho/metrics/work_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Metrics::Work do
   let(:metric)    { described_class.new(length: 1, output: report) }
   let(:report)    { StringIO.new }
   let(:work)      { ::Work::Submission.all.first }
-  let(:file_set)  { Work::FileSet.find(work.file_set_ids.first) }
+  let(:file_set)  { Work::FileSet.find(work.member_ids.first) }
   let(:file_uri)  { URI(Work::File.find(file_set.member_ids.first).file_identifier.to_s) }
 
   describe '#file_size' do

--- a/spec/cho/transaction/operations/file/save_spec.rb
+++ b/spec/cho/transaction/operations/file/save_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Transaction::Operations::File::Save do
           result = operation.call(change_set)
           expect(result).to be_success
           expect(result.success).to eq(change_set)
-          expect(result.success.file_set_ids.count).to eq(1)
+          expect(result.success.member_ids.count).to eq(1)
         }.to change { Work::File.count }.by(2).and change { Work::FileSet.count }.by(1)
       end
     end

--- a/spec/cho/transaction/operations/import/work_spec.rb
+++ b/spec/cho/transaction/operations/import/work_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Transaction::Operations::Import::Work do
           result = operation.call(change_set)
           expect(result).to be_success
           expect(result.success).to eq(change_set)
-          expect(result.success.file_set_ids.count).to eq(1)
+          expect(result.success.member_ids.count).to eq(1)
         }.to change { ::Work::File.count }.by(5).and change { ::Work::FileSet.count }.by(1)
       end
     end
@@ -70,7 +70,7 @@ RSpec.describe Transaction::Operations::Import::Work do
           result = operation.call(change_set)
           expect(result).to be_success
           expect(result.success).to eq(change_set)
-          expect(result.success.file_set_ids.count).to eq(1)
+          expect(result.success.member_ids.count).to eq(1)
         }.to change { ::Work::File.count }.by(5).and change { ::Work::FileSet.count }.by(1)
       end
     end

--- a/spec/cho/work/file_set/delete_spec.rb
+++ b/spec/cho/work/file_set/delete_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Deleting file sets', type: :feature do
+  let!(:resource) { create(:file_set, :with_creator, :with_member_file, title: 'File Set to Delete') }
+  let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
+
+  it "removes the file set and file from the system and updates the work's membership" do
+    visit(polymorphic_path([:solr_document], id: Work::Submission.all.first.id))
+    click_link('File Set to Delete')
+    expect(page).to have_selector('li', text: 'hello_world.txt')
+    click_link('Edit')
+    click_button('Delete File Set')
+    expect(page).to have_content('The following resources will be deleted')
+    expect(page).to have_content(resource.title.first)
+    expect(page).to have_selector('li', text: 'File: hello_world.txt')
+    click_button('Continue')
+    expect(page).to have_content('You have successfully deleted the following items')
+    expect(page).to have_content('File Set to Delete (1 items)')
+    expect(Work::File.all.count).to eq(0)
+    expect(Work::FileSet.all.count).to eq(0)
+    expect(adapter.index_adapter.query_service.find_all.count).to eq(2)
+    expect(File.exists?('tmp/files/hello_world.txt')).to be(false)
+    visit(polymorphic_path([:solr_document], id: Work::Submission.all.first.id))
+    expect(page).not_to have_content('File Set to Delete')
+  end
+end

--- a/spec/cho/work/import/create_spec.rb
+++ b/spec/cho/work/import/create_spec.rb
@@ -66,8 +66,8 @@ RSpec.describe 'Preview of CSV Import', type: :feature do
       # Verify each work has a file set and a file
       Work::Submission.all.each do |work|
         expect(work.batch_id).to eq('batch1_2018-07-12')
-        expect(work.file_set_ids.count).to eq(1)
-        file_set = Work::FileSet.find(Valkyrie::ID.new(work.file_set_ids.first))
+        expect(work.member_ids.count).to eq(1)
+        file_set = Work::FileSet.find(Valkyrie::ID.new(work.member_ids.first))
         expect(file_set.member_ids.count).to eq(1)
         file = Work::File.find(Valkyrie::ID.new(file_set.member_ids.first))
         expect(file_set.title).to contain_exactly(file.original_filename)
@@ -146,7 +146,7 @@ RSpec.describe 'Preview of CSV Import', type: :feature do
       # Verify each work has a file set and a file
       imported_work = Work::Submission.all.first
       expect(imported_work.title).to eq(['My Work1'])
-      file_sets = imported_work.file_set_ids.map do |id|
+      file_sets = imported_work.member_ids.map do |id|
         Work::FileSet.find(Valkyrie::ID.new(id))
       end
       expect(file_sets.count).to eq(5)

--- a/spec/cho/work/submissions/change_set_spec.rb
+++ b/spec/cho/work/submissions/change_set_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Work::SubmissionChangeSet do
     end
 
     it 'has multiple file sets' do
-      expect(change_set).to be_multiple(:file_set_ids)
+      expect(change_set).to be_multiple(:member_ids)
     end
 
     it 'has a single batch id' do
@@ -51,7 +51,7 @@ RSpec.describe Work::SubmissionChangeSet do
     its(:work_type) { is_expected.to be_nil }
     its(:file) { is_expected.to be_nil }
     its(:member_of_collection_ids) { is_expected.to be_nil }
-    its(:file_set_ids) { is_expected.to be_empty }
+    its(:member_ids) { is_expected.to be_empty }
     its(:batch_id) { is_expected.to be_nil }
     its(:import_work) { is_expected.to be_nil }
     its(:file_set_hashes) { is_expected.to be_empty }
@@ -120,11 +120,11 @@ RSpec.describe Work::SubmissionChangeSet do
     end
   end
 
-  describe '#file_set_ids' do
-    before { change_set.validate(file_set_ids: ['1']) }
+  describe '#member_ids' do
+    before { change_set.validate(member_ids: ['1']) }
 
     it 'casts ids to Valkyrie IDs' do
-      expect(change_set.file_set_ids.first).to be_kind_of(Valkyrie::ID)
+      expect(change_set.member_ids.first).to be_kind_of(Valkyrie::ID)
     end
   end
 

--- a/spec/cho/work/submissions/submission_spec.rb
+++ b/spec/cho/work/submissions/submission_spec.rb
@@ -74,23 +74,23 @@ RSpec.describe Work::Submission do
     end
   end
 
-  describe '#file_set_ids' do
+  describe '#member_ids' do
     it 'is empty when not set' do
-      expect(resource_klass.new.file_set_ids).to be_empty
+      expect(resource_klass.new.member_ids).to be_empty
     end
 
     it 'can be set as an attribute' do
-      resource = resource_klass.new(file_set_ids: ['1', '2'])
-      expect(resource.attributes[:file_set_ids].map(&:id)).to contain_exactly('1', '2')
-      expect(resource.attributes[:file_set_ids].first.class).to eq(Valkyrie::ID)
+      resource = resource_klass.new(member_ids: ['1', '2'])
+      expect(resource.attributes[:member_ids].map(&:id)).to contain_exactly('1', '2')
+      expect(resource.attributes[:member_ids].first.class).to eq(Valkyrie::ID)
     end
 
     it 'is included in the list of attributes' do
-      expect(resource_klass.new.has_attribute?(:file_set_ids)).to eq true
+      expect(resource_klass.new.has_attribute?(:member_ids)).to eq true
     end
 
     it 'is included in the list of fields' do
-      expect(resource_klass.fields).to include(:file_set_ids)
+      expect(resource_klass.fields).to include(:member_ids)
     end
   end
 
@@ -114,7 +114,7 @@ RSpec.describe Work::Submission do
   end
 
   describe '#file_sets' do
-    let(:work)     { create(:work, file_set_ids: [file_set.id]) }
+    let(:work)     { create(:work, member_ids: [file_set.id]) }
     let(:file_set) { create(:file_set) }
 
     it { expect(work.file_sets.map(&:id)).to contain_exactly(file_set.id) }
@@ -122,14 +122,14 @@ RSpec.describe Work::Submission do
 
   describe '#representative_file_set' do
     context 'without a designated representative' do
-      let(:work)     { create(:work, file_set_ids: [file_set.id]) }
+      let(:work)     { create(:work, member_ids: [file_set.id]) }
       let(:file_set) { create(:file_set) }
 
       it { expect(work.representative_file_set.id).to eq(file_set.id) }
     end
 
     context 'with a designated representative' do
-      let(:work)           { create(:work, file_set_ids: [file_set.id, representative.id]) }
+      let(:work)           { create(:work, member_ids: [file_set.id, representative.id]) }
       let(:file_set)       { create(:file_set, alternate_ids: ['alt-id']) }
       let(:representative) { create(:file_set, alternate_ids: []) }
 

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
       fileset = Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: resource)
       work = attributes.work
       work ||= FactoryBot.build(:work_submission)
-      work.file_set_ids << fileset.id
+      work.member_ids << fileset.id
       Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: work)
       fileset
     end
@@ -33,7 +33,7 @@ FactoryBot.define do
       fileset = Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: resource)
       work = attributes.work
       work ||= FactoryBot.build(:work_submission)
-      work.file_set_ids << fileset.id
+      work.member_ids << fileset.id
       Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: work)
       fileset
     end


### PR DESCRIPTION
## Description

Parent resources were not updated when their child members were deleted. This fixes that by doing a larger scale change and unifying all the membership methods between Valkyrie resources.

All memberships, whether many-to-one or one-to-many, can be found using the `member_ids` method. This makes the process of delete contained resources and updating their containing resources much easier.

Connected to #638

## Changes

* `file_set_ids` is changed to `member_ids`
* collection membership can also be expressed in ids with `member_ids`
* ChangeSetPersister#delete updates containing/parent resources when their members are deleted
