### PR TITLE
Parse agents and roles in csv files

### DIFF
--- a/app/cho/agent/resource.rb
+++ b/app/cho/agent/resource.rb
@@ -2,6 +2,8 @@
 
 module Agent
   class Resource < Valkyrie::Resource
+    NAME_SEPARATOR = ','
+
     include CommonQueries
 
     attribute :given_name, Valkyrie::Types::String
@@ -9,6 +11,10 @@ module Agent
 
     def to_s
       "#{given_name} #{surname}"
+    end
+
+    def display_name
+      "#{surname}#{NAME_SEPARATOR} #{given_name}"
     end
   end
 end

--- a/app/cho/shared/csv_parsing.rb
+++ b/app/cho/shared/csv_parsing.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 module CsvParsing
-  VALUE_SEPARATOR = '|'
+  VALUE_SEPARATOR = '||'
+  SUBVALUE_SEPARATOR = '|'
 end

--- a/app/cho/work/import/work_hash_validator.rb
+++ b/app/cho/work/import/work_hash_validator.rb
@@ -16,6 +16,7 @@ module Work
 
         def clean_hash
           resource_hash['member_of_collection_ids'] = collection_ids
+          resource_hash['creator'] = agents_with_roles
           unless updating? || work_type.blank?
             resource_hash['work_type_id'] = work_type.id
           end
@@ -38,6 +39,31 @@ module Work
           Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: id).id
         rescue Valkyrie::Persistence::ObjectNotFoundError
           id
+        end
+
+        def agents_with_roles
+          Array.wrap(resource_hash['creator']).map do |creator|
+            fullname, role = creator.split(CsvParsing::SUBVALUE_SEPARATOR)
+            {
+              role: find_role(role),
+              agent: find_agent(fullname)
+            }
+          end
+        end
+
+        def find_agent(name)
+          surname, given_name = name.split(Agent::Resource::NAME_SEPARATOR)
+          result = Agent::Resource.where(given_name: given_name.strip, surname: surname.strip).first
+          if result
+            result.id.to_s
+          else
+            name
+          end
+        end
+
+        def find_role(role)
+          return if role.blank?
+          RDF::URI("http://id.loc.gov/vocabulary/relators/#{role}")
         end
     end
   end

--- a/spec/blacklight/solr_document_spec.rb
+++ b/spec/blacklight/solr_document_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe SolrDocument, type: :model do
       }
     end
 
-    it { is_expected.to eq("abc123,my_title,,,,,,,,value1|value2,,xyx789,,\n") }
+    it { is_expected.to eq("abc123,my_title,,,,,,,,value1||value2,,xyx789,,\n") }
 
     context 'with a collection containing works and file sets' do
       let(:collection) { create :library_collection }
@@ -122,7 +122,7 @@ RSpec.describe SolrDocument, type: :model do
       end
 
       let(:file_set) { create(:file_set) }
-      let(:work_csv) { 'abc123,my_title,,,,,,,,value1|value2,,xyx789,,' }
+      let(:work_csv) { 'abc123,my_title,,,,,,,,value1||value2,,xyx789,,' }
       let(:file_set_csv) { "#{file_set.id},Original File Name,,,,,,,,,,,," }
 
       before { file_set }

--- a/spec/cho/csv/reader_spec.rb
+++ b/spec/cho/csv/reader_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Csv::Reader do
     it { is_expected.to eq(csv_hash) }
 
     context 'value has multiple items' do
-      let(:csv_file) { StringIO.new("header1,header2\ndata1,data2\ndataA1|dataA2,dataB") }
+      let(:csv_file) { StringIO.new("header1,header2\ndata1,data2\ndataA1||dataA2,dataB") }
       let(:csv_hash) do
         [{ 'header1' => 'data1', 'header2' => 'data2' }, { 'header1' => ['dataA1', 'dataA2'], 'header2' => 'dataB' }]
       end

--- a/spec/cho/work/import/csv_reader_spec.rb
+++ b/spec/cho/work/import/csv_reader_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Work::Import::CsvReader do
     it { is_expected.to eq(csv_hash) }
 
     context 'value has multiple items' do
-      let(:csv_file) { StringIO.new("header1,header2\ndata1,data2\ndataA1|dataA2,dataB") }
+      let(:csv_file) { StringIO.new("header1,header2\ndata1,data2\ndataA1||dataA2,dataB") }
       let(:csv_hash) do
         [{ 'header1' => 'data1', 'header2' => 'data2' }, { 'header1' => ['dataA1', 'dataA2'], 'header2' => 'dataB' }]
       end

--- a/spec/factories/agent.rb
+++ b/spec/factories/agent.rb
@@ -10,4 +10,9 @@ FactoryBot.define do
       Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: resource)
     end
   end
+
+  trait :generate_name do
+    given_name { Faker::Name.first_name }
+    surname { Faker::Name.last_name }
+  end
 end


### PR DESCRIPTION
## Description

Takes a correctly-formatted agent/role combination in the csv creator field and parses it so that it will be correctly linked in the application. Errors are reported in the dry run if the agent or role does not exist.

Connected to #736 