### PR TITLE
Fixing bugs with agent import

### DIFF
--- a/app/cho/agent/csv_presenter.rb
+++ b/app/cho/agent/csv_presenter.rb
@@ -18,7 +18,7 @@ module Agent
     private
 
       def csv_header
-        headers = export_attributes.map(&:titleize)
+        headers = export_attributes
         ::CSV.generate_line(headers)
       end
 

--- a/app/cho/agent/import/csv_dry_run.rb
+++ b/app/cho/agent/import/csv_dry_run.rb
@@ -9,7 +9,7 @@ module Agent
       # @param [true, false] update
       def initialize(csv_file_name, update: false)
         @update = update
-        @reader = Csv::Reader.new(::File.new(csv_file_name, 'r'))
+        @reader = Csv::Reader.new(::File.new(csv_file_name, 'r', encoding: 'bom|utf-8'))
         validate_structure
         results
       end

--- a/app/cho/agent/resources_controller.rb
+++ b/app/cho/agent/resources_controller.rb
@@ -58,7 +58,7 @@ module Agent
       alias_method :delete_change_set, :update_change_set
 
       def resource_params
-        params[:agent].to_unsafe_h
+        params[:agent_resource].to_unsafe_h
       end
 
       def change_set_class

--- a/app/views/agent/import/csv/_dry_run_result.html.erb
+++ b/app/views/agent/import/csv/_dry_run_result.html.erb
@@ -1,5 +1,6 @@
 <tr>
-  <td><%= "#{dry_run_result.given_name} #{dry_run_result.surname}" %></td>
+  <td><%= dry_run_result.given_name %></td>
+  <td><%= dry_run_result.surname %>
   <td>
     <% if dry_run_result.errors.present? %>
       <%= render 'csv/dry_run_error_list', errors: dry_run_result.errors.full_messages %>

--- a/spec/cho/agent/controller_spec.rb
+++ b/spec/cho/agent/controller_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Agent::ResourcesController, type: :controller do
         get :index, params: {}, session: valid_session, format: :csv
         expect(response.content_type).to eq('text/csv')
         expect(response.body).to include(
-          "Id,Surname,Given Name\n"
+          "id,surname,given_name\n"
         )
         expect(response.body).to include(
           "#{agent.id},#{agent.surname},#{agent.given_name}\n"
@@ -89,7 +89,7 @@ RSpec.describe Agent::ResourcesController, type: :controller do
         end
 
         it 'updates the requested agent' do
-          put :update, params: { id: agent.to_param, agent: new_attributes },
+          put :update, params: { id: agent.to_param, agent_resource: new_attributes },
                        session: valid_session
           expect(response).to redirect_to(reloaded_agent)
           expect(reloaded_agent.surname).to eq('Smith')
@@ -99,7 +99,7 @@ RSpec.describe Agent::ResourcesController, type: :controller do
 
       context 'with invalid params' do
         it "returns a success response (i.e. to display the 'edit' template)" do
-          put :update, params: { id: agent.to_param, agent: invalid_attributes },
+          put :update, params: { id: agent.to_param, agent_resource: invalid_attributes },
                        session: valid_session
           expect(response).to be_success
         end
@@ -132,19 +132,19 @@ RSpec.describe Agent::ResourcesController, type: :controller do
     context 'with valid params' do
       it 'creates a new MetadataField' do
         expect {
-          post :create, params: { agent: valid_attributes }, session: valid_session
+          post :create, params: { agent_resource: valid_attributes }, session: valid_session
         }.to change(Agent::Resource, :count).by(1)
       end
 
       it 'redirects to the created agent' do
-        post :create, params: { agent: valid_attributes }, session: valid_session
+        post :create, params: { agent_resource: valid_attributes }, session: valid_session
         expect(response).to redirect_to(Agent::Resource.all.max_by(&:created_at))
       end
     end
 
     context 'with invalid params' do
       it "returns a success response (i.e. to display the 'new' template)" do
-        post :create, params: { agent: invalid_attributes }, session: valid_session
+        post :create, params: { agent_resource: invalid_attributes }, session: valid_session
         expect(response).to be_success
         expect(assigns[:agent].errors.first)
           .to eq([:given_name, 'can\'t be blank'])
@@ -164,7 +164,7 @@ RSpec.describe Agent::ResourcesController, type: :controller do
       end
 
       it "returns a success response (i.e. to display the 'new' template)" do
-        post :create, params: { agent: valid_attributes }, session: valid_session
+        post :create, params: { agent_resource: valid_attributes }, session: valid_session
         expect(response).to be_success
         expect(assigns[:agent].errors.first).to eq([:save, 'an error saving'])
       end

--- a/spec/cho/agent/import/csv_dry_run_spec.rb
+++ b/spec/cho/agent/import/csv_dry_run_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Agent::Import::CsvDryRun do
 
   describe '#update?' do
     before do
-      allow(File).to receive(:new).with('path', 'r')
+      allow(File).to receive(:new).with('path', 'r', encoding: 'bom|utf-8')
       allow(Csv::Reader).to receive(:new).with(any_args).and_return(mock_reader)
     end
 
@@ -30,7 +30,7 @@ RSpec.describe Agent::Import::CsvDryRun do
 
   describe '#bag?' do
     before do
-      allow(File).to receive(:new).with('path', 'r')
+      allow(File).to receive(:new).with('path', 'r', encoding: 'bom|utf-8')
       allow(Csv::Reader).to receive(:new).with(any_args).and_return(mock_reader)
     end
 


### PR DESCRIPTION
## Description
  There were a number of issues with the Agent process.  Editing an agent blew up (see image below) csv files created by excel included the BOM character which caused the id label not to be parsed correctly, the labels on export were titleized, and the formatting was off on the display.

Connected to #843 
Connected to #820
    
## Changes
* Added BOM encoding
* Fixed bug with agent vs agent_resource in the params
* removed the titleize from the export

Import screen formatting
![Screen Shot 2019-03-11 at 1 13 49 PM](https://user-images.githubusercontent.com/1599081/54143126-90688080-43ff-11e9-9194-3bbacfb10d3e.png)


Before parameter change:
![Screen Shot 2019-03-11 at 1 07 07 PM](https://user-images.githubusercontent.com/1599081/54142812-e2f56d00-43fe-11e9-9523-2f6052b4616a.png)

After Parameter change:
![Screen Shot 2019-03-11 at 1 10 03 PM](https://user-images.githubusercontent.com/1599081/54142896-07e9e000-43ff-11e9-9ffa-8ecd0cb255f7.png)

