### PR TITLE
Assume a representative thumbnail if there isn't one

### DIFF
--- a/app/cho/work/submission_indexer.rb
+++ b/app/cho/work/submission_indexer.rb
@@ -41,10 +41,16 @@ module Work
       end
 
       def thumbnail_path
-        thumbnail = resource.representative_file_set.thumbnail
+        thumbnail = resource.representative_file_set.thumbnail || select_thumbnail
         return if thumbnail.nil?
 
         thumbnail.path.to_s
+      end
+
+      def select_thumbnail
+        possible_thumbnails = resource.file_sets.select(&:thumbnail)
+        return if possible_thumbnails.empty?
+        possible_thumbnails.first.thumbnail
       end
   end
 end


### PR DESCRIPTION
## Description

If the representative file set lacks a thumbnail, or otherwise doesn't have a representative file set at all, choose the first file set that has a thumbnail and use that for display purposes.

Connected to #827