### PR TITLE
allowing work type to have any case

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -53,6 +53,7 @@ RSpec/NestedGroups:
     - 'spec/cho/schema/metadata_field_change_set_spec.rb'
     - 'spec/cho/shared/item_factory_spec.rb'
     - 'spec/cho/work/submissions/change_set_spec.rb'
+    - 'spec/cho/work/import/work_hash_validator_spec.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.

--- a/app/cho/work/import/work_hash_validator.rb
+++ b/app/cho/work/import/work_hash_validator.rb
@@ -25,6 +25,7 @@ module Work
         def work_type
           @work_type ||= begin
                            label = resource_hash.fetch('work_type', nil)
+                           label = label.downcase.titleize if label.present?
                            Work::Type.find_using(label: label).first
                          end
         end

--- a/spec/cho/work/import/work_hash_validator_spec.rb
+++ b/spec/cho/work/import/work_hash_validator_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Work::Import::WorkHashValidator do
 
   let(:collection) { create :library_collection }
   let(:generic_work_type) { Work::Type.find_using(label: 'Generic').first }
+  let(:still_image_work_type) { Work::Type.find_using(label: 'Still Image').first }
 
   describe '#change_set' do
     subject(:change_set) { reader.change_set }
@@ -31,6 +32,63 @@ RSpec.describe Work::Import::WorkHashValidator do
         expect(change_set.model).to be_a(Work::Submission)
         expect(change_set.work_type_id).to eq(generic_work_type.id)
         expect(change_set.member_of_collection_ids).to eq(collection.id)
+      end
+
+      context 'with a work type properly cased' do
+        let(:work_hash) do
+          {
+            'member_of_collection_ids' => [collection.id],
+            'work_type' => 'Still Image',
+            'title' => 'my awesome work',
+            'description' => ''
+          }
+        end
+
+        it 'is valid and has a work type set' do
+          expect(change_set).to be_a(Work::SubmissionChangeSet)
+          expect(change_set).to be_valid
+          expect(change_set.model).to be_a(Work::Submission)
+          expect(change_set.work_type_id).to eq(still_image_work_type.id)
+          expect(change_set.member_of_collection_ids).to eq(collection.id)
+        end
+      end
+
+      context 'with a work type improperly upper cased' do
+        let(:work_hash) do
+          {
+            'member_of_collection_ids' => [collection.id],
+            'work_type' => 'GENERIC',
+            'title' => 'my awesome work',
+            'description' => ''
+          }
+        end
+
+        it 'is valid and has a work type set' do
+          expect(change_set).to be_a(Work::SubmissionChangeSet)
+          expect(change_set).to be_valid
+          expect(change_set.model).to be_a(Work::Submission)
+          expect(change_set.work_type_id).to eq(generic_work_type.id)
+          expect(change_set.member_of_collection_ids).to eq(collection.id)
+        end
+      end
+
+      context 'with a work type improperly lower cased' do
+        let(:work_hash) do
+          {
+            'member_of_collection_ids' => [collection.id],
+            'work_type' => 'geNeric',
+            'title' => 'my awesome work',
+            'description' => ''
+          }
+        end
+
+        it 'is valid and has a work type set' do
+          expect(change_set).to be_a(Work::SubmissionChangeSet)
+          expect(change_set).to be_valid
+          expect(change_set.model).to be_a(Work::Submission)
+          expect(change_set.work_type_id).to eq(generic_work_type.id)
+          expect(change_set.member_of_collection_ids).to eq(collection.id)
+        end
       end
     end
 


### PR DESCRIPTION
## Description

This was requested to make the import process more foolproof.

Connected to #656 

## Changes

* allow work_type to be case insensitive
