### PR TITLE
Use correct use types in file fixtures

### DIFF
--- a/spec/cho/repository/downloads_controller_spec.rb
+++ b/spec/cho/repository/downloads_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Repository::DownloadsController, type: :controller do
       specify do
         get :download, params: { id: file_set.id }
         expect(response).to be_success
-        expect(response.body).to eq('Hello World!')
+        expect(response.body).to eq('Hello World! (preservation)')
       end
     end
 
@@ -20,7 +20,7 @@ RSpec.describe Repository::DownloadsController, type: :controller do
       specify do
         get :download, params: { id: file_set.id }
         expect(response).to be_success
-        expect(response.body).to eq('Hello World!')
+        expect(response.body).to eq('Hello World! (redacted preservation)')
       end
     end
 
@@ -30,7 +30,7 @@ RSpec.describe Repository::DownloadsController, type: :controller do
       specify do
         get :download, params: { id: file_set.id }
         expect(response).to be_success
-        expect(response.body).to eq('Hello World!')
+        expect(response.body).to eq('Hello World! (service)')
       end
     end
 
@@ -40,7 +40,7 @@ RSpec.describe Repository::DownloadsController, type: :controller do
       specify do
         get :download, params: { id: file_set.id, use_type: 'PreservationMasterFile' }
         expect(response).to be_success
-        expect(response.body).to eq('Hello World!')
+        expect(response.body).to eq('Hello World! (redacted preservation)')
       end
     end
 
@@ -50,7 +50,7 @@ RSpec.describe Repository::DownloadsController, type: :controller do
       specify do
         get :download, params: { id: file_set.id, use_type: 'PreservationMasterFile' }
         expect(response).to be_success
-        expect(response.body).to eq('Hello World!')
+        expect(response.body).to eq('Hello World! (preservation)')
       end
     end
 
@@ -60,7 +60,7 @@ RSpec.describe Repository::DownloadsController, type: :controller do
       specify do
         get :download, params: { id: file_set.id, use_type: 'AccessFile' }
         expect(response).to be_success
-        expect(response.body).to eq('Hello World!')
+        expect(response.body).to eq('Hello World! (access)')
       end
     end
 
@@ -70,7 +70,7 @@ RSpec.describe Repository::DownloadsController, type: :controller do
       specify do
         get :download, params: { id: file_set.id, use_type: 'ServiceFile' }
         expect(response).to be_success
-        expect(response.body).to eq('Hello World!')
+        expect(response.body).to eq('Hello World! (service)')
       end
     end
 
@@ -80,7 +80,7 @@ RSpec.describe Repository::DownloadsController, type: :controller do
       specify do
         get :download, params: { id: file_set.id, use_type: :bogus }
         expect(response).to be_success
-        expect(response.body).to eq('Hello World!')
+        expect(response.body).to eq('Hello World! (service)')
       end
     end
 

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -23,90 +23,57 @@ FactoryBot.define do
 
   trait :with_member_file do
     to_create do |resource, attributes|
-      temp_file = Rack::Test::UploadedFile.new(Rails.root.join('spec', 'fixtures', 'hello_world.txt'))
-      file = Work::File.new(original_filename: temp_file.original_filename)
-      file_change_set = Work::FileChangeSet.new(file)
-      result = Transaction::Operations::File::Create.new.call(file_change_set, temp_file: temp_file)
-      raise result.failure if result.failure?
-
-      resource.member_ids = [result.success.id]
-      fileset = Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: resource)
-      work = attributes.work
-      work ||= FactoryBot.build(:work_submission)
-      work.member_ids << fileset.id
-      Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: work)
-      fileset
+      file_factory = FileFactory.new
+      file_factory.build_file_set(resource: resource, attributes: attributes)
     end
   end
 
   trait :with_preservation_file do
     to_create do |resource, attributes|
-      result = FileFactory.new.hello_world
-
-      resource.member_ids = [result.success.id]
-      fileset = Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: resource)
-      work = attributes.work
-      work ||= FactoryBot.build(:work_submission)
-      work.member_ids << fileset.id
-      Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: work)
-      fileset
+      file_factory = FileFactory.new(
+        use: Valkyrie::Vocab::PCDMUse.PreservationMasterFile,
+        text: 'Hello World! (preservation)'
+      )
+      file_factory.build_file_set(resource: resource, attributes: attributes)
     end
   end
 
   trait :with_missing_file do
     to_create do |resource, attributes|
-      result = FileFactory.new.hello_world
-      FileUtils.rm_f(result.success.resource.path)
-
-      resource.member_ids = [result.success.id]
-      fileset = Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: resource)
-      work = attributes.work
-      work ||= FactoryBot.build(:work_submission)
-      work.member_ids << fileset.id
-      Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: work)
+      file_factory = FileFactory.new
+      fileset = file_factory.build_file_set(resource: resource, attributes: attributes)
+      FileUtils.rm_f(fileset.files.first.path)
       fileset
     end
   end
 
   trait :with_redacted_preservation_file do
     to_create do |resource, attributes|
-      result = FileFactory.new(use: Vocab::FileUse.RedactedPreservationMasterFile).hello_world
-
-      resource.member_ids = [result.success.id]
-      fileset = Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: resource)
-      work = attributes.work
-      work ||= FactoryBot.build(:work_submission)
-      work.member_ids << fileset.id
-      Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: work)
-      fileset
+      file_factory = FileFactory.new(
+        use: Vocab::FileUse.RedactedPreservationMasterFile,
+        text: 'Hello World! (redacted preservation)'
+      )
+      file_factory.build_file_set(resource: resource, attributes: attributes)
     end
   end
 
   trait :with_service_file do
     to_create do |resource, attributes|
-      result = FileFactory.new(use: Valkyrie::Vocab::PCDMUse.ServiceFile).hello_world
-
-      resource.member_ids = [result.success.id]
-      fileset = Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: resource)
-      work = attributes.work
-      work ||= FactoryBot.build(:work_submission)
-      work.member_ids << fileset.id
-      Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: work)
-      fileset
+      file_factory = FileFactory.new(
+        use: Valkyrie::Vocab::PCDMUse.ServiceFile,
+        text: 'Hello World! (service)'
+      )
+      file_factory.build_file_set(resource: resource, attributes: attributes)
     end
   end
 
   trait :with_access_file do
     to_create do |resource, attributes|
-      result = FileFactory.new(use: Vocab::FileUse.AccessFile).hello_world
-
-      resource.member_ids = [result.success.id]
-      fileset = Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: resource)
-      work = attributes.work
-      work ||= FactoryBot.build(:work_submission)
-      work.member_ids << fileset.id
-      Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: work)
-      fileset
+      file_factory = FileFactory.new(
+        use: Vocab::FileUse.AccessFile,
+        text: 'Hello World! (access)'
+      )
+      file_factory.build_file_set(resource: resource, attributes: attributes)
     end
   end
 end


### PR DESCRIPTION
## Description

Corrects a problem with the file fixtures used in file sets. The use types were not being correctly set.

Additionally, refactors the FileFactory code in conjunction with the file set factory bot.

Thanks to @cam156 for catching this!