### PR TITLE
Adding a title so the display does not blow up

### DIFF
--- a/app/cho/csv/hash_validator.rb
+++ b/app/cho/csv/hash_validator.rb
@@ -47,6 +47,10 @@ module Csv
           current_errors
         end
 
+        def title
+          [I18n.t('cho.work.missing')]
+        end
+
         def valid?
           false
         end

--- a/config/locales/cho.yml
+++ b/config/locales/cho.yml
@@ -54,6 +54,7 @@ en:
         delete_link: "Delete Work"
         delete_confirmation: "Are you sure?"
       error: "%{count} prohibited this work from being saved:"
+      missing: "Missing"
       show:
         files_heading: "Files"
     collection:

--- a/spec/cho/csv/hash_validator_spec.rb
+++ b/spec/cho/csv/hash_validator_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe Csv::HashValidator, type: :model do
 
     it 'is not valid and has errors' do
       expect(change_set).not_to be_valid
+      expect(change_set.title).to eq(['Missing'])
       expect(change_set.errors.full_messages).to eq(['Id does not exist'])
     end
   end


### PR DESCRIPTION
## Description

Fixing a bug when the id does not match any item on update works.

## Without title:
<img width="1435" alt="Screen Shot 2019-03-14 at 9 09 39 AM" src="https://user-images.githubusercontent.com/1599081/54359729-abbed000-4639-11e9-8daf-14f05e71b51a.png">


## With title:
<img width="1192" alt="Screen Shot 2019-03-14 at 9 10 03 AM" src="https://user-images.githubusercontent.com/1599081/54359703-9d70b400-4639-11e9-838f-3016f08a52dd.png">
