### PR TITLE
disallow a changing work type in the validation

### DIFF
--- a/app/cho/work/import/work_hash_validator.rb
+++ b/app/cho/work/import/work_hash_validator.rb
@@ -17,7 +17,7 @@ module Work
         def clean_hash
           resource_hash['member_of_collection_ids'] = collection_ids
           resource_hash['creator'] = agents_with_roles
-          unless updating? || work_type.blank?
+          if work_type.present?
             resource_hash['work_type_id'] = work_type.id
           end
         end

--- a/app/cho/work/submission_change_set.rb
+++ b/app/cho/work/submission_change_set.rb
@@ -41,7 +41,7 @@ module Work
 
     def validate_work_type_id!(field)
       return if work_type_id.blank?
-
+      errors.add(field, 'can not be changed') if id.present? && work_type_id.id != model.work_type_id.id
       errors.add(field, "#{work_type_id} does not exist") if work_type.blank?
     end
 

--- a/spec/cho/work/import/work_hash_validator_spec.rb
+++ b/spec/cho/work/import/work_hash_validator_spec.rb
@@ -121,6 +121,24 @@ RSpec.describe Work::Import::WorkHashValidator do
         expect(change_set.member_of_collection_ids).to eq(collection.id)
         expect(change_set.id).to eq(work.id)
       end
+
+      context 'with a changed work_type' do
+        let(:work_hash) do
+          {
+            'id' => work.id,
+            'member_of_collection_ids' => [collection.id],
+            'title' => 'my awesome updated work',
+            'description' => 'updated description',
+            'work_type' => 'Audio'
+          }
+        end
+
+        it 'is not valid and has an id' do
+          expect(change_set).to be_a(Work::SubmissionChangeSet)
+          expect(change_set).not_to be_valid
+          expect(change_set.errors.full_messages).to eq(['Work type can not be changed'])
+        end
+      end
     end
 
     context 'with a non-existent work' do


### PR DESCRIPTION
## Description

Adding a validation to not allow work type to change

Connected to #817

## Changes

* Add a validation to disallow work type from changing
* Allow work_type to be modified by the hash validator, so the error message will be produced
