### PR TITLE
CSV metadata for works and file sets

### DIFF
--- a/app/cho/work/import/csv_dry_run.rb
+++ b/app/cho/work/import/csv_dry_run.rb
@@ -59,7 +59,7 @@ module Work
             file_set_hash = file_set_metadata(file_set.id).first
             next if file_set_hash.nil?
 
-            Csv::HashValidator.new(file_set_hash,
+            FileSetHashValidator.new(file_set_hash,
               resource_class: Work::FileSet,
               change_set_class: Work::FileSetChangeSet).change_set
           end

--- a/app/cho/work/import/csv_dry_run_results_presenter.rb
+++ b/app/cho/work/import/csv_dry_run_results_presenter.rb
@@ -15,7 +15,7 @@ module Work
       end
 
       def change_set_list
-        dry_run.results
+        dry_run.results + dry_run.results.map(&:file_set_hashes).flatten
       end
 
       def invalid_rows

--- a/app/cho/work/import/file_set_hash_validator.rb
+++ b/app/cho/work/import/file_set_hash_validator.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Work
+  module Import
+    class FileSetHashValidator < Csv::HashValidator
+      include WithHashCreators
+
+      private
+
+        def validate
+          clean_creators
+          super
+        end
+
+        def clean_creators
+          resource_hash['creator'] = agents_with_roles
+        end
+    end
+  end
+end

--- a/app/cho/work/import/with_hash_creators.rb
+++ b/app/cho/work/import/with_hash_creators.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Work::Import::WithHashCreators
+  def agents_with_roles
+    Array.wrap(resource_hash['creator']).map do |creator|
+      fullname, role = creator.split(CsvParsing::SUBVALUE_SEPARATOR)
+      {
+        role: find_role(role),
+        agent: find_agent(fullname)
+      }
+    end
+  end
+
+  def find_agent(name)
+    surname, given_name = name.split(Agent::Resource::NAME_SEPARATOR)
+    result = Agent::Resource.where(given_name: given_name.strip, surname: surname.strip).first
+    if result
+      result.id.to_s
+    else
+      name
+    end
+  end
+
+  def find_role(role)
+    return if role.blank?
+    RDF::URI("http://id.loc.gov/vocabulary/relators/#{role}")
+  end
+end

--- a/app/cho/work/import/work_hash_validator.rb
+++ b/app/cho/work/import/work_hash_validator.rb
@@ -7,6 +7,8 @@
 module Work
   module Import
     class WorkHashValidator < Csv::HashValidator
+      include WithHashCreators
+
       private
 
         def validate
@@ -40,31 +42,6 @@ module Work
           Valkyrie.config.metadata_adapter.query_service.find_by_alternate_identifier(alternate_identifier: id).id
         rescue Valkyrie::Persistence::ObjectNotFoundError
           id
-        end
-
-        def agents_with_roles
-          Array.wrap(resource_hash['creator']).map do |creator|
-            fullname, role = creator.split(CsvParsing::SUBVALUE_SEPARATOR)
-            {
-              role: find_role(role),
-              agent: find_agent(fullname)
-            }
-          end
-        end
-
-        def find_agent(name)
-          surname, given_name = name.split(Agent::Resource::NAME_SEPARATOR)
-          result = Agent::Resource.where(given_name: given_name.strip, surname: surname.strip).first
-          if result
-            result.id.to_s
-          else
-            name
-          end
-        end
-
-        def find_role(role)
-          return if role.blank?
-          RDF::URI("http://id.loc.gov/vocabulary/relators/#{role}")
         end
     end
   end

--- a/app/views/work/import/csv/_dry_run_result.html.erb
+++ b/app/views/work/import/csv/_dry_run_result.html.erb
@@ -1,10 +1,11 @@
 <tr>
-  <td><%= (dry_run_result.title || ['Title is Missing']).first %></td>
+  <td><%= (dry_run_result.title || [t('cho.csv.work.dry_run.missing_title')]).first %></td>
+  <td><%= dry_run_result.alternate_ids.first %></td>
   <td>
     <% if dry_run_result.errors.present? %>
       <%= render 'csv/dry_run_error_list', errors: dry_run_result.errors.full_messages %>
     <% else %>
-      Success
+      <%= t('cho.csv.work.dry_run.work_success') %>
     <% end %>
   </td>
 </tr>

--- a/app/views/work/import/csv/dry_run_results.html.erb
+++ b/app/views/work/import/csv/dry_run_results.html.erb
@@ -27,6 +27,7 @@
   <thead>
   <tr>
     <th><%= t('cho.csv.work.dry_run.preview_table.title') %></th>
+    <th><%= t('cho.csv.work.dry_run.preview_table.identifier') %></th>
     <th><%= t('cho.csv.work.dry_run.preview_table.status') %></th>
   </tr>
   </thead>

--- a/config/locales/cho.yml
+++ b/config/locales/cho.yml
@@ -120,12 +120,15 @@ en:
           preview_table:
             title: "Title"
             status: "Status"
+            identifier: "Identifier"
           submit: "Perform Import"
           cancel: "Cancel"
           bag_status: Bag Status
           bag_failure: "The bag contains %{count} error(s)"
           bag_success: "The bag is valid and contains no errors"
           csv_status: CSV Status
+          missing_title: "[No Title]"
+          work_success: "Success"
       import:
         failure:
           header: "Failed Import"

--- a/spec/support/import_factory/zip.rb
+++ b/spec/support/import_factory/zip.rb
@@ -6,6 +6,7 @@ module ImportFactory
     # @param [ImportFactory::Bag]
     def self.create(bag)
       output_file = Rails.root.join('tmp', 'ingest-test', "#{bag.path.basename}.zip")
+      FileUtils.rm_f(output_file)
       new(bag.path, output_file).write
       output_file
     end


### PR DESCRIPTION
## Description

Corrects errors and inconsistencies when creating or updated metadata in file sets via the csv import process.

Connected to #686 
