### PR TITLE
Allow creators with no roles to index correctly

### DIFF
--- a/app/cho/indexing/creator.rb
+++ b/app/cho/indexing/creator.rb
@@ -24,7 +24,7 @@ module Indexing
       attr_reader :role_id, :agent_id
 
       def initialize(arg)
-        @role_id = arg.fetch(:role)
+        @role_id = arg.fetch(:role, nil)
         @agent_id = arg.fetch(:agent)
       end
 
@@ -53,7 +53,7 @@ module Indexing
 
       def display_name
         return if blank?
-        "#{agent.surname}, #{agent.given_name}, #{role}"
+        [agent.display_name, role].compact.join(', ')
       end
     end
   end

--- a/spec/cho/work/import/create_spec.rb
+++ b/spec/cho/work/import/create_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Preview of CSV Import', type: :feature do
         creator: [
           "#{agent1.display_name}#{CsvParsing::SUBVALUE_SEPARATOR}bsl",
           "#{agent2.display_name}#{CsvParsing::SUBVALUE_SEPARATOR}cli",
-          "#{agent3.display_name}#{CsvParsing::SUBVALUE_SEPARATOR}bsl"
+          agent3.display_name.to_s
         ]
       )
     end
@@ -70,12 +70,26 @@ RSpec.describe 'Preview of CSV Import', type: :feature do
         expect(page).to have_selector('li a', text: 'My Work 2')
         expect(page).to have_selector('li a', text: 'My Work 3')
       end
+
+      # Inspect the collection and its members
       visit(polymorphic_path([:solr_document], id: collection.id))
       within('div#members') do
-        expect(page).to have_link('My Work 1')
-        expect(page).to have_link('My Work 2')
-        expect(page).to have_link('My Work 3')
+        click_link('My Work 1')
       end
+      expect(page).to have_content('My Work 1')
+      expect(page).to have_content("#{agent1.display_name}, blasting")
+      click_link('my collection')
+      within('div#members') do
+        click_link('My Work 2')
+      end
+      expect(page).to have_content('My Work 2')
+      expect(page).to have_content("#{agent2.display_name}, climbing")
+      click_link('my collection')
+      within('div#members') do
+        click_link('My Work 3')
+      end
+      expect(page).to have_content('My Work 3')
+      expect(page).to have_content(agent3.display_name.to_s)
 
       # Verify each work has a file set and a file
       Work::Submission.all.each do |work|

--- a/spec/cho/work/import/update_spec.rb
+++ b/spec/cho/work/import/update_spec.rb
@@ -105,10 +105,17 @@ RSpec.describe 'Preview of CSV Update', type: :feature do
 
       matrix.each_with_index do |row, i|
         next if i == 0
+
         row[2] = titles[i - 1]
         row[3] = MetadataFactory.fancy_title
         row[4] = Faker::Lorem.paragraph
-        row[6] = "#{agent.display_name}#{CsvParsing::SUBVALUE_SEPARATOR}cli"
+
+        row[6] = if i == 1
+                   agent.display_name.to_s
+                 else
+                   "#{agent.display_name}#{CsvParsing::SUBVALUE_SEPARATOR}cli"
+                 end
+
         row[8] = dates[i - 1]
       end
 
@@ -188,6 +195,8 @@ RSpec.describe 'Preview of CSV Update', type: :feature do
 
       # Verify metadata updates
       work = SolrDocument.find('work1')
+      expect(work['creator_tesim']).to contain_exactly(agent.display_name)
+      expect(work['creator_role_ssim']).to be_nil
       expect(work.file_sets.map(&:title).flatten).to match_array(titles.drop(1))
       expect(work.file_sets.map(&:created).flatten.uniq.compact).to contain_exactly('2019')
       expect(work.file_sets.map(&:creator).flatten.uniq.first).to eq(


### PR DESCRIPTION
## Description

Corrects a bug with creators that have no role specified in their csv file.

Connected to #736 