### PR TITLE
Remove file upload from work edit form

### DIFF
--- a/app/views/work/submissions/_form.html.erb
+++ b/app/views/work/submissions/_form.html.erb
@@ -5,10 +5,11 @@
   <%= form.hidden_field :work_type_id, value: work_form.work_type_id %>
   <%= form.hidden_field :optimistic_lock_token, multiple: true, value: work_form.optimistic_lock_token %>
 
-  <%= form.hidden_field :file, value: work_form.model.cached_file_data %>
-
-  <%= form.label :file, t('cho.form.file_selection') %>
-  <%= form.file_field :file %>
+  <% if form.object.new_record %>
+    <%= form.hidden_field :file, value: work_form.model.cached_file_data %>
+    <%= form.label :file, t('cho.form.file_selection') %>
+    <%= form.file_field :file %>
+  <% end %>
 
   <%= render 'errors', work: work_form if work_form.errors.any? %>
 

--- a/spec/cho/work/submissions/edit_spec.rb
+++ b/spec/cho/work/submissions/edit_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'Editing works', type: :feature do
       expect(page).to have_selector('h2', text: 'Work to edit')
       expect(page).to have_link('Show')
       expect(page).to have_field('Description', type: 'textarea', with: nil)
+      expect(page).not_to have_field('work_submission[file]')
       fill_in('work_submission[title]', with: 'Updated Work Title')
       fill_in('work_submission[description]', with: 'Updated description')
       click_button('Update Resource')

--- a/spec/views/work_submissions/edit.html.erb_spec.rb
+++ b/spec/views/work_submissions/edit.html.erb_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe 'work/submissions/edit', type: :view do
       assert_select 'textarea[name=?]', 'work_submission[description]'
       assert_select 'label[for=?]', "work_submission_#{specific_field}", text: display_label
       assert_select 'input[name=?]', "work_submission[#{specific_field}]"
-      assert_select 'label', 'File Selection'
+      assert_select 'label[for=?]', 'work_submission_file', false
     end
   end
 end


### PR DESCRIPTION

## Description

For works that have been batch imported and have file sets attached, there is no meaningful reason to be able to edit the file.

Connected to #845 

## Changes

* Remove file upload from work submissions form, if the resource has been persisted