### PR TITLE
Default SolrDocument#file_sets to preservation file sets

### DIFF
--- a/app/blacklight/solr_document.rb
+++ b/app/blacklight/solr_document.rb
@@ -40,7 +40,7 @@ class SolrDocument
 
   # @return [Array<Work::FileSet>]
   def file_sets
-    Array.wrap(self['member_ids_ssim']).map do |id|
+    Array.wrap(self['preservation_file_set_ids_ssim']).map do |id|
       Work::FileSet.find(Valkyrie::ID.new(id.sub(/^id-/, '')))
     end
   end

--- a/app/cho/work/submission.rb
+++ b/app/cho/work/submission.rb
@@ -42,6 +42,11 @@ module Work
       @file_sets ||= member_ids.map { |id| Work::FileSet.find(id) }
     end
 
+    def preservation_file_sets
+      return file_sets if file_sets.count == 1
+      file_sets.reject(&:representative?)
+    end
+
     def representative_file_set
       file_sets.select(&:representative?).first || file_sets.first || NullRepresentativeFileSet.new
     end

--- a/app/cho/work/submission_indexer.rb
+++ b/app/cho/work/submission_indexer.rb
@@ -13,7 +13,8 @@ module Work
       {
         work_type_ssim: label_for_id,
         member_of_collection_ssim: collection_labels_for_ids,
-        thumbnail_path_ss: thumbnail_path
+        thumbnail_path_ss: thumbnail_path,
+        preservation_file_set_ids_ssim: preservation_file_set_ids
       }
     end
 
@@ -51,6 +52,13 @@ module Work
         possible_thumbnails = resource.file_sets.select(&:thumbnail)
         return if possible_thumbnails.empty?
         possible_thumbnails.first.thumbnail
+      end
+
+      def preservation_file_set_ids
+        return unless resource.respond_to?(:preservation_file_sets)
+        resource.preservation_file_sets.map do |file_set|
+          "id-#{file_set.id}"
+        end
       end
   end
 end

--- a/spec/blacklight/solr_document_spec.rb
+++ b/spec/blacklight/solr_document_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe SolrDocument, type: :model do
     subject { solr_document.file_sets.first }
 
     let(:file_set) { create :file_set }
-    let(:document) { { 'internal_resource_tsim' => 'MyResource', member_ids_ssim: [file_set.id.to_s] } }
+    let(:document) { { 'internal_resource_tsim' => 'MyResource', preservation_file_set_ids_ssim: [file_set.id.to_s] } }
 
     its(:to_h) { is_expected.to include(title: ['Original File Name'],
                                         internal_resource: 'Work::FileSet',

--- a/spec/cho/work/import/update_spec.rb
+++ b/spec/cho/work/import/update_spec.rb
@@ -197,7 +197,9 @@ RSpec.describe 'Preview of CSV Update', type: :feature do
       work = SolrDocument.find('work1')
       expect(work['creator_tesim']).to contain_exactly(agent.display_name)
       expect(work['creator_role_ssim']).to be_nil
-      expect(work.file_sets.map(&:title).flatten).to match_array(titles.drop(1))
+      expect(work.file_sets.map(&:title).flatten).to contain_exactly(
+        'Page Four', 'Page One', 'Page Three', 'Page Two'
+      )
       expect(work.file_sets.map(&:created).flatten.uniq.compact).to contain_exactly('2019')
       expect(work.file_sets.map(&:creator).flatten.uniq.first).to eq(
         role: 'http://id.loc.gov/vocabulary/relators/cli', agent: agent.id.to_s

--- a/spec/cho/work/submissions/new_spec.rb
+++ b/spec/cho/work/submissions/new_spec.rb
@@ -183,12 +183,6 @@ RSpec.describe Work::Submission, type: :feature do
       expect(page).to have_content('work1_00001_02_preservation.tif')
       expect(page).to have_content('work1_00002_01_preservation.tif')
       expect(page).to have_content('work1_00002_02_preservation.tif')
-
-      # Check thumbnail display on the file set
-      click_link('work1_access.pdf')
-      expect(page).to have_selector('h1', text: 'work1_access.pdf')
-      expect(page).to have_xpath("//img[@src='/files/work1_thumb.jpg']")
-      expect(page).to have_xpath("//img[@alt='Work1 thumb']")
     end
   end
 
@@ -228,20 +222,12 @@ RSpec.describe Work::Submission, type: :feature do
       expect(page).to have_link('Edit')
       expect(page).to have_selector('h2', text: 'Parts')
       expect(page).to have_link('work1_00001_preservation.tif')
-      expect(page).to have_link('work1_access.pdf')
 
       # Check thumbnail display on the preservation file set
       click_link('work1_00001_preservation.tif')
       expect(page).to have_selector('h1', text: 'work1_00001_preservation.tif')
       expect(page).to have_xpath("//img[@src='/files/work1_00001_thumb.png']")
       expect(page).to have_xpath("//img[@alt='Work1 00001 thumb']")
-
-      # Thumbnail does not appear on the representative file set
-      click_link('Work and file sets with an alternate thumbnail')
-      click_link('work1_access.pdf')
-      expect(page).to have_selector('h1', text: 'work1_access.pdf')
-      expect(page).not_to have_xpath("//img[@src='/files/work1_00001_thumb.png']")
-      expect(page).not_to have_xpath("//img[@alt='Work1 00001 thumb']")
     end
   end
 end

--- a/spec/cho/work/submissions/submission_spec.rb
+++ b/spec/cho/work/submissions/submission_spec.rb
@@ -140,4 +140,27 @@ RSpec.describe Work::Submission do
       its(:representative_file_set) { is_expected.to be_a(Work::Submission::NullRepresentativeFileSet) }
     end
   end
+
+  describe '#preservation_file_sets' do
+    context 'with no file sets' do
+      let(:work) { build(:work) }
+
+      it { expect(work.preservation_file_sets).to be_empty }
+    end
+
+    context 'with a single file set' do
+      let(:work)     { create(:work, member_ids: [file_set.id]) }
+      let(:file_set) { create(:file_set) }
+
+      it { expect(work.preservation_file_sets.map(&:id)).to contain_exactly(file_set.id) }
+    end
+
+    context 'with multiple file sets' do
+      let(:work)           { create(:work, member_ids: [file_set.id, representative.id]) }
+      let(:file_set)       { create(:file_set, alternate_ids: ['alt-id']) }
+      let(:representative) { create(:file_set, alternate_ids: []) }
+
+      it { expect(work.preservation_file_sets.map(&:id)).to contain_exactly(file_set.id) }
+    end
+  end
 end

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -5,10 +5,14 @@
 require Rails.root.join('spec', 'support', 'seed_map')
 
 FactoryBot.define do
-  factory :file_set, class: Work::FileSet do
+  factory :file_set, aliases: [:representative_file_set], class: Work::FileSet do
     title { 'Original File Name' }
     transient do
       work { nil }
+    end
+
+    factory :preservation_file_set do
+      alternate_ids { [rand(1..1_000)] }
     end
 
     to_create do |resource, attributes|


### PR DESCRIPTION
## Description

Distinguishes between preservation file sets and representative file sets for the purposes of display in the work landing page.

Connected to #482 