### PR TITLE
Paragraph-heading transformation for acknowledgments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,3 +46,4 @@ Metrics/BlockLength:
 Rails/Presence:
   Exclude:
     - 'app/cho/indexing/creator.rb'
+    - 'app/blacklight/metadata_field_presenter.rb'

--- a/app/blacklight/catalog_controller.rb
+++ b/app/blacklight/catalog_controller.rb
@@ -57,8 +57,12 @@ class CatalogController < ApplicationController
       catalog_field = map_field.solr_search_field
       catalog_label = map_field.display_name || map_field.label.titleize
       catalog_helper = map_field.display_transformation == 'no_transformation' ? nil : map_field.display_transformation.to_sym
-      config.add_index_field catalog_field, label: catalog_label, helper_method: catalog_helper
-      config.add_show_field catalog_field, label: catalog_label, helper_method: catalog_helper
+
+      unless map_field.display_transformation == 'paragraph_heading'
+        config.add_index_field catalog_field, label: catalog_label, helper_method: catalog_helper
+        config.add_show_field catalog_field, label: catalog_label, helper_method: catalog_helper
+      end
+
       config.add_search_field(map_field.label) do |field|
         # solr_parameters hash are sent to Solr as ordinary url query params.
         field.solr_parameters = { 'spellcheck.dictionary': field.label,

--- a/app/blacklight/local_helper_behavior.rb
+++ b/app/blacklight/local_helper_behavior.rb
@@ -15,4 +15,9 @@ module LocalHelperBehavior
       doc['title_tesim'].first
     end
   end
+
+  # @note Avoids any NoMethodError problems when specifying a custom partial display transformation
+  def paragraph_heading(*args)
+    # noop
+  end
 end

--- a/app/blacklight/metadata_field_presenter.rb
+++ b/app/blacklight/metadata_field_presenter.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class MetadataFieldPresenter
+  attr_reader :field, :document
+
+  delegate :label, :display_transformation, to: :field
+
+  def initialize(field:, document:)
+    @field = field
+    @document = document
+  end
+
+  def content
+    @content ||= document.send(field.method_name)
+  end
+
+  delegate :present?, :blank?, to: :content
+
+  def paragraphs
+    return [] if blank?
+    content.join("\n").split(/\n+/)
+  end
+end

--- a/app/blacklight/solr_document.rb
+++ b/app/blacklight/solr_document.rb
@@ -101,4 +101,17 @@ class SolrDocument
                         work_type
                       end
   end
+
+  def metadata_fields
+    @metadata_fields ||= schema.field_ids.map do |field_id|
+      Schema::MetadataField.find(field_id)
+    end
+  end
+
+  def transformed_fields
+    @transformed_fields ||= begin
+      field_list = metadata_fields.reject { |field| field.display_transformation == 'no_transformation' }
+      field_list.map { |field| MetadataFieldPresenter.new(field: field, document: self) }
+    end
+  end
 end

--- a/app/cho/display_transformation/factory.rb
+++ b/app/cho/display_transformation/factory.rb
@@ -33,8 +33,11 @@ module DisplayTransformation
       private
 
         def default_items
-          { default_key => DisplayTransformation::None.new,
-            render_link_to_collection: DisplayTransformation::None.new }
+          {
+            default_key => DisplayTransformation::None.new,
+            render_link_to_collection: DisplayTransformation::None.new,
+            paragraph_heading: DisplayTransformation::None.new
+          }
         end
 
         def item_class

--- a/app/views/catalog/_show_collection_archival.html.erb
+++ b/app/views/catalog/_show_collection_archival.html.erb
@@ -1,3 +1,10 @@
+<% @document.transformed_fields.each do |field| %>
+  <% if field.present? %>
+    <%= render partial: "shared/transformation_partials/#{field.display_transformation}",
+               locals: { presenter: field } %>
+  <% end %>
+<% end %>
+
 <%= render partial: 'show', locals: { document: @document } %>
 
 <% unless @document_facade.members.empty? %>

--- a/app/views/catalog/_show_collection_curated.html.erb
+++ b/app/views/catalog/_show_collection_curated.html.erb
@@ -1,3 +1,10 @@
+<% @document.transformed_fields.each do |field| %>
+  <% if field.present? %>
+    <%= render partial: "shared/transformation_partials/#{field.display_transformation}",
+               locals: { presenter: field } %>
+  <% end %>
+<% end %>
+
 <%= render partial: 'show', locals: { document: @document } %>
 
 <% unless @document_facade.members.empty? %>

--- a/app/views/catalog/_show_collection_library.html.erb
+++ b/app/views/catalog/_show_collection_library.html.erb
@@ -1,3 +1,10 @@
+<% @document.transformed_fields.each do |field| %>
+  <% if field.present? %>
+    <%= render partial: "shared/transformation_partials/#{field.display_transformation}",
+               locals: { presenter: field } %>
+  <% end %>
+<% end %>
+
 <%= render partial: 'show', locals: { document: @document } %>
 
 <% unless @document_facade.members.empty? %>

--- a/app/views/shared/transformation_partials/_paragraph_heading.html.erb
+++ b/app/views/shared/transformation_partials/_paragraph_heading.html.erb
@@ -1,0 +1,5 @@
+<h2><%= presenter.label.titleize %></h2>
+
+<% presenter.paragraphs.each do |paragraph| %>
+  <p><%= paragraph %></p>
+<% end %>

--- a/config/data_dictionary/data_dictionary_development.csv
+++ b/config/data_dictionary/data_dictionary_development.csv
@@ -7,6 +7,7 @@ date_created,string,required_to_publish,no_validation,true,no_vocabulary,,Date C
 subject,string,optional,no_validation,true,no_vocabulary,,Subject,no_transformation,no_facet,help me,true
 location,string,optional,no_validation,true,no_vocabulary,,Location,no_transformation,no_facet,help me,true
 description,text,optional,no_validation,true,no_vocabulary,,Description,no_transformation,no_facet,help me,true
+acknowledgments,text,optional,no_validation,true,no_vocabulary,,,paragraph_heading,no_facet,help me,false
 genre,string,required_to_publish,no_validation,true,no_vocabulary,,Genre,no_transformation,no_facet,help me,true
 collection,string,required_to_publish,no_validation,true,no_vocabulary,,Collection,no_transformation,no_facet,help me,true
 repository,string,required_to_publish,no_validation,true,no_vocabulary,,Repository,no_transformation,no_facet,help me,true

--- a/config/data_dictionary/data_dictionary_production.csv
+++ b/config/data_dictionary/data_dictionary_production.csv
@@ -7,6 +7,7 @@ date_created,string,required_to_publish,no_validation,true,no_vocabulary,,Date C
 subject,string,optional,no_validation,true,no_vocabulary,,Subject,no_transformation,no_facet,help me,true
 location,string,optional,no_validation,true,no_vocabulary,,Location,no_transformation,no_facet,help me,true
 description,text,optional,no_validation,true,no_vocabulary,,Description,no_transformation,no_facet,help me,true
+acknowledgments,text,optional,no_validation,true,no_vocabulary,,,paragraph_heading,no_facet,help me,false
 genre,string,required_to_publish,no_validation,true,no_vocabulary,,Genre,no_transformation,no_facet,help me,true
 collection,string,required_to_publish,no_validation,true,no_vocabulary,,Collection,no_transformation,no_facet,help me,true
 repository,string,required_to_publish,no_validation,true,no_vocabulary,,Repository,no_transformation,no_facet,help me,true

--- a/config/data_dictionary/data_dictionary_test.csv
+++ b/config/data_dictionary/data_dictionary_test.csv
@@ -3,6 +3,7 @@ title,string,required,no_validation,true,no_vocabulary,,Object Title,no_transfor
 home_collection_id,valkyrie_id,optional,resource_exists,false,cho_collections,,Collection,render_link_to_collection,facet,help me,false
 subtitle,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,true
 description,text,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,true
+acknowledgments,text,optional,no_validation,true,no_vocabulary,,,paragraph_heading,no_facet,help me,false
 created,date,optional,edtf_date,true,no_vocabulary,,,no_transformation,date,help me,false
 generic_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,facet,help me,false
 document_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false

--- a/config/data_dictionary/schema_fields.yml
+++ b/config/data_dictionary/schema_fields.yml
@@ -1,6 +1,8 @@
 development: &development
   - schema: 'Collection'
-    fields: []
+    fields:
+      acknowledgments:
+        order_index: 1
     work_type: 'false'
   - schema: 'FileSet'
     fields: []
@@ -225,7 +227,9 @@ test:
         requirement_designation: 'required'
         order_index: 2
   - schema: 'Collection'
-    fields: []
+    fields:
+      acknowledgments:
+        order_index: 1
     work_type: 'false'
   - schema: 'FileSet'
     fields: []

--- a/spec/blacklight/metadata_field_presenter_spec.rb
+++ b/spec/blacklight/metadata_field_presenter_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MetadataFieldPresenter do
+  subject(:presenter) { described_class.new(field: field, document: document) }
+
+  let(:field) { build(:data_dictionary_field, label: 'acknowledgments') }
+  let(:value) { ['value'] }
+  let(:document) { SolrDocument.new('acknowledgments_tesim' => value) }
+
+  it { is_expected.to delegate_method(:present?).to(:content) }
+  it { is_expected.to delegate_method(:blank?).to(:content) }
+  it { is_expected.to delegate_method(:label).to(:field) }
+  it { is_expected.to delegate_method(:display_transformation).to(:field) }
+
+  describe '#content' do
+    its(:content) { is_expected.to contain_exactly('value') }
+  end
+
+  describe '#paragraphs' do
+    context 'when the field has no content' do
+      let(:value) { [] }
+
+      its(:paragraphs) { is_expected.to be_empty }
+    end
+
+    context 'when the field has multiple entries and multiple lines' do
+      let(:value) do
+        [
+          "This is the first paragraph.\nThis is the second.",
+          "This is the third paragraph.\nThis is the last."
+        ]
+      end
+
+      its(:paragraphs) do
+        is_expected.to contain_exactly(
+          'This is the first paragraph.',
+          'This is the second.',
+          'This is the third paragraph.',
+          'This is the last.'
+        )
+      end
+    end
+  end
+end

--- a/spec/blacklight/solr_document_spec.rb
+++ b/spec/blacklight/solr_document_spec.rb
@@ -84,8 +84,22 @@ RSpec.describe SolrDocument, type: :model do
     subject { solr_document.export_as_csv }
 
     let(:csv_header) do
-      'id,work_type,title,subtitle,description,alternate_ids,creator,audio_field,created,document_field,'\
-        'generic_field,home_collection_id,map_field,moving_image_field,still_image_field'
+      'id,' \
+      'work_type,' \
+      'title,' \
+      'subtitle,' \
+      'description,' \
+      'alternate_ids,' \
+      'creator,' \
+      'acknowledgments,' \
+      'audio_field,' \
+      'created,' \
+      'document_field,' \
+      'generic_field,' \
+      'home_collection_id,' \
+      'map_field,' \
+      'moving_image_field,' \
+      'still_image_field'
     end
 
     let(:document) do
@@ -98,16 +112,16 @@ RSpec.describe SolrDocument, type: :model do
       }
     end
 
-    it { is_expected.to eq("#{csv_header}\nabc123,,my_title,,,,,,,,value1||value2,xyx789,,,\n") }
+    it { is_expected.to eq("#{csv_header}\nabc123,,my_title,,,,,,,,,value1||value2,xyx789,,,\n") }
 
     context 'with a collection containing works and file sets' do
       let(:collection) { create :library_collection }
       let(:work) { create :work, :with_file, home_collection_id: [collection.id], title: 'Work One' }
-      let(:work1_csv) { "#{work.id},Generic,Work One,,,,,,,,,#{collection.id},,," }
-      let(:file_set1_csv) { "#{work.member_ids.first},,hello_world.txt,,,,,,,,,,,," }
+      let(:work1_csv) { "#{work.id},Generic,Work One,,,,,,,,,,#{collection.id},,," }
+      let(:file_set1_csv) { "#{work.member_ids.first},,hello_world.txt,,,,,,,,,,,,," }
       let(:work2) { create :work, :with_file, home_collection_id: [collection.id], title: 'Work Two' }
-      let(:work2_csv) { "#{work2.id},Generic,Work Two,,,,,,,,,#{collection.id},,," }
-      let(:file_set2_csv) { "#{work2.member_ids.first},,hello_world.txt,,,,,,,,,,,," }
+      let(:work2_csv) { "#{work2.id},Generic,Work Two,,,,,,,,,,#{collection.id},,," }
+      let(:file_set2_csv) { "#{work2.member_ids.first},,hello_world.txt,,,,,,,,,,,,," }
 
       let(:document) do
         { 'internal_resource_tsim' => 'MyCollection', id: collection.id, title_tesim: ['my_collection'] }
@@ -139,8 +153,8 @@ RSpec.describe SolrDocument, type: :model do
       end
 
       let(:file_set) { create(:file_set) }
-      let(:work_csv) { 'abc123,,my_title,,,,,,,,value1||value2,xyx789,,,' }
-      let(:file_set_csv) { "#{file_set.id},,Original File Name,,,,,,,,,,,," }
+      let(:work_csv) { 'abc123,,my_title,,,,,,,,,value1||value2,xyx789,,,' }
+      let(:file_set_csv) { "#{file_set.id},,Original File Name,,,,,,,,,,,,," }
 
       before { file_set }
 

--- a/spec/cho/collection/archival_collections/new_spec.rb
+++ b/spec/cho/collection/archival_collections/new_spec.rb
@@ -31,4 +31,34 @@ RSpec.describe Collection::Archival, type: :feature do
       expect(page).to have_content('Alternate ids existing-id already exists')
     end
   end
+
+  context 'when filling in all the collection metadata' do
+    let!(:agent) { create(:agent, :generate_name) }
+    let(:title) { Faker::Company.name }
+    let(:subtitle) { Faker::Hipster.sentence }
+    let(:description) { Faker::Hipster.sentence }
+    let(:identifier) { Faker::Number.leading_zero_number(10) }
+    let(:acknowledgments) { Faker::Lorem.paragraph }
+
+    it 'creates a new archival collection' do
+      visit(new_archival_collection_path)
+      fill_in('archival_collection[title]', with: title)
+      fill_in('archival_collection[subtitle]', with: subtitle)
+      fill_in('archival_collection[description]', with: description)
+      fill_in('archival_collection[alternate_ids]', with: identifier)
+      fill_in('archival_collection[acknowledgments]', with: acknowledgments)
+      select(agent, from: 'archival_collection[creator][agent]')
+      select('blasting', from: 'archival_collection[creator][role]')
+      choose('Mediated')
+      choose('PSU Access')
+      click_button('Create Archival collection')
+      expect(page).to have_content(title)
+      expect(page).to have_content(subtitle)
+      expect(page).to have_content(description)
+      expect(page).to have_content(identifier)
+      expect(page).to have_content("#{agent.display_name}, blasting")
+      expect(page).to have_selector('h2', text: 'Acknowledgments')
+      expect(page).to have_content(acknowledgments)
+    end
+  end
 end

--- a/spec/cho/collection/change_set_behaviors_spec.rb
+++ b/spec/cho/collection/change_set_behaviors_spec.rb
@@ -85,7 +85,8 @@ RSpec.describe Collection::ChangeSetBehaviors do
         'description',
         'title',
         'alternate_ids',
-        'creator'
+        'creator',
+        'acknowledgments'
       )
     end
   end
@@ -99,7 +100,8 @@ RSpec.describe Collection::ChangeSetBehaviors do
         'description',
         'title',
         'alternate_ids',
-        'creator'
+        'creator',
+        'acknowledgments'
       )
     end
   end

--- a/spec/cho/collection/curated_collections/new_spec.rb
+++ b/spec/cho/collection/curated_collections/new_spec.rb
@@ -31,4 +31,34 @@ RSpec.describe Collection::Curated, type: :feature do
       expect(page).to have_content('Alternate ids existing-id already exists')
     end
   end
+
+  context 'when filling in all the collection metadata' do
+    let!(:agent) { create(:agent, :generate_name) }
+    let(:title) { Faker::Company.name }
+    let(:subtitle) { Faker::Hipster.sentence }
+    let(:description) { Faker::Hipster.sentence }
+    let(:identifier) { Faker::Number.leading_zero_number(10) }
+    let(:acknowledgments) { Faker::Lorem.paragraph }
+
+    it 'creates a new curated collection' do
+      visit(new_curated_collection_path)
+      fill_in('curated_collection[title]', with: title)
+      fill_in('curated_collection[subtitle]', with: subtitle)
+      fill_in('curated_collection[description]', with: description)
+      fill_in('curated_collection[alternate_ids]', with: identifier)
+      fill_in('curated_collection[acknowledgments]', with: acknowledgments)
+      select(agent, from: 'curated_collection[creator][agent]')
+      select('blasting', from: 'curated_collection[creator][role]')
+      choose('Mediated')
+      choose('PSU Access')
+      click_button('Create Curated collection')
+      expect(page).to have_content(title)
+      expect(page).to have_content(subtitle)
+      expect(page).to have_content(description)
+      expect(page).to have_content(identifier)
+      expect(page).to have_content("#{agent.display_name}, blasting")
+      expect(page).to have_selector('h2', text: 'Acknowledgments')
+      expect(page).to have_content(acknowledgments)
+    end
+  end
 end

--- a/spec/cho/collection/library_collections/new_spec.rb
+++ b/spec/cho/collection/library_collections/new_spec.rb
@@ -31,4 +31,34 @@ RSpec.describe Collection::Library, type: :feature do
       expect(page).to have_content('Alternate ids existing-id already exists')
     end
   end
+
+  context 'when filling in all the collection metadata' do
+    let!(:agent) { create(:agent, :generate_name) }
+    let(:title) { Faker::Company.name }
+    let(:subtitle) { Faker::Hipster.sentence }
+    let(:description) { Faker::Hipster.sentence }
+    let(:identifier) { Faker::Number.leading_zero_number(10) }
+    let(:acknowledgments) { Faker::Lorem.paragraph }
+
+    it 'creates a new library collection' do
+      visit(new_library_collection_path)
+      fill_in('library_collection[title]', with: title)
+      fill_in('library_collection[subtitle]', with: subtitle)
+      fill_in('library_collection[description]', with: description)
+      fill_in('library_collection[alternate_ids]', with: identifier)
+      fill_in('library_collection[acknowledgments]', with: acknowledgments)
+      select(agent, from: 'library_collection[creator][agent]')
+      select('blasting', from: 'library_collection[creator][role]')
+      choose('Mediated')
+      choose('PSU Access')
+      click_button('Create Library collection')
+      expect(page).to have_content(title)
+      expect(page).to have_content(subtitle)
+      expect(page).to have_content(description)
+      expect(page).to have_content(identifier)
+      expect(page).to have_content("#{agent.display_name}, blasting")
+      expect(page).to have_selector('h2', text: 'Acknowledgments')
+      expect(page).to have_content(acknowledgments)
+    end
+  end
 end

--- a/spec/cho/display_transformation/factory_spec.rb
+++ b/spec/cho/display_transformation/factory_spec.rb
@@ -46,12 +46,12 @@ RSpec.describe DisplayTransformation::Factory, type: :model do
       described_class.transformations = transformations
     end
 
-    it { is_expected.to eq([:no_transformation, :render_link_to_collection]) }
+    it { is_expected.to eq([:no_transformation, :render_link_to_collection, :paragraph_heading]) }
 
     context 'valid transformations set' do
       let(:transformations) { { abc: MyTransformation.new, other: OtherTransformation.new } }
 
-      it { is_expected.to eq([:abc, :other, :no_transformation, :render_link_to_collection]) }
+      it { is_expected.to eq([:abc, :other, :no_transformation, :render_link_to_collection, :paragraph_heading]) }
     end
   end
 

--- a/spec/cho/schema/configuration_spec.rb
+++ b/spec/cho/schema/configuration_spec.rb
@@ -49,7 +49,11 @@ RSpec.describe Schema::Configuration, type: :model do
             'audio_field' => { 'order_index' => 1 }
           }
         },
-        { 'schema' => 'Collection', 'fields' => [], 'work_type' => 'false' },
+        {
+          'schema' => 'Collection',
+          'fields' => { 'acknowledgments' => { 'order_index' => 1 } },
+          'work_type' => 'false'
+        },
         { 'schema' => 'FileSet', 'fields' => [], 'work_type' => 'false' }
       ]
     )

--- a/spec/cho/work/import/update_spec.rb
+++ b/spec/cho/work/import/update_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe 'Preview of CSV Update', type: :feature do
                    "#{agent.display_name}#{CsvParsing::SUBVALUE_SEPARATOR}cli"
                  end
 
-        row[8] = dates[i - 1]
+        row[9] = dates[i - 1]
       end
 
       Tempfile.open do |csv_file|
@@ -133,7 +133,7 @@ RSpec.describe 'Preview of CSV Update', type: :feature do
         next if i == 0
         row[2] = missing_titles[i - 1]
         row[6] = [nil, nil, nil, nil, 'Dude, Bad Agent', nil][i - 1]
-        row[8] = bad_dates[i - 1]
+        row[9] = bad_dates[i - 1]
       end
 
       Tempfile.open do |csv_file|


### PR DESCRIPTION
## Description

Creates a new kind of transformation that displays a property as a separate paragraph with a heading. This is used in conjunction with a new acknowledgments property that is available to collections.

Connected to #572 

## Changes

* add heading transformation
* acknowledgments property to collections
* MetadataFieldPresenter for displaying contents of field as separate paragraphs
