### PR TITLE
Buttons download representative work & plain text

### DIFF
--- a/app/blacklight/solr_document.rb
+++ b/app/blacklight/solr_document.rb
@@ -45,6 +45,12 @@ class SolrDocument
     end
   end
 
+  # @ return Work::File or nil
+  def representative_file_set
+    return unless id = self['representative_file_set_id_ss'].presence
+    Work::FileSet.find(Valkyrie::ID.new(id.sub(/^id-/, '')))
+  end
+
   def member_ids
     Array.wrap(self['member_ids_ssim'])
   end

--- a/app/cho/work/submission.rb
+++ b/app/cho/work/submission.rb
@@ -60,6 +60,10 @@ module Work
       def thumbnail
         @thumbnail ||= Thumbnail.new(nil)
       end
+
+      def id
+        nil
+      end
     end
   end
 end

--- a/app/cho/work/submission_indexer.rb
+++ b/app/cho/work/submission_indexer.rb
@@ -14,7 +14,8 @@ module Work
         work_type_ssim: label_for_id,
         member_of_collection_ssim: collection_labels_for_ids,
         thumbnail_path_ss: thumbnail_path,
-        preservation_file_set_ids_ssim: preservation_file_set_ids
+        preservation_file_set_ids_ssim: preservation_file_set_ids,
+        representative_file_set_id_ss: representative_file_set_id
       }
     end
 
@@ -59,6 +60,12 @@ module Work
         resource.preservation_file_sets.map do |file_set|
           "id-#{file_set.id}"
         end
+      end
+
+      def representative_file_set_id
+        return unless resource.respond_to?(:representative_file_set)
+        return if resource.representative_file_set.id.blank?
+        "id-#{resource.representative_file_set.id}"
       end
   end
 end

--- a/app/views/catalog/_download_representatives.html.erb
+++ b/app/views/catalog/_download_representatives.html.erb
@@ -1,6 +1,6 @@
 <% if fs = document.representative_file_set %>
 
-  <div class="btn-group-vertical">
+  <div class="btn-group pb-4">
     <% if access_file = fs.files.find(&:access?) %>
       <%= link_to t('cho.work.show.download_representative_link'),
                   download_path(fs.id, use_type: access_file.use.first.fragment),

--- a/app/views/catalog/_download_representatives.html.erb
+++ b/app/views/catalog/_download_representatives.html.erb
@@ -1,0 +1,19 @@
+<% if fs = document.representative_file_set %>
+
+  <div class="btn-group-vertical">
+    <% if access_file = fs.files.find(&:access?) %>
+      <%= link_to t('cho.work.show.download_representative_link'),
+                  download_path(fs.id, use_type: access_file.use.first.fragment),
+                  class: 'btn btn-outline-secondary',
+                  data: { turbolinks: false } %>
+    <% end %>
+
+    <% if text_file = fs.files.find(&:text?) %>
+      <%= link_to t('cho.work.show.download_text_link'),
+                  download_path(fs.id, use_type: text_file.use.first.fragment),
+                  class: 'btn btn-outline-secondary',
+                  data: { turbolinks: false } %>
+    <% end %>
+  </div>
+
+<% end %>

--- a/app/views/catalog/_show_header.html.erb
+++ b/app/views/catalog/_show_header.html.erb
@@ -1,0 +1,3 @@
+<%# bookmark/folder functions -%>
+<%= render_document_heading(document, tag: :h1) %>
+<%= render 'download_representatives', document: document %>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -13,14 +13,12 @@
     <% if presenter(@document).thumbnail.exists? %>
       <div class="col-xs-12 col-md-4">
         <%= render 'thumbnail', document: @document, document_counter: 0 %>
-        <%= render 'download_representatives', document: @document %>
       </div>
       <div class="col-xs-12 col-md-8">
         <%= render_document_main_content_partial %>
       </div>
     <% else %>
       <div class="col-xs-12">
-        <%= render 'download_representatives', document: @document %>
         <%= render_document_main_content_partial %>
       </div>
     <% end %>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -13,12 +13,14 @@
     <% if presenter(@document).thumbnail.exists? %>
       <div class="col-xs-12 col-md-4">
         <%= render 'thumbnail', document: @document, document_counter: 0 %>
+        <%= render 'download_representatives', document: @document %>
       </div>
       <div class="col-xs-12 col-md-8">
         <%= render_document_main_content_partial %>
       </div>
     <% else %>
       <div class="col-xs-12">
+        <%= render 'download_representatives', document: @document %>
         <%= render_document_main_content_partial %>
       </div>
     <% end %>

--- a/config/locales/cho.yml
+++ b/config/locales/cho.yml
@@ -60,6 +60,8 @@ en:
       missing: "Missing"
       show:
         files_heading: "Parts"
+        download_representative_link: 'Download Work'
+        download_text_link: 'Download Plain Text'
     collection:
       members:
         title: "Title"

--- a/spec/blacklight/solr_document_spec.rb
+++ b/spec/blacklight/solr_document_spec.rb
@@ -32,6 +32,23 @@ RSpec.describe SolrDocument, type: :model do
                                         id: Valkyrie::ID.new(file_set.id)) }
   end
 
+  describe '#representative_file_set' do
+    subject { solr_document.representative_file_set }
+
+    let(:file_set) { create :file_set }
+    let(:document) { { 'internal_resource_tsim' => 'MyResource', representative_file_set_id_ss: file_set.id.to_s } }
+
+    its(:to_h) { is_expected.to include(title: ['Original File Name'],
+                                        internal_resource: 'Work::FileSet',
+                                        id: Valkyrie::ID.new(file_set.id)) }
+
+    context 'when representative_file_set_id_ss is nil' do
+      let(:document) { { 'internal_resource_tsim' => 'MyResource', representative_file_set_id_ss: nil } }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   describe '#member_of_collections' do
     subject { solr_document.member_of_collections.first }
 

--- a/spec/cho/work/submissions/show_spec.rb
+++ b/spec/cho/work/submissions/show_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Work::Submission, type: :feature do
   end
 
   context 'when the work has a file' do
-    let(:work) { create(:work, :with_file, title: 'An editable file', work_type_id: work_type.id) }
+    let(:work) { create(:work, :with_representative_file_set, title: 'An editable file', work_type_id: work_type.id) }
 
     it 'displays metadata and files' do
       visit(polymorphic_path([:solr_document], id: work.id))
@@ -39,6 +39,10 @@ RSpec.describe Work::Submission, type: :feature do
         expect(page).to have_blacklight_label('work_type_ssim').with('Resource Type')
         expect(page).to have_blacklight_field('work_type_ssim').with('Document')
       end
+      expect(page).to have_link(
+        'Download Work',
+        href: download_path(work.representative_file_set.id, use_type: Vocab::FileUse.AccessFile.fragment)
+      )
       expect(page).to have_selector('h2', text: 'Parts')
       expect(page).to have_content('hello_world.txt')
       click_link('Edit')

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -53,6 +53,18 @@ FactoryBot.define do
     end
   end
 
+  trait :with_representative_file_set do
+    transient do
+      filename { 'hello_world.txt' }
+    end
+
+    to_create do |resource, evaluator|
+      saved_resource = Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: resource)
+      FactoryBot.create(:file_set, :with_access_file, work: saved_resource, title: evaluator.filename)
+      saved_resource
+    end
+  end
+
   trait :with_creator do
     creator do
       if @build_strategy.is_a? FactoryBot::Strategy::Build


### PR DESCRIPTION
## Description

On the Work landing page, add dedicated buttons to download the representative access file and the full plain text. If the work has a thumbnail, these buttons are added in the left column just below the thumbnail; if the work has no thumbnail, there is no left column so the buttons are added above the work's title. The styles need a little love... it would be great if we could do a little flexbox magic and lay the buttons out vertically if there's a thumbnail, and horizontally if not. @mtribone, perhaps you and I could pair on that while @awead is out tomorrow (Thursday).

_Please note,_ this functionality works through a new field in the solr document, so you will need to rebuild your solr index to see it.

Connected to #482 

## Changes

* Index representative file set id in solr
* Add new partial for the download buttons.
* Hack in some new factory traits to make this testable... Adam and I would like to refactor the factories to make this cleaner at some point