### PR TITLE
Show a fileset's files as a table with type, size

### DIFF
--- a/app/cho/work/file.rb
+++ b/app/cho/work/file.rb
@@ -20,6 +20,12 @@ class Work::File < Valkyrie::Resource
     file_identifier.id.gsub('disk://', '')
   end
 
+  # @todo I reckon this should be stored in Valkyrie on import rather than
+  #       hitting the disk every time
+  def size
+    File.exist?(path.to_s) ? File.size(path) : 0
+  end
+
   # @todo Update to use FITS data when available.
   def mime_type
     MIME::Types.type_for(path)

--- a/app/views/catalog/_show_work_fileset.html.erb
+++ b/app/views/catalog/_show_work_fileset.html.erb
@@ -5,7 +5,7 @@
 <%# write method to grab the files from the file set %>
 <% unless @document.files.empty? %>
   <h2>Files</h2>
-  <table>
+  <table class="table table-striped">
     <thead>
       <tr>
         <th scope="col">Type</th>
@@ -17,7 +17,7 @@
     <%- @document.files.each do |file| %>
       <tr>
         <td><%= file.mime_type.first.friendly || file.mime_type.first.extensions.first %></td>
-        <td><%= number_to_human_size file.size %></td>
+        <td class="text-nowrap"><%= number_to_human_size file.size %></td>
         <td>
           <%= link_to file.original_filename,
                       download_path(@document.id, use_type: file.use.first.fragment),

--- a/app/views/catalog/_show_work_fileset.html.erb
+++ b/app/views/catalog/_show_work_fileset.html.erb
@@ -5,14 +5,27 @@
 <%# write method to grab the files from the file set %>
 <% unless @document.files.empty? %>
   <h2>Files</h2>
-  <ul>
+  <table>
+    <thead>
+      <tr>
+        <th scope="col">Type</th>
+        <th scope="col">Size</th>
+        <th scope="col">File</th>
+      </tr>
+    </thead>
+    <tbody>
     <%- @document.files.each do |file| %>
-      <li>
-        <%= link_to file.original_filename,
-                    download_path(@document.id, use_type: file.use.first.fragment),
-                    data: { turbolinks: false },
-                    aria: { label: t('cho.file_set.download.aria_label', name: file.original_filename) } %>
-      </li>
+      <tr>
+        <td><%= file.mime_type.first.friendly || file.mime_type.first.extensions.first %></td>
+        <td><%= number_to_human_size file.size %></td>
+        <td>
+          <%= link_to file.original_filename,
+                      download_path(@document.id, use_type: file.use.first.fragment),
+                      data: { turbolinks: false },
+                      aria: { label: t('cho.file_set.download.aria_label', name: file.original_filename) } %>
+        </td>
+      </tr>
     <%- end %>
-  </ul>
+    </tbody>
+  </table>
 <% end %>

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
+
+# jp2 does not have a friendly name. I'm not sure if this is the best place to
+# provide that, but it seems better than nothing.
+#
+# Also note that `Mime` and `MIME` are different constants, one provided by
+# Rails and the other provided by the mime-types gem.
+require 'mime-types'
+MIME::Types.of('jp2').each do |t|
+  t.friendly 'en' => 'JPEG 2000 Image'
+end

--- a/spec/cho/work/file_set/delete_spec.rb
+++ b/spec/cho/work/file_set/delete_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Deleting file sets', type: :feature do
   it "removes the file set and file from the system and updates the work's membership" do
     visit(polymorphic_path([:solr_document], id: Work::Submission.all.first.id))
     click_link('File Set to Delete')
-    expect(page).to have_selector('li', text: 'hello_world.txt')
+    expect(page).to have_selector('td', text: 'hello_world.txt')
     click_link('Edit')
     click_button('Delete File Set')
     expect(page).to have_content('The following resources will be deleted')

--- a/spec/cho/work/file_spec.rb
+++ b/spec/cho/work/file_spec.rb
@@ -41,4 +41,21 @@ RSpec.describe Work::File do
       its(:path) { is_expected.to eq(Metrics::Repository.storage_directory.join('My File.txt').to_s) }
     end
   end
+
+  describe '#size' do
+    subject { file.size }
+
+    context 'when no file is present' do
+      it { is_expected.to eq 0 }
+    end
+
+    context 'with a file' do
+      before do
+        file.file_identifier = binary_content.id
+        allow(File).to receive(:size).with(file.path).and_return(:the_file_size_from_disk)
+      end
+
+      it { is_expected.to eq :the_file_size_from_disk }
+    end
+  end
 end


### PR DESCRIPTION
## Description

On the File Set landing page, replace the list of file downloads with a table, which shows the filename (which itself is a link to download the file) along with the file size and the file type of each available file

Please be aware that the file size is not stored anywhere in a File's metadata at the moment, which means that we have to hit the disk for every file in this list on every page view. This could have scaling issues down the road, for instance if the files are stored in a cloud service, or just not on the same machine as the web server. I would like to see the file size stored in the database but we are splitting that out into a separate ticket.

Mike and I are going to be pairing on some UI stuff tomorrow so I'm hoping we'll take a look through this one as well.

Connected to #796 

## Changes

* Add method to read file size off disk
* Add a "friendly" string to the image/jp2 mime type
* Display the above in a table along with the file name