### PR TITLE
Paragraph transformation for curator’s textual narrative

### DIFF
--- a/app/blacklight/catalog_controller.rb
+++ b/app/blacklight/catalog_controller.rb
@@ -53,12 +53,17 @@ class CatalogController < ApplicationController
     # @todo configuration of linked field indexing
     config.add_facet_field 'creator_role_ssim', label: I18n.t('cho.field_label.role')
 
+    fields_excluded_from_metadata_list = %w[
+      acknowledgments
+      narrative
+    ]
+
     DataDictionary::Field.all.sort_by(&:created_at).each do |map_field|
       catalog_field = map_field.solr_search_field
       catalog_label = map_field.display_name || map_field.label.titleize
       catalog_helper = map_field.display_transformation == 'no_transformation' ? nil : map_field.display_transformation.to_sym
 
-      unless map_field.display_transformation == 'paragraph_heading'
+      unless fields_excluded_from_metadata_list.include?(map_field.label)
         config.add_index_field catalog_field, label: catalog_label, helper_method: catalog_helper
         config.add_show_field catalog_field, label: catalog_label, helper_method: catalog_helper
       end

--- a/app/blacklight/local_helper_behavior.rb
+++ b/app/blacklight/local_helper_behavior.rb
@@ -20,4 +20,9 @@ module LocalHelperBehavior
   def paragraph_heading(*args)
     # noop
   end
+
+  # @note Avoids any NoMethodError problems when specifying a custom partial display transformation
+  def paragraph(*args)
+    # noop
+  end
 end

--- a/app/blacklight/solr_document.rb
+++ b/app/blacklight/solr_document.rb
@@ -103,9 +103,9 @@ class SolrDocument
   end
 
   def metadata_fields
-    @metadata_fields ||= schema.field_ids.map do |field_id|
-      Schema::MetadataField.find(field_id)
-    end
+    @metadata_fields ||= schema.field_ids
+      .map { |field_id| Schema::MetadataField.find(field_id) }
+      .sort_by(&:order_index)
   end
 
   def transformed_fields

--- a/app/cho/display_transformation/factory.rb
+++ b/app/cho/display_transformation/factory.rb
@@ -36,7 +36,8 @@ module DisplayTransformation
           {
             default_key => DisplayTransformation::None.new,
             render_link_to_collection: DisplayTransformation::None.new,
-            paragraph_heading: DisplayTransformation::None.new
+            paragraph_heading: DisplayTransformation::None.new,
+            paragraph: DisplayTransformation::None.new
           }
         end
 

--- a/app/views/shared/transformation_partials/_paragraph.html.erb
+++ b/app/views/shared/transformation_partials/_paragraph.html.erb
@@ -1,0 +1,3 @@
+<% presenter.paragraphs.each do |paragraph| %>
+  <p><%= paragraph %></p>
+<% end %>

--- a/config/data_dictionary/data_dictionary_development.csv
+++ b/config/data_dictionary/data_dictionary_development.csv
@@ -8,6 +8,7 @@ subject,string,optional,no_validation,true,no_vocabulary,,Subject,no_transformat
 location,string,optional,no_validation,true,no_vocabulary,,Location,no_transformation,no_facet,help me,true
 description,text,optional,no_validation,true,no_vocabulary,,Description,no_transformation,no_facet,help me,true
 acknowledgments,text,optional,no_validation,true,no_vocabulary,,,paragraph_heading,no_facet,help me,false
+narrative,text,optional,no_validation,true,no_vocabulary,,Narrative,paragraph,no_facet,help me,false
 genre,string,required_to_publish,no_validation,true,no_vocabulary,,Genre,no_transformation,no_facet,help me,true
 collection,string,required_to_publish,no_validation,true,no_vocabulary,,Collection,no_transformation,no_facet,help me,true
 repository,string,required_to_publish,no_validation,true,no_vocabulary,,Repository,no_transformation,no_facet,help me,true

--- a/config/data_dictionary/data_dictionary_production.csv
+++ b/config/data_dictionary/data_dictionary_production.csv
@@ -8,6 +8,7 @@ subject,string,optional,no_validation,true,no_vocabulary,,Subject,no_transformat
 location,string,optional,no_validation,true,no_vocabulary,,Location,no_transformation,no_facet,help me,true
 description,text,optional,no_validation,true,no_vocabulary,,Description,no_transformation,no_facet,help me,true
 acknowledgments,text,optional,no_validation,true,no_vocabulary,,,paragraph_heading,no_facet,help me,false
+narrative,text,optional,no_validation,true,no_vocabulary,,Narrative,paragraph,no_facet,help me,false
 genre,string,required_to_publish,no_validation,true,no_vocabulary,,Genre,no_transformation,no_facet,help me,true
 collection,string,required_to_publish,no_validation,true,no_vocabulary,,Collection,no_transformation,no_facet,help me,true
 repository,string,required_to_publish,no_validation,true,no_vocabulary,,Repository,no_transformation,no_facet,help me,true

--- a/config/data_dictionary/data_dictionary_test.csv
+++ b/config/data_dictionary/data_dictionary_test.csv
@@ -4,6 +4,7 @@ home_collection_id,valkyrie_id,optional,resource_exists,false,cho_collections,,C
 subtitle,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,true
 description,text,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,true
 acknowledgments,text,optional,no_validation,true,no_vocabulary,,,paragraph_heading,no_facet,help me,false
+narrative,text,optional,no_validation,true,no_vocabulary,,Narrative,paragraph,no_facet,help me,false
 created,date,optional,edtf_date,true,no_vocabulary,,,no_transformation,date,help me,false
 generic_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,facet,help me,false
 document_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false

--- a/config/data_dictionary/schema_fields.yml
+++ b/config/data_dictionary/schema_fields.yml
@@ -2,6 +2,8 @@ development: &development
   - schema: 'Collection'
     fields:
       acknowledgments:
+        order_index: 2
+      narrative:
         order_index: 1
     work_type: 'false'
   - schema: 'FileSet'
@@ -229,6 +231,8 @@ test:
   - schema: 'Collection'
     fields:
       acknowledgments:
+        order_index: 2
+      narrative:
         order_index: 1
     work_type: 'false'
   - schema: 'FileSet'

--- a/spec/blacklight/solr_document_spec.rb
+++ b/spec/blacklight/solr_document_spec.rb
@@ -99,6 +99,7 @@ RSpec.describe SolrDocument, type: :model do
       'home_collection_id,' \
       'map_field,' \
       'moving_image_field,' \
+      'narrative,' \
       'still_image_field'
     end
 
@@ -112,16 +113,16 @@ RSpec.describe SolrDocument, type: :model do
       }
     end
 
-    it { is_expected.to eq("#{csv_header}\nabc123,,my_title,,,,,,,,,value1||value2,xyx789,,,\n") }
+    it { is_expected.to eq("#{csv_header}\nabc123,,my_title,,,,,,,,,value1||value2,xyx789,,,,\n") }
 
     context 'with a collection containing works and file sets' do
       let(:collection) { create :library_collection }
       let(:work) { create :work, :with_file, home_collection_id: [collection.id], title: 'Work One' }
-      let(:work1_csv) { "#{work.id},Generic,Work One,,,,,,,,,,#{collection.id},,," }
-      let(:file_set1_csv) { "#{work.member_ids.first},,hello_world.txt,,,,,,,,,,,,," }
+      let(:work1_csv) { "#{work.id},Generic,Work One,,,,,,,,,,#{collection.id},,,," }
+      let(:file_set1_csv) { "#{work.member_ids.first},,hello_world.txt,,,,,,,,,,,,,," }
       let(:work2) { create :work, :with_file, home_collection_id: [collection.id], title: 'Work Two' }
-      let(:work2_csv) { "#{work2.id},Generic,Work Two,,,,,,,,,,#{collection.id},,," }
-      let(:file_set2_csv) { "#{work2.member_ids.first},,hello_world.txt,,,,,,,,,,,,," }
+      let(:work2_csv) { "#{work2.id},Generic,Work Two,,,,,,,,,,#{collection.id},,,," }
+      let(:file_set2_csv) { "#{work2.member_ids.first},,hello_world.txt,,,,,,,,,,,,,," }
 
       let(:document) do
         { 'internal_resource_tsim' => 'MyCollection', id: collection.id, title_tesim: ['my_collection'] }
@@ -153,8 +154,8 @@ RSpec.describe SolrDocument, type: :model do
       end
 
       let(:file_set) { create(:file_set) }
-      let(:work_csv) { 'abc123,,my_title,,,,,,,,,value1||value2,xyx789,,,' }
-      let(:file_set_csv) { "#{file_set.id},,Original File Name,,,,,,,,,,,,," }
+      let(:work_csv) { 'abc123,,my_title,,,,,,,,,value1||value2,xyx789,,,,' }
+      let(:file_set_csv) { "#{file_set.id},,Original File Name,,,,,,,,,,,,,," }
 
       before { file_set }
 

--- a/spec/cho/collection/archival_collections/new_spec.rb
+++ b/spec/cho/collection/archival_collections/new_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Collection::Archival, type: :feature do
     let(:description) { Faker::Hipster.sentence }
     let(:identifier) { Faker::Number.leading_zero_number(10) }
     let(:acknowledgments) { Faker::Lorem.paragraph }
+    let(:narrative) { Faker::Lorem.paragraph }
 
     it 'creates a new archival collection' do
       visit(new_archival_collection_path)
@@ -47,6 +48,7 @@ RSpec.describe Collection::Archival, type: :feature do
       fill_in('archival_collection[description]', with: description)
       fill_in('archival_collection[alternate_ids]', with: identifier)
       fill_in('archival_collection[acknowledgments]', with: acknowledgments)
+      fill_in('archival_collection[narrative]', with: narrative)
       select(agent, from: 'archival_collection[creator][agent]')
       select('blasting', from: 'archival_collection[creator][role]')
       choose('Mediated')
@@ -59,6 +61,7 @@ RSpec.describe Collection::Archival, type: :feature do
       expect(page).to have_content("#{agent.display_name}, blasting")
       expect(page).to have_selector('h2', text: 'Acknowledgments')
       expect(page).to have_content(acknowledgments)
+      expect(page).to have_content(narrative)
     end
   end
 end

--- a/spec/cho/collection/change_set_behaviors_spec.rb
+++ b/spec/cho/collection/change_set_behaviors_spec.rb
@@ -86,7 +86,8 @@ RSpec.describe Collection::ChangeSetBehaviors do
         'title',
         'alternate_ids',
         'creator',
-        'acknowledgments'
+        'acknowledgments',
+        'narrative'
       )
     end
   end
@@ -101,7 +102,8 @@ RSpec.describe Collection::ChangeSetBehaviors do
         'title',
         'alternate_ids',
         'creator',
-        'acknowledgments'
+        'acknowledgments',
+        'narrative'
       )
     end
   end

--- a/spec/cho/collection/curated_collections/new_spec.rb
+++ b/spec/cho/collection/curated_collections/new_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe Collection::Curated, type: :feature do
     let(:subtitle) { Faker::Hipster.sentence }
     let(:description) { Faker::Hipster.sentence }
     let(:identifier) { Faker::Number.leading_zero_number(10) }
-    let(:acknowledgments) { Faker::Lorem.paragraph }
+    let(:acknowledgments) { 'Acknowledgmentium ' + Faker::Lorem.paragraph }
+    let(:narrative) { 'Narratismus ' + Faker::Lorem.paragraph }
 
     it 'creates a new curated collection' do
       visit(new_curated_collection_path)
@@ -47,6 +48,7 @@ RSpec.describe Collection::Curated, type: :feature do
       fill_in('curated_collection[description]', with: description)
       fill_in('curated_collection[alternate_ids]', with: identifier)
       fill_in('curated_collection[acknowledgments]', with: acknowledgments)
+      fill_in('curated_collection[narrative]', with: narrative)
       select(agent, from: 'curated_collection[creator][agent]')
       select('blasting', from: 'curated_collection[creator][role]')
       choose('Mediated')
@@ -59,6 +61,7 @@ RSpec.describe Collection::Curated, type: :feature do
       expect(page).to have_content("#{agent.display_name}, blasting")
       expect(page).to have_selector('h2', text: 'Acknowledgments')
       expect(page).to have_content(acknowledgments)
+      expect(page).to have_content(narrative)
     end
   end
 end

--- a/spec/cho/collection/library_collections/new_spec.rb
+++ b/spec/cho/collection/library_collections/new_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Collection::Library, type: :feature do
     let(:description) { Faker::Hipster.sentence }
     let(:identifier) { Faker::Number.leading_zero_number(10) }
     let(:acknowledgments) { Faker::Lorem.paragraph }
+    let(:narrative) { Faker::Lorem.paragraph }
 
     it 'creates a new library collection' do
       visit(new_library_collection_path)
@@ -47,6 +48,7 @@ RSpec.describe Collection::Library, type: :feature do
       fill_in('library_collection[description]', with: description)
       fill_in('library_collection[alternate_ids]', with: identifier)
       fill_in('library_collection[acknowledgments]', with: acknowledgments)
+      fill_in('library_collection[narrative]', with: narrative)
       select(agent, from: 'library_collection[creator][agent]')
       select('blasting', from: 'library_collection[creator][role]')
       choose('Mediated')
@@ -59,6 +61,7 @@ RSpec.describe Collection::Library, type: :feature do
       expect(page).to have_content("#{agent.display_name}, blasting")
       expect(page).to have_selector('h2', text: 'Acknowledgments')
       expect(page).to have_content(acknowledgments)
+      expect(page).to have_content(narrative)
     end
   end
 end

--- a/spec/cho/display_transformation/factory_spec.rb
+++ b/spec/cho/display_transformation/factory_spec.rb
@@ -46,12 +46,12 @@ RSpec.describe DisplayTransformation::Factory, type: :model do
       described_class.transformations = transformations
     end
 
-    it { is_expected.to eq([:no_transformation, :render_link_to_collection, :paragraph_heading]) }
+    it { is_expected.to eq([:no_transformation, :render_link_to_collection, :paragraph_heading, :paragraph]) }
 
     context 'valid transformations set' do
       let(:transformations) { { abc: MyTransformation.new, other: OtherTransformation.new } }
 
-      it { is_expected.to eq([:abc, :other, :no_transformation, :render_link_to_collection, :paragraph_heading]) }
+      it { is_expected.to eq([:abc, :other, :no_transformation, :render_link_to_collection, :paragraph_heading, :paragraph]) }
     end
   end
 

--- a/spec/cho/schema/configuration_spec.rb
+++ b/spec/cho/schema/configuration_spec.rb
@@ -51,7 +51,10 @@ RSpec.describe Schema::Configuration, type: :model do
         },
         {
           'schema' => 'Collection',
-          'fields' => { 'acknowledgments' => { 'order_index' => 1 } },
+          'fields' => {
+            'acknowledgments' => { 'order_index' => 2 },
+            'narrative' => { 'order_index' => 1 }
+          },
           'work_type' => 'false'
         },
         { 'schema' => 'FileSet', 'fields' => [], 'work_type' => 'false' }


### PR DESCRIPTION
## Description

Creates a new kind of transformation that displays a property as one or more paragraphs. This is used with the new `narrative` property on collections that allows curators to provide text content.

Connected to #899 

## Changes

* Add new `narrative` field to data dictionary (please double check I got all the options right)
* Add new display transformation partial for a paragraph type
* Narrative gets displayed above Acknowledgments (and metadata list) on Collection pages... displaying it below the Acknowledgments made it look like it was a part of that section
