### PR TITLE
UTF-8 validation

### DIFF
--- a/app/cho/validation/character_encoding.rb
+++ b/app/cho/validation/character_encoding.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Validation
+  class CharacterEncoding < Base
+    # @note you may be wondering why I'm calling `.to_s` a lot here instead of
+    # `.blank?`, the reason is because the latter will raise a kind of UTF-8
+    # encoding error, but not in a way that is desirable
+    def validate(field_value)
+      self.errors = []
+
+      Array.wrap(field_value).each do |value|
+        begin
+          value.to_s.encode('UTF-8', 'binary') # will raise UndefinedConversionError
+
+          if other_bad_characters.any? { |char| value.to_s.include?(char) }
+            errors << error_message_for(value)
+          end
+        rescue Encoding::UndefinedConversionError
+          errors << error_message_for(value)
+        end
+      end
+
+      errors.empty?
+    end
+
+    private
+
+      def other_bad_characters
+        [
+          0o000.chr(Encoding::UTF_8) # Postgres can't handle this
+        ]
+      end
+
+      def error_message_for(string_with_encoding_issues)
+        invalid_replacement = I18n.t('cho.validation.character_encoding.invalid_character_replacement')
+
+        corrected_string = string_with_encoding_issues
+          .encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: invalid_replacement)
+          .tr(other_bad_characters.join, invalid_replacement)
+
+        I18n.t(
+          'cho.validation.character_encoding.message',
+          invalid_character_replacement: invalid_replacement,
+          corrected_string: corrected_string
+        )
+      end
+  end
+end

--- a/app/cho/validation/factory.rb
+++ b/app/cho/validation/factory.rb
@@ -19,7 +19,8 @@ module Validation
             resource_exists: Validation::ResourceExists,
             edtf_date: Validation::EDTFDate,
             creator: Validation::Creator,
-            unique: Validation::Unique
+            unique: Validation::Unique,
+            character_encoding: Validation::CharacterEncoding
           }
         end
 

--- a/config/data_dictionary/data_dictionary_development.csv
+++ b/config/data_dictionary/data_dictionary_development.csv
@@ -1,14 +1,14 @@
 Label,Field Type,Requirement Designation,Validation,Multiple,Controlled Vocabulary,Default Value,Display Name,Display Transformation,Index Type,Help Text,Core Field
-title,string,required,no_validation,false,no_vocabulary,,Title,no_transformation,no_facet,help me,true
+title,string,required,character_encoding,false,no_vocabulary,,Title,no_transformation,no_facet,help me,true
 home_collection_id,valkyrie_id,optional,resource_exists,false,cho_collections,,Collection,render_link_to_collection,facet,help me,false
 alternate_ids,alternate_id,required_to_publish,unique,true,no_vocabulary,,Identifier,no_transformation,no_facet,help me,true
 creator,creator,optional,creator,true,creator_vocabulary,,Creator,no_transformation,linked_field,help me,true
 date_created,string,required_to_publish,no_validation,true,no_vocabulary,,Date Created,no_transformation,date,help me,true
-subject,string,optional,no_validation,true,no_vocabulary,,Subject,no_transformation,no_facet,help me,true
-location,string,optional,no_validation,true,no_vocabulary,,Location,no_transformation,no_facet,help me,true
-description,text,optional,no_validation,true,no_vocabulary,,Description,no_transformation,no_facet,help me,true
-acknowledgments,text,optional,no_validation,true,no_vocabulary,,,paragraph_heading,no_facet,help me,false
-narrative,text,optional,no_validation,true,no_vocabulary,,Narrative,paragraph,no_facet,help me,false
+subject,string,optional,character_encoding,true,no_vocabulary,,Subject,no_transformation,no_facet,help me,true
+location,string,optional,character_encoding,true,no_vocabulary,,Location,no_transformation,no_facet,help me,true
+description,text,optional,character_encoding,true,no_vocabulary,,Description,no_transformation,no_facet,help me,true
+acknowledgments,text,optional,character_encoding,true,no_vocabulary,,,paragraph_heading,no_facet,help me,false
+narrative,text,optional,character_encoding,true,no_vocabulary,,Narrative,paragraph,no_facet,help me,false
 genre,string,required_to_publish,no_validation,true,no_vocabulary,,Genre,no_transformation,no_facet,help me,true
 collection,string,required_to_publish,no_validation,true,no_vocabulary,,Collection,no_transformation,no_facet,help me,true
 repository,string,required_to_publish,no_validation,true,no_vocabulary,,Repository,no_transformation,no_facet,help me,true

--- a/config/data_dictionary/data_dictionary_production.csv
+++ b/config/data_dictionary/data_dictionary_production.csv
@@ -1,14 +1,14 @@
 Label,Field Type,Requirement Designation,Validation,Multiple,Controlled Vocabulary,Default Value,Display Name,Display Transformation,Index Type,Help Text,Core Field
-title,string,required,no_validation,false,no_vocabulary,,Title,no_transformation,no_facet,help me,true
+title,string,required,character_encoding,false,no_vocabulary,,Title,no_transformation,no_facet,help me,true
 home_collection_id,valkyrie_id,optional,resource_exists,false,cho_collections,,Collection,render_link_to_collection,facet,help me,false
 alternate_ids,alternate_id,required_to_publish,unique,true,no_vocabulary,,Identifier,no_transformation,no_facet,help me,true
 creator,creator,optional,creator,true,creator_vocabulary,,Creator,no_transformation,linked_field,help me,true
 date_created,string,required_to_publish,no_validation,true,no_vocabulary,,Date Created,no_transformation,date,help me,true
-subject,string,optional,no_validation,true,no_vocabulary,,Subject,no_transformation,no_facet,help me,true
-location,string,optional,no_validation,true,no_vocabulary,,Location,no_transformation,no_facet,help me,true
-description,text,optional,no_validation,true,no_vocabulary,,Description,no_transformation,no_facet,help me,true
-acknowledgments,text,optional,no_validation,true,no_vocabulary,,,paragraph_heading,no_facet,help me,false
-narrative,text,optional,no_validation,true,no_vocabulary,,Narrative,paragraph,no_facet,help me,false
+subject,string,optional,character_encoding,true,no_vocabulary,,Subject,no_transformation,no_facet,help me,true
+location,string,optional,character_encoding,true,no_vocabulary,,Location,no_transformation,no_facet,help me,true
+description,text,optional,character_encoding,true,no_vocabulary,,Description,no_transformation,no_facet,help me,true
+acknowledgments,text,optional,character_encoding,true,no_vocabulary,,,paragraph_heading,no_facet,help me,false
+narrative,text,optional,character_encoding,true,no_vocabulary,,Narrative,paragraph,no_facet,help me,false
 genre,string,required_to_publish,no_validation,true,no_vocabulary,,Genre,no_transformation,no_facet,help me,true
 collection,string,required_to_publish,no_validation,true,no_vocabulary,,Collection,no_transformation,no_facet,help me,true
 repository,string,required_to_publish,no_validation,true,no_vocabulary,,Repository,no_transformation,no_facet,help me,true

--- a/config/data_dictionary/data_dictionary_test.csv
+++ b/config/data_dictionary/data_dictionary_test.csv
@@ -1,10 +1,10 @@
 Label,Field Type,Requirement Designation,Validation,Multiple,Controlled Vocabulary,Default Value,Display Name,Display Transformation,Index Type,Help Text,Core Field
-title,string,required,no_validation,true,no_vocabulary,,Object Title,no_transformation,no_facet,help me,true
+title,string,required,character_encoding,true,no_vocabulary,,Object Title,no_transformation,no_facet,help me,true
 home_collection_id,valkyrie_id,optional,resource_exists,false,cho_collections,,Collection,render_link_to_collection,facet,help me,false
-subtitle,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,true
-description,text,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,true
-acknowledgments,text,optional,no_validation,true,no_vocabulary,,,paragraph_heading,no_facet,help me,false
-narrative,text,optional,no_validation,true,no_vocabulary,,Narrative,paragraph,no_facet,help me,false
+subtitle,string,optional,character_encoding,true,no_vocabulary,,,no_transformation,no_facet,help me,true
+description,text,optional,character_encoding,true,no_vocabulary,,,no_transformation,no_facet,help me,true
+acknowledgments,text,optional,character_encoding,true,no_vocabulary,,,paragraph_heading,no_facet,help me,false
+narrative,text,optional,character_encoding,true,no_vocabulary,,Narrative,paragraph,no_facet,help me,false
 created,date,optional,edtf_date,true,no_vocabulary,,,no_transformation,date,help me,false
 generic_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,facet,help me,false
 document_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false

--- a/config/locales/cho.yml
+++ b/config/locales/cho.yml
@@ -173,3 +173,6 @@ en:
         hash_keys: "must contain an agent and a role"
         role: "role '%{role}' does not exist"
         agent: "agent '%{agent}' does not exist"
+      character_encoding:
+        invalid_character_replacement: ! "\U0001F4A9"
+        message: "contains invalid characters. The %{invalid_character_replacement} character represents an invalid character that needs to be replaced before re-submitting this form: \"%{corrected_string}\""

--- a/spec/cho/data_dictionary/fields_controller_spec.rb
+++ b/spec/cho/data_dictionary/fields_controller_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe DataDictionary::FieldsController, type: :controller do
       'label' => 'title',
       'field_type' => 'string',
       'requirement_designation' => 'required',
-      'validation' => 'no_validation',
+      'validation' => 'character_encoding',
       'multiple' => true,
       'controlled_vocabulary' => 'no_vocabulary',
       'default_value' => nil,
@@ -128,7 +128,7 @@ RSpec.describe DataDictionary::FieldsController, type: :controller do
           "Default Value,Display Name,Display Transformation,Index Type,Help Text,Core Field\n"
         )
         expect(response.body).to include(
-          'title,string,required,no_validation,true,no_vocabulary,,Object Title,'\
+          'title,string,required,character_encoding,true,no_vocabulary,,Object Title,'\
           "no_transformation,no_facet,help me,true\n"
         )
         expect(response.body).to include(

--- a/spec/cho/schema/metadata_field_spec.rb
+++ b/spec/cho/schema/metadata_field_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Schema::MetadataField, type: :model do
                                 multiple: true,
                                 requirement_designation: 'required',
                                 order_index: nil,
-                                validation: 'no_validation' } }
+                                validation: 'character_encoding' } }
 
     its(:attributes) { is_expected.to include(expected_metadata) }
 
@@ -99,7 +99,7 @@ RSpec.describe Schema::MetadataField, type: :model do
                                     requirement_designation: 'required_to_publish',
                                     core_field: false,
                                     order_index: 20,
-                                    validation: 'no_validation' } }
+                                    validation: 'character_encoding' } }
 
       let(:expected_metadata) { { controlled_vocabulary: 'no_vocabulary',
                                   core_field: true,
@@ -114,7 +114,7 @@ RSpec.describe Schema::MetadataField, type: :model do
                                   multiple: true,
                                   requirement_designation: 'required',
                                   order_index: 20,
-                                  validation: 'no_validation' } }
+                                  validation: 'character_encoding' } }
 
       its(:attributes) { is_expected.to include(expected_metadata) }
     end

--- a/spec/cho/validation/character_encoding_spec.rb
+++ b/spec/cho/validation/character_encoding_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Validation::CharacterEncoding, type: :model do
+  describe '#validate' do
+    subject { validation_instance.validate(strings) }
+
+    let(:validation_instance) { described_class.new }
+
+    # @note the crazy (+"string") syntax below is required to make
+    # frozen_string_literal and rubocop happy. It's just a string.
+    let(:string_with_invalid_utf) { (+"\255 is invalid UTF-8").force_encoding('UTF-8') }
+    let(:string_disliked_by_postres) { (+"\000 is disliked by postgres").force_encoding('UTF-8') }
+
+    context 'with a single valid string' do
+      let(:strings) { 'hello world' }
+
+      it 'is valid' do
+        expect(validation_instance.validate(strings)).to be_truthy
+        expect(validation_instance.errors).to be_empty
+      end
+    end
+
+    context 'with multiple valid strings' do
+      let(:strings) { ['hello', 'world'] }
+
+      it 'is valid' do
+        expect(validation_instance.validate(strings)).to be_truthy
+        expect(validation_instance.errors).to be_empty
+      end
+    end
+
+    context 'with a single invalid string' do
+      let(:strings) { string_with_invalid_utf }
+
+      it 'is invalid' do
+        expect(validation_instance.validate(strings)).to be_falsey
+        expect(validation_instance.errors).to contain_exactly(/contains invalid characters.*is invalid UTF-8/)
+      end
+    end
+
+    context 'with a multiple invalid strings' do
+      let(:strings) { [string_with_invalid_utf, string_disliked_by_postres] }
+
+      it 'is invalid' do
+        expect(validation_instance.validate(strings)).to be_falsey
+        expect(validation_instance.errors).to contain_exactly(
+          /contains invalid characters.*is invalid UTF-8/,
+          /contains invalid characters.*is disliked by postgres/
+        )
+      end
+    end
+
+    context 'with both valid and invalid strings' do
+      let(:strings) { ['hello world', string_with_invalid_utf] }
+
+      it 'is invalid' do
+        expect(validation_instance.validate(strings)).to be_falsey
+        expect(validation_instance.errors).to contain_exactly(/contains invalid characters.*is invalid UTF-8/)
+      end
+    end
+
+    context 'with a nil string' do
+      let(:strings) { nil }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'with an empty set of strings' do
+      let(:strings) { [] }
+
+      it { is_expected.to be_truthy }
+    end
+  end
+end

--- a/spec/cho/validation/factory_spec.rb
+++ b/spec/cho/validation/factory_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe Validation::Factory, type: :model do
           'no_validation',
           'resource_exists',
           'unique',
-          'edtf_date'
+          'edtf_date',
+          'character_encoding'
         )
       end
     end
@@ -77,7 +78,8 @@ RSpec.describe Validation::Factory, type: :model do
           'no_validation',
           'resource_exists',
           'edtf_date',
-          'unique'
+          'unique',
+          'character_encoding'
         )
       end
     end

--- a/spec/postgres/utf8_spec.rb
+++ b/spec/postgres/utf8_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Valkyrie::Resource, type: :model do
+  before do
+    class UtfModel < Valkyrie::Resource
+      attribute :random_string
+    end
+  end
+
+  after do
+    ActiveSupport::Dependencies.remove_constant('UtfModel')
+  end
+
+  let(:valid_characters) { Faker::String.random(1_000).tr(bad_characters, '') }
+  let(:invalid_characters) { Faker::String.random(1_000) + bad_characters }
+  let(:bad_characters) { 0o000.chr(Encoding::UTF_8) }
+
+  it 'accepts all valid UTF-8 characters, except for the ones we know it does not' do
+    resource = UtfModel.new(random_string: valid_characters)
+    updated_resource = Valkyrie.config.metadata_adapter.persister.save(resource: resource)
+    expect(updated_resource.random_string).to contain_exactly(valid_characters)
+  end
+
+  it 'raises an error when there are bad UTF characters' do
+    resource = UtfModel.new(random_string: invalid_characters)
+    expect {
+      Valkyrie.config.metadata_adapter.persister.save(resource: resource)
+    }.to raise_error(ActiveRecord::StatementInvalid)
+  end
+end


### PR DESCRIPTION
## Description

Previously if an invalid UTF-8 character was entered, it would result in a 500 error. Now we scan for these invalid characters; if any are detected, they are replaced with a 💩 (lol) and returned back to the user with a helpful error message asking them to make the necessary changes. Additionally, there is one _valid_ UTF-8 character that is not acceptable by Postgres—this character is also detected and 💩'd. 

Please note, however, that this only detects truly invalid UTF-8 characters that would cause a crash. If someone copy-and-pasted something from an old version of MS Word that contained the phrase "it's" in some weird encoding, and was represented as "itâ€™s" in UTF-8, we do not flag this, because all of the characters are indeed _valid_ even if unintentionally weird—unintentionally weird being rather difficult to detect automatically by a computer.

Please also note that it's really hard / borderline impossible to actually test this through a modern browser like Chrome which tends to do the right thing most of the time. I tried to generate invalid UTF-8 characters myself and paste them into the Chrome input fields, and they were replaced with the "�" when pasted into the field. ¯\_(ツ)_/¯ 

Connected to #93 

## Changes

* Development and Production data dictionary currently get the new UTF-8 validator on the following fields: `title, subject, location, description, acknowledgments, narrative`