### PR TITLE
Escape characters when querying Postgres

### DIFF
--- a/app/valkyrie/find_using.rb
+++ b/app/valkyrie/find_using.rb
@@ -30,7 +30,7 @@ class FindUsing
     query.each_key do |key|
       value = query[key]
       clause = if value.is_a?(String)
-                 "metadata @> '{\"#{key}\":[\"#{value}\"]}'"
+                 "metadata @> '{\"#{key}\":[\"#{PG::Connection.escape_string(value)}\"]}'"
                elsif value.nil?
                  "metadata->>'#{key}' is null"
                else

--- a/spec/valkyrie/find_using_spec.rb
+++ b/spec/valkyrie/find_using_spec.rb
@@ -71,4 +71,17 @@ RSpec.describe FindUsing do
       expect(results.first.id).to eq(persisted_sample.id)
     end
   end
+
+  context 'when escaping punctuation in the search term' do
+    let(:retrieved_resource) { query_service.custom_queries.find_using(framjam: "Pot 'o Gold").first }
+
+    before do
+      resource = SampleResource.new(framjam: "Pot 'o Gold")
+      Valkyrie.config.metadata_adapter.persister.save(resource: resource)
+    end
+
+    it 'retrieves the correct resource' do
+      expect(retrieved_resource.framjam).to eq("Pot 'o Gold")
+    end
+  end
 end


### PR DESCRIPTION
## Description

Fixes bug when querying Postgres with values that have punctuation.

Connected to #885 