### PR TITLE
Use polymorphic solr_document path for show links

### DIFF
--- a/app/views/collection/archival_collections/edit.html.erb
+++ b/app/views/collection/archival_collections/edit.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'collection/base/form', collection: @collection %>
 <%= render 'shared/form_delete', resource: @collection %>
-<%= link_to 'Show', @collection %>
+<%= link_to t('cho.archival_collection.edit.show'), polymorphic_path([:solr_document], id: @collection.id) %>

--- a/app/views/collection/curated_collections/edit.html.erb
+++ b/app/views/collection/curated_collections/edit.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'collection/base/form', collection: @collection %>
 <%= render 'shared/form_delete', resource: @collection %>
-<%= link_to 'Show', @collection %>
+<%= link_to t('cho.curated_collection.edit.show'), polymorphic_path([:solr_document], id: @collection.id) %>

--- a/app/views/collection/library_collections/edit.html.erb
+++ b/app/views/collection/library_collections/edit.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'collection/base/form', collection: @collection %>
 <%= render 'shared/form_delete', resource: @collection %>
-<%= link_to 'Show', @collection %>
+<%= link_to t('cho.library_collection.edit.show'), polymorphic_path([:solr_document], id: @collection.id) %>

--- a/app/views/work/file_sets/edit.html.erb
+++ b/app/views/work/file_sets/edit.html.erb
@@ -3,4 +3,4 @@
 
 <%= render partial: 'form', locals: { file_set_form: @file_set } %>
 <%= render 'shared/form_delete', resource: @file_set %>
-<%= link_to t('cho.work.edit.show_link'), file_set_path(@file_set.model) %>
+<%= link_to t('cho.work.edit.show_link'), polymorphic_path([:solr_document], id: @file_set.id) %>

--- a/app/views/work/submissions/edit.html.erb
+++ b/app/views/work/submissions/edit.html.erb
@@ -3,4 +3,4 @@
 
 <%= render partial: 'form', locals: { work_form: @work } %>
 <%= render 'shared/form_delete', resource: @work %>
-<%= link_to t('cho.work.edit.show_link'), work_path(@work.model) %>
+<%= link_to t('cho.work.edit.show_link'), polymorphic_path([:solr_document], id: @work.id) %>

--- a/config/locales/cho.yml
+++ b/config/locales/cho.yml
@@ -83,18 +83,21 @@ en:
       edit:
         delete_link: "Delete Archival Collection"
         heading: "Edit Collection"
+        show: "Show"
       new:
         heading: "New Archival Collection"
     library_collection:
       edit:
         delete_link: "Delete Library Collection"
         heading: "Edit Collection"
+        show: "Show"
       new:
         heading: "New Library Collection"
     curated_collection:
       edit:
         delete_link: "Delete Curated Collection"
         heading: "Edit Collection"
+        show: "Show"
       new:
         heading: "New Curated Collection"
     agent:

--- a/spec/views/archival_collections/edit.html.erb_spec.rb
+++ b/spec/views/archival_collections/edit.html.erb_spec.rb
@@ -24,5 +24,6 @@ RSpec.describe 'collection/archival_collections/edit', type: :view do
       assert_select 'legend', 'Workflow'
       assert_select 'legend', 'Access Level'
     end
+    assert_select 'a[href=?]', "/catalog/#{collection.id}"
   end
 end

--- a/spec/views/curated_collections/edit.html.erb_spec.rb
+++ b/spec/views/curated_collections/edit.html.erb_spec.rb
@@ -24,5 +24,6 @@ RSpec.describe 'collection/curated_collections/edit', type: :view do
       assert_select 'legend', 'Workflow'
       assert_select 'legend', 'Access Level'
     end
+    assert_select 'a[href=?]', "/catalog/#{collection.id}"
   end
 end

--- a/spec/views/library_collections/edit.html.erb_spec.rb
+++ b/spec/views/library_collections/edit.html.erb_spec.rb
@@ -24,5 +24,6 @@ RSpec.describe 'collection/library_collections/edit', type: :view do
       assert_select 'legend', 'Workflow'
       assert_select 'legend', 'Access Level'
     end
+    assert_select 'a[href=?]', "/catalog/#{collection.id}"
   end
 end

--- a/spec/views/work_file_sets/edit.html.erb_spec.rb
+++ b/spec/views/work_file_sets/edit.html.erb_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'work/file_sets/edit', type: :view do
+  let(:file_set) { create(:file_set, title: ['Editable file set']) }
+  let(:change_set) { Work::FileSetChangeSet.new(file_set) }
+  let(:form) { change_set }
+
+  before do
+    controller.request.path_parameters[:id] = file_set.id.to_s
+    @file_set = assign(:file_set, form)
+    render
+  end
+
+  it 'renders the form' do
+    assert_select 'form[action=?][method=?]', file_set_path(file_set), 'post' do
+      assert_select 'label[for=?]', 'work_file_set_title', text: /(\s*)required/
+      assert_select 'input[name=?]', 'work_file_set[title]'
+      assert_select 'label[for=?]', 'work_file_set_subtitle'
+      assert_select 'input[name=?]', 'work_file_set[subtitle][]'
+      assert_select 'label[for=?]', 'work_file_set_description'
+      assert_select 'textarea[name=?]', 'work_file_set[description][]'
+    end
+    assert_select 'a[href=?]', "/catalog/#{file_set.id}"
+  end
+end

--- a/spec/views/work_submissions/edit.html.erb_spec.rb
+++ b/spec/views/work_submissions/edit.html.erb_spec.rb
@@ -75,5 +75,6 @@ RSpec.describe 'work/submissions/edit', type: :view do
       assert_select 'input[name=?]', "work_submission[#{specific_field}][]"
       assert_select 'label[for=?]', 'work_submission_file', false
     end
+    assert_select 'a[href=?]', "/catalog/#{@work.id}"
   end
 end


### PR DESCRIPTION
## Description

Links to the show page should reference the catalog path, via Blacklight's solr document, and not the postgres Valkyrie object.

Connected to #478 