### PR TITLE
Add Blacklight gallery

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
 
 # Supporting gems
 gem 'bagit'
+gem 'blacklight-gallery', git: 'https://github.com/projectblacklight/blacklight-gallery'
 gem 'bootsnap', require: false
 gem 'cancancan'
 gem 'coffee-rails', '~> 4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/projectblacklight/blacklight-gallery
+  revision: f885a5a57db751b4cdf57ebdff47d86a2fcad426
+  specs:
+    blacklight-gallery (1.0.0.alpha)
+      blacklight (~> 7.0)
+      bootstrap (~> 4.0)
+      openseadragon (>= 0.2.0)
+      rails
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -377,6 +387,8 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
+    openseadragon (0.5.0)
+      rails (> 3.2.0)
     orm_adapter (0.5.0)
     parallel (1.12.1)
     parser (2.5.3.0)
@@ -675,6 +687,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   blacklight (~> 7.0)
+  blacklight-gallery!
   bootsnap
   bootstrap (~> 4.3)
   byebug

--- a/app/application/application_controller.rb
+++ b/app/application/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   include DeviseRemote::HttpHeaderAuthenticatableBehavior
 
   helper LocalHelperBehavior, LayoutHelperBehavior
+  helper Openseadragon::OpenseadragonHelper
 
   layout 'blacklight'
 

--- a/app/assets/javascripts/blacklight_gallery.js
+++ b/app/assets/javascripts/blacklight_gallery.js
@@ -1,0 +1,1 @@
+//= require blacklight_gallery/default

--- a/app/assets/javascripts/openseadragon.js
+++ b/app/assets/javascripts/openseadragon.js
@@ -1,0 +1,2 @@
+//= require openseadragon/openseadragon
+//= require openseadragon/rails

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -11,5 +11,7 @@
  * It is generally better to create a new file per style scope.
  *
  *= require_self
+ *= require blacklight_gallery
+ *= require openseadragon
  *= require cho
  */

--- a/app/assets/stylesheets/blacklight_gallery.css.scss
+++ b/app/assets/stylesheets/blacklight_gallery.css.scss
@@ -1,0 +1,1 @@
+//= require blacklight_gallery/default

--- a/app/assets/stylesheets/openseadragon.css
+++ b/app/assets/stylesheets/openseadragon.css
@@ -1,0 +1,3 @@
+/*
+ *= require openseadragon/openseadragon
+ */

--- a/app/blacklight/catalog_controller.rb
+++ b/app/blacklight/catalog_controller.rb
@@ -10,6 +10,14 @@ class CatalogController < ApplicationController
   Blacklight::IndexPresenter.thumbnail_presenter = ::ThumbnailPresenter
 
   configure_blacklight do |config|
+    ## Configure blacklight-gallery
+    config.view.gallery.partials = [:index_header, :index]
+    config.view.masonry.partials = [:index]
+    config.view.slideshow.partials = [:index]
+
+    config.show.tile_source_field = :content_metadata_image_iiif_info_ssm
+    config.show.partials.insert(1, :openseadragon)
+
     ## Class for sending and receiving requests from a search index
     # config.repository_class = Blacklight::Solr::Repository
     #

--- a/app/blacklight/solr_document.rb
+++ b/app/blacklight/solr_document.rb
@@ -2,6 +2,7 @@
 
 class SolrDocument
   include Blacklight::Solr::Document
+  include Blacklight::Gallery::OpenseadragonSolrDocument
   include DataDictionary::FieldsForSolrDocument
 
   # self.unique_key = 'id'


### PR DESCRIPTION
## Description

Adds the blacklight-gallery gem, but there are several things of note here

The current official release of blacklight-gallery gem does not support Blacklight 7, therefore I had to install it from the master branch of its GitHub repository. We are using and alpha version of the gem.

The masonry layout looks quite terrible and our image thumbnails are not properly cropped/resized to the columns as would be expected. I personally am hesitant to deploy this, so I will leave it up to the rest of the team to decide whether it is ready go now, or needs some UI attention before it is deployed.

On a technical note, CHO's nonstandard app folder layout caused the installation generators for both blacklight-gallery and its dependency opeanseadragon to crash. I read through their code, and manually inserted the installation code into its respective locations in CHO. 

Connected to #895 

## Changes

* install alpha version of blacklight-gallery directly from github repo
* manually install the blacklight-gallery and openseadragon gems because install generators crashed
* inserted blacklight-gallery and openseadragon css's into the asset pipeline — @mtribone could you please confirm that I did that in a pleasing way