### PR TITLE
Check permissions on configured directories

### DIFF
--- a/app/cho/repository/config_file.rb
+++ b/app/cho/repository/config_file.rb
@@ -16,21 +16,35 @@ module Repository
 
     def validate
       requirements.each do |requirement|
-        send(requirement.values.first, requirement.keys.first)
+        setting = JSON.parse(requirement.values.first.to_json, object_class: OpenStruct)
+        property = requirement.keys.first
+        check_requirement(setting: setting, property: property)
+        check_directory(setting: setting, property: property)
       end
     end
 
     private
 
-      def required(value)
-        return if keys.include?(value)
-        raise Configuration::Error, "#{value} is a required key in #{name}"
+      def check_requirement(property:, setting:)
+        return if keys.include?(property) || !setting.required
+        raise Configuration::Error, "#{property} is a required key in #{name}"
       end
 
-      def required_directory(value)
-        required(value)
-        return if Pathname.new(config.fetch(value)).exist?
-        raise Configuration::Error, "#{config.fetch(value)} is a required directory in #{name}"
+      def check_directory(property:, setting:)
+        return unless setting.directory
+        directory_exists(property)
+        directory_writable(property: property, setting: setting)
+      end
+
+      def directory_exists(value)
+        path = Pathname.new(config.fetch(value))
+        return if path.exist? && path.readable?
+        raise Configuration::Error, "#{config.fetch(value)} must be present and readable in #{name}"
+      end
+
+      def directory_writable(property:, setting:)
+        return if Pathname.new(config.fetch(property)).writable? || !setting.directory.writable
+        raise Configuration::Error, "#{config.fetch(property)} must be writable in #{name}"
       end
   end
 end

--- a/app/cho/repository/configuration.rb
+++ b/app/cho/repository/configuration.rb
@@ -6,12 +6,12 @@ module Repository
 
     REQUIREMENTS = {
       'application.yml' => [
-        { 'service_name' => :required },
-        { 'service_instance' => :required },
-        { 'virtual_host' => :required },
-        { 'network_ingest_directory' => :required_directory },
-        { 'extraction_directory' => :required_directory },
-        { 'storage_directory' => :required_directory }
+        { 'service_name' => { required: true } },
+        { 'service_instance' => { required: true } },
+        { 'virtual_host' => { required: true } },
+        { 'network_ingest_directory' => { required: true, directory: { writable: false } } },
+        { 'extraction_directory' => { required: true, directory: { writable: true } } },
+        { 'storage_directory' => { required: true, directory: { writable: true } } }
       ]
     }.freeze
 

--- a/spec/cho/repository/configuration_spec.rb
+++ b/spec/cho/repository/configuration_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Repository::Configuration do
   describe '::check' do
     context 'with the current configuration files' do
       specify do
-        expect { described_class.check }.not_to raise_error(Repository::Configuration::Error)
+        expect { described_class.check }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
## Description

Expanding on a previous commit that verifies our server-side configuration files, this checks the permissions on any directories in the config file and raises errors if they are not readable or writable depending on the requirements.

This will help avoid problems when reading and extracting bags.