### PR TITLE
Update labels on Resource Landing Page

### DIFF
--- a/config/locales/cho.yml
+++ b/config/locales/cho.yml
@@ -71,9 +71,9 @@ en:
       error: "%{count} prohibited this resource from being saved:"
       missing: "Missing"
       show:
-        files_heading: "Parts"
-        download_representative_link: 'Download Work'
-        download_text_link: 'Download Plain Text'
+        files_heading: "Resource Parts"
+        download_representative_link: "Download Resource"
+        download_text_link: "Download Text"
     collection:
       members:
         title: "Title"


### PR DESCRIPTION
Tweaking labels for download buttons on resources. Also changing parts heading to resource parts.

## Description
Tweaking labels and headings on the resource landing page.

## Changes
* Changing "Download Work" button label to "Download Resource"
* Changing "Download Plain Text" button label to "Download Text"
* Changing "Parts" heading to "Resource Parts"
