### PR TITLE
Create symlinks under the public directory during deployment

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -102,6 +102,10 @@ namespace :deploy do
     on roles(:web, :job) do
       execute 'rm -f /home/deploy/cho/shared/config'
       execute "ln -sf /#{fetch(:application)}/config_#{fetch(:stage)}/cho /home/deploy/cho/shared/config"
+      execute 'rm -f /home/deploy/cho/shared/public/files'
+      execute "ln -sf /#{fetch(:application)}/shared_#{fetch(:stage)}/public/files /home/deploy/cho/shared/public/files"
+      execute 'rm -f /home/deploy/cho/shared/public/robots.txt'
+      execute "ln -sf /#{fetch(:application)}/shared_#{fetch(:stage)}/public/robots.txt /home/deploy/cho/shared/public/robots.txt"
     end
   end
   before 'deploy:check:linked_dirs', :symlink_shared_directories


### PR DESCRIPTION
## Description

Makes sure the symlinks are correct under `shared/public` so that when Capistrano links to them, they exist and are pointing to the right locations.

## Notes

The symlink to `public/files` will need to be removed later once #967 is completed.