### PR TITLE
Add access controls to Valkyrie resources

### DIFF
--- a/app/blacklight/catalog_controller.rb
+++ b/app/blacklight/catalog_controller.rb
@@ -143,14 +143,14 @@ class CatalogController < ApplicationController
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
     config.add_index_field 'work_type_ssim', label: I18n.t('cho.field_label.work_type')
-    config.add_index_field 'visibility_ssim', label: I18n.t('cho.field_label.visibility')
+    config.add_index_field 'access_level_ssim', label: I18n.t('cho.field_label.access_level')
     config.add_index_field 'workflow_ssim', label: I18n.t('cho.field_label.workflow')
     config.add_index_field 'collection_type_ssim', label: I18n.t('cho.field_label.collection_type')
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
     config.add_show_field 'work_type_ssim', label: I18n.t('cho.field_label.work_type')
-    config.add_show_field 'visibility_ssim', label: I18n.t('cho.field_label.visibility')
+    config.add_show_field 'access_level_ssim', label: I18n.t('cho.field_label.access_level')
     config.add_show_field 'workflow_ssim', label: I18n.t('cho.field_label.workflow')
     config.add_show_field 'collection_type_ssim', label: I18n.t('cho.field_label.collection_type')
 

--- a/app/cho/collection/change_set_behaviors.rb
+++ b/app/cho/collection/change_set_behaviors.rb
@@ -10,9 +10,9 @@ module Collection::ChangeSetBehaviors
     validates :workflow, inclusion: { in: ::Collection::CommonFields::WORKFLOW }
     validates :workflow, presence: true
 
-    property :visibility, multiple: false, required: true
-    validates :visibility, inclusion: { in: ::Collection::CommonFields::VISIBILITY }
-    validates :visibility, presence: true
+    property :access_level, multiple: false, required: true
+    validates :access_level, inclusion: { in: ::Collection::CommonFields::ACCESS_LEVEL }
+    validates :access_level, presence: true
   end
 
   # @return [Array<Schema::MetadataField>]

--- a/app/cho/collection/common_fields.rb
+++ b/app/cho/collection/common_fields.rb
@@ -5,10 +5,10 @@ module Collection::CommonFields
   include DataDictionary::FieldsForObject
 
   WORKFLOW = ['default', 'mediated'].freeze
-  VISIBILITY = ['public', 'authenticated', 'private'].freeze
+  ACCESS_LEVEL = ['public', 'authenticated', 'private'].freeze
 
   included do
     attribute :workflow, Valkyrie::Types::Set.of(Valkyrie::Types::String.enum(*WORKFLOW))
-    attribute :visibility, Valkyrie::Types::Set.of(Valkyrie::Types::String.enum(*VISIBILITY))
+    attribute :access_level, Valkyrie::Types::Set.of(Valkyrie::Types::String.enum(*ACCESS_LEVEL))
   end
 end

--- a/app/cho/metrics/collection.rb
+++ b/app/cho/metrics/collection.rb
@@ -58,7 +58,7 @@ module Metrics
           title: [I18n.t("#{i18n_key}.title")],
           description: [I18n.t("#{i18n_key}.description")],
           workflow: 'default',
-          visibility: 'public'
+          access_level: 'public'
         }
       end
 

--- a/app/cho/work/file_set.rb
+++ b/app/cho/work/file_set.rb
@@ -5,6 +5,7 @@
 # File sets are indexed both in Solr and and Postgres using the {IndexingAdapter}.
 class Work::FileSet < Valkyrie::Resource
   enable_optimistic_locking
+  include Valkyrie::Resource::AccessControls
   include CommonQueries
   include DataDictionary::FieldsForObject
 

--- a/app/views/collection/base/_form.html.erb
+++ b/app/views/collection/base/_form.html.erb
@@ -17,17 +17,17 @@
   </fieldset>
 
   <fieldset>
-    <legend><%= t('cho.form.visibility') %></legend>
-    <%= form.label :visibility_public do %>
-      <%= form.radio_button :visibility, 'public' %> <%= t('cho.field_label.public') %>
+    <legend><%= t('cho.form.access_level') %></legend>
+    <%= form.label :access_level_public do %>
+      <%= form.radio_button :access_level, 'public' %> <%= t('cho.field_label.public') %>
     <% end %>
 
-    <%= form.label :visibility_authenticated do %>
-      <%= form.radio_button :visibility, 'authenticated' %> <%= t('cho.field_label.authenticated') %>
+    <%= form.label :access_level_authenticated do %>
+      <%= form.radio_button :access_level, 'authenticated' %> <%= t('cho.field_label.authenticated') %>
     <% end %>
 
-    <%= form.label :visibility_private do %>
-      <%= form.radio_button :visibility, 'private' %> <%= t('cho.field_label.private') %>
+    <%= form.label :access_level_private do %>
+      <%= form.radio_button :access_level, 'private' %> <%= t('cho.field_label.private') %>
     <% end %>
   </fieldset>
 

--- a/config/locales/cho.yml
+++ b/config/locales/cho.yml
@@ -21,7 +21,7 @@ en:
     form:
       metadata: "Basic Metadata"
       workflow: "Workflow"
-      visibility: "Access Level"
+      access_level: "Access Level"
       file_selection: "File Selection"
       required: "required"
     field_label:
@@ -31,7 +31,7 @@ en:
       workflow: "Workflow"
       default: "Publish Immediately"
       mediated: "Mediated"
-      visibility: "Access Level"
+      access_level: "Access Level"
       public: "Public Access"
       authenticated: "PSU Access"
       private: "Restricted Access"

--- a/lib/tasks/ingest.rake
+++ b/lib/tasks/ingest.rake
@@ -31,7 +31,7 @@ namespace :cho do
       collection = Collection::Archival.new(
         title: "Collection for #{id}",
         alternate_ids: [id],
-        visibility: 'public',
+        access_level: 'public',
         workflow: 'default'
       )
       change_set_persister.persister.save(resource: collection)

--- a/spec/cho/collection/archival_collections/archival_spec.rb
+++ b/spec/cho/collection/archival_collections/archival_spec.rb
@@ -12,4 +12,5 @@ RSpec.describe Collection::Archival, type: :model do
 
   it_behaves_like 'a collection'
   it_behaves_like 'a Valkyrie::Resource'
+  it_behaves_like 'a resource with Valkyrie::Resource::AccessControls'
 end

--- a/spec/cho/collection/change_set_behaviors_spec.rb
+++ b/spec/cho/collection/change_set_behaviors_spec.rb
@@ -30,14 +30,14 @@ RSpec.describe Collection::ChangeSetBehaviors do
   describe '#multiple?' do
     it 'has one title and description' do
       expect(change_set).not_to be_multiple(:workflow)
-      expect(change_set).not_to be_multiple(:visibility)
+      expect(change_set).not_to be_multiple(:access_level)
     end
   end
 
   describe '#required?' do
     it 'has required fields' do
       expect(change_set).to be_required(:workflow)
-      expect(change_set).to be_required(:visibility)
+      expect(change_set).to be_required(:access_level)
     end
   end
 
@@ -45,7 +45,7 @@ RSpec.describe Collection::ChangeSetBehaviors do
     before { change_set.prepopulate! }
 
     its(:workflow) { is_expected.to be_nil }
-    its(:visibility) { is_expected.to be_nil }
+    its(:access_level) { is_expected.to be_nil }
   end
 
   describe '#validate' do
@@ -65,14 +65,14 @@ RSpec.describe Collection::ChangeSetBehaviors do
       its(:full_messages) { is_expected.to include('Workflow is not included in the list') }
     end
 
-    context 'with an unsupported visibility' do
-      let(:params) { { title: 'title', visibility: 'foo' } }
+    context 'with an unsupported access_level' do
+      let(:params) { { title: 'title', access_level: 'foo' } }
 
-      its(:full_messages) { is_expected.to include('Visibility is not included in the list') }
+      its(:full_messages) { is_expected.to include('Access level is not included in the list') }
     end
 
     context 'with all required fields' do
-      let(:params) { { title: 'Title', description: 'My collection', workflow: 'default', visibility: 'public' } }
+      let(:params) { { title: 'Title', description: 'My collection', workflow: 'default', access_level: 'public' } }
 
       its(:full_messages) { is_expected.to be_empty }
     end

--- a/spec/cho/collection/common_fields_spec.rb
+++ b/spec/cho/collection/common_fields_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe Collection::CommonFields, type: :model do
 
   it { is_expected.to respond_to(:id) }
   it { is_expected.to respond_to(:workflow) }
-  it { is_expected.to respond_to(:visibility) }
+  it { is_expected.to respond_to(:access_level) }
 
-  describe '#visibility=' do
+  describe '#access_level=' do
     it 'can be set' do
-      expect { collection.visibility = 'public' }.not_to raise_error
-      expect { collection.visibility = 'authenticated' }.not_to raise_error
-      expect { collection.visibility = 'private' }.not_to raise_error
-      expect { collection.visibility = 'bogus' }.to raise_error(Dry::Types::ConstraintError)
+      expect { collection.access_level = 'public' }.not_to raise_error
+      expect { collection.access_level = 'authenticated' }.not_to raise_error
+      expect { collection.access_level = 'private' }.not_to raise_error
+      expect { collection.access_level = 'bogus' }.to raise_error(Dry::Types::ConstraintError)
     end
   end
 

--- a/spec/cho/collection/curated_collections/curated_spec.rb
+++ b/spec/cho/collection/curated_collections/curated_spec.rb
@@ -12,4 +12,5 @@ RSpec.describe Collection::Curated, type: :model do
 
   it_behaves_like 'a collection'
   it_behaves_like 'a Valkyrie::Resource'
+  it_behaves_like 'a resource with Valkyrie::Resource::AccessControls'
 end

--- a/spec/cho/collection/library_collections/library_spec.rb
+++ b/spec/cho/collection/library_collections/library_spec.rb
@@ -12,4 +12,5 @@ RSpec.describe Collection::Library, type: :model do
 
   it_behaves_like 'a collection'
   it_behaves_like 'a Valkyrie::Resource'
+  it_behaves_like 'a resource with Valkyrie::Resource::AccessControls'
 end

--- a/spec/cho/work/file_set_spec.rb
+++ b/spec/cho/work/file_set_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Work::FileSet do
   let(:resource_klass) { described_class }
 
   it_behaves_like 'a Valkyrie::Resource'
+  it_behaves_like 'a resource with Valkyrie::Resource::AccessControls'
 
   describe '#member_ids' do
     its(:member_ids) { is_expected.to be_empty }

--- a/spec/cho/work/submissions/submission_spec.rb
+++ b/spec/cho/work/submissions/submission_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Work::Submission do
   let(:resource_klass) { described_class }
 
   it_behaves_like 'a Valkyrie::Resource'
+  it_behaves_like 'a resource with Valkyrie::Resource::AccessControls'
 
   describe '#title' do
     it 'is nil when not set' do

--- a/spec/factories/archival_collections.rb
+++ b/spec/factories/archival_collections.rb
@@ -6,6 +6,6 @@ FactoryBot.define do
     subtitle { 'subtitle for an archival collection' }
     description { 'Sample archival collection' }
     workflow { 'default' }
-    visibility { 'public' }
+    access_level { 'public' }
   end
 end

--- a/spec/factories/curated_collections.rb
+++ b/spec/factories/curated_collections.rb
@@ -6,6 +6,6 @@ FactoryBot.define do
     description { 'Sample curated collection' }
     subtitle { 'subtitle for a curated collection' }
     workflow { 'default' }
-    visibility { 'public' }
+    access_level { 'public' }
   end
 end

--- a/spec/factories/library_collections.rb
+++ b/spec/factories/library_collections.rb
@@ -6,6 +6,6 @@ FactoryBot.define do
     description { 'Sample library collection' }
     subtitle { 'subtitle for a library collection' }
     workflow { 'default' }
-    visibility { 'public' }
+    access_level { 'public' }
   end
 end

--- a/spec/support/shared/controllers.rb
+++ b/spec/support/shared/controllers.rb
@@ -7,7 +7,7 @@ RSpec.shared_examples 'a collection controller' do
       subtitle: 'use only for testing',
       description: 'A sample collection',
       workflow: 'default',
-      visibility: 'public'
+      access_level: 'public'
     }
   end
 
@@ -68,7 +68,7 @@ RSpec.shared_examples 'a collection controller' do
           subtitle: 'use only for testing',
           description: 'An updated sample collection',
           workflow: 'default',
-          visibility: 'public'
+          access_level: 'public'
         }
       end
 

--- a/spec/support/shared/models.rb
+++ b/spec/support/shared/models.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'a resource with Valkyrie::Resource::AccessControls' do
+  before do
+    raise 'resource_klass must be set with `let(:resource_klass)`' unless
+      defined? resource_klass
+  end
+
+  describe '#read_groups' do
+    it 'can be set via instantiation' do
+      resource = resource_klass.new(read_groups: ['one', 'two'])
+      expect(resource.read_groups).to eq ['one', 'two']
+    end
+
+    it 'is empty when not set' do
+      resource = resource_klass.new
+      expect(resource.read_groups).to be_empty
+    end
+
+    describe '#has_attribute?' do
+      it 'returns true when it has a given attribute' do
+        resource = resource_klass.new
+        expect(resource.has_attribute?(:read_groups)).to eq true
+      end
+    end
+
+    describe '#fields' do
+      it 'returns a set of fields' do
+        expect(resource_klass).to respond_to(:fields).with(0).arguments
+        expect(resource_klass.fields).to include(:read_groups)
+      end
+    end
+
+    describe '#attributes' do
+      it 'returns a list of all set attributes' do
+        resource = resource_klass.new(read_groups: ['one', 'two'])
+        expect(resource.attributes[:read_groups]).to eq ['one', 'two']
+      end
+    end
+  end
+
+  describe '#read_users' do
+    it 'can be set via instantiation' do
+      resource = resource_klass.new(read_users: ['one', 'two'])
+      expect(resource.read_users).to eq ['one', 'two']
+    end
+
+    it 'is empty when not set' do
+      resource = resource_klass.new
+      expect(resource.read_users).to be_empty
+    end
+
+    describe '#has_attribute?' do
+      it 'returns true when it has a given attribute' do
+        resource = resource_klass.new
+        expect(resource.has_attribute?(:read_users)).to eq true
+      end
+    end
+
+    describe '#fields' do
+      it 'returns a set of fields' do
+        expect(resource_klass).to respond_to(:fields).with(0).arguments
+        expect(resource_klass.fields).to include(:read_users)
+      end
+    end
+
+    describe '#attributes' do
+      it 'returns a list of all set attributes' do
+        resource = resource_klass.new(read_users: ['one', 'two'])
+        expect(resource.attributes[:read_users]).to eq ['one', 'two']
+      end
+    end
+  end
+
+  describe '#edit_users' do
+    it 'can be set via instantiation' do
+      resource = resource_klass.new(edit_users: ['one', 'two'])
+      expect(resource.edit_users).to eq ['one', 'two']
+    end
+
+    it 'is empty when not set' do
+      resource = resource_klass.new
+      expect(resource.edit_users).to be_empty
+    end
+
+    describe '#has_attribute?' do
+      it 'returns true when it has a given attribute' do
+        resource = resource_klass.new
+        expect(resource.has_attribute?(:edit_users)).to eq true
+      end
+    end
+
+    describe '#fields' do
+      it 'returns a set of fields' do
+        expect(resource_klass).to respond_to(:fields).with(0).arguments
+        expect(resource_klass.fields).to include(:edit_users)
+      end
+    end
+
+    describe '#attributes' do
+      it 'returns a list of all set attributes' do
+        resource = resource_klass.new(edit_users: ['one', 'two'])
+        expect(resource.attributes[:edit_users]).to eq ['one', 'two']
+      end
+    end
+  end
+
+  describe '#edit_groups' do
+    it 'can be set via instantiation' do
+      resource = resource_klass.new(edit_groups: ['one', 'two'])
+      expect(resource.edit_groups).to eq ['one', 'two']
+    end
+
+    it 'is empty when not set' do
+      resource = resource_klass.new
+      expect(resource.edit_groups).to be_empty
+    end
+
+    describe '#has_attribute?' do
+      it 'returns true when it has a given attribute' do
+        resource = resource_klass.new
+        expect(resource.has_attribute?(:edit_groups)).to eq true
+      end
+    end
+
+    describe '#fields' do
+      it 'returns a set of fields' do
+        expect(resource_klass).to respond_to(:fields).with(0).arguments
+        expect(resource_klass.fields).to include(:edit_groups)
+      end
+    end
+
+    describe '#attributes' do
+      it 'returns a list of all set attributes' do
+        resource = resource_klass.new(edit_groups: ['one', 'two'])
+        expect(resource.attributes[:edit_groups]).to eq ['one', 'two']
+      end
+    end
+  end
+end

--- a/spec/views/archival_collections/edit.html.erb_spec.rb
+++ b/spec/views/archival_collections/edit.html.erb_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'collection/archival_collections/edit', type: :view do
       assert_select 'input[name=?]', 'archival_collection[subtitle][]'
       assert_select 'textarea[name=?]', 'archival_collection[description][]'
       assert_select 'input[name=?]', 'archival_collection[workflow]'
-      assert_select 'input[name=?]', 'archival_collection[visibility]'
+      assert_select 'input[name=?]', 'archival_collection[access_level]'
       # Added to make sure accessibility changes are in place
       assert_select 'legend', 'Basic Metadata'
       assert_select 'label[for=?]', 'archival_collection_title', text: /\s.* required/

--- a/spec/views/archival_collections/new.html.erb_spec.rb
+++ b/spec/views/archival_collections/new.html.erb_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'collection/archival_collections/new', type: :view do
       assert_select 'input[name=?]', 'archival_collection[subtitle][]'
       assert_select 'textarea[name=?]', 'archival_collection[description][]'
       assert_select 'input[name=?]', 'archival_collection[workflow]'
-      assert_select 'input[name=?]', 'archival_collection[visibility]'
+      assert_select 'input[name=?]', 'archival_collection[access_level]'
       # Added to make sure accessibility changes are in place
       assert_select 'legend', 'Basic Metadata'
       assert_select 'label[for=?]', 'archival_collection_title', text: /\s.* required/

--- a/spec/views/curated_collections/edit.html.erb_spec.rb
+++ b/spec/views/curated_collections/edit.html.erb_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'collection/curated_collections/edit', type: :view do
       assert_select 'input[name=?]', 'curated_collection[subtitle][]'
       assert_select 'textarea[name=?]', 'curated_collection[description][]'
       assert_select 'input[name=?]', 'curated_collection[workflow]'
-      assert_select 'input[name=?]', 'curated_collection[visibility]'
+      assert_select 'input[name=?]', 'curated_collection[access_level]'
       # Added to make sure accessibility changes are in place
       assert_select 'legend', 'Basic Metadata'
       assert_select 'label[for=?]', 'curated_collection_title', text: /\s.* required/

--- a/spec/views/curated_collections/new.html.erb_spec.rb
+++ b/spec/views/curated_collections/new.html.erb_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'collection/curated_collections/new', type: :view do
       assert_select 'input[name=?]', 'curated_collection[subtitle][]'
       assert_select 'textarea[name=?]', 'curated_collection[description][]'
       assert_select 'input[name=?]', 'curated_collection[workflow]'
-      assert_select 'input[name=?]', 'curated_collection[visibility]'
+      assert_select 'input[name=?]', 'curated_collection[access_level]'
       # Added to make sure accessibility changes are in place
       assert_select 'legend', 'Basic Metadata'
       assert_select 'label[for=?]', 'curated_collection_title', text: /\s.* required/

--- a/spec/views/library_collections/edit.html.erb_spec.rb
+++ b/spec/views/library_collections/edit.html.erb_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'collection/library_collections/edit', type: :view do
       assert_select 'input[name=?]', 'library_collection[subtitle][]'
       assert_select 'textarea[name=?]', 'library_collection[description][]'
       assert_select 'input[name=?]', 'library_collection[workflow]'
-      assert_select 'input[name=?]', 'library_collection[visibility]'
+      assert_select 'input[name=?]', 'library_collection[access_level]'
       # Added to make sure accessibility changes are in place
       assert_select 'legend', 'Basic Metadata'
       assert_select 'label[for=?]', 'library_collection_title', text: /\s.* required/

--- a/spec/views/library_collections/new.html.erb_spec.rb
+++ b/spec/views/library_collections/new.html.erb_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'collection/library_collections/new', type: :view do
       assert_select 'input[name=?]', 'library_collection[subtitle][]'
       assert_select 'textarea[name=?]', 'library_collection[description][]'
       assert_select 'input[name=?]', 'library_collection[workflow]'
-      assert_select 'input[name=?]', 'library_collection[visibility]'
+      assert_select 'input[name=?]', 'library_collection[access_level]'
       # Added to make sure accessibility changes are in place
       assert_select 'legend', 'Basic Metadata'
       assert_select 'label[for=?]', 'library_collection_title', text: /\s.* required/


### PR DESCRIPTION
## Description

Access controls were already available to most of the resources in CHO, except file sets. This adds the controls to file sets, as well as as the tests for all the resources (collections, works, file sets) that ensures the access controls are working as expected.

Connected to #973 

## Changes

* add access controls to file sets
* create shared spec tests for access controls
* rename visibility to access level
