### PR TITLE
Add fits characterization to preservation files

### DIFF
--- a/app/cho/transaction/operations/import/work.rb
+++ b/app/cho/transaction/operations/import/work.rb
@@ -78,11 +78,23 @@ module Transaction
           # @param [Import::File] file
           # @return [Work::File]
           def import_file(file)
-            ::Work::File.new(
+            change_set = ::Work::FileChangeSet.new(::Work::File.new)
+
+            change_set.validate(
               file_identifier: adapter_file(file).id,
               original_filename: file.original_filename,
               use: file.type
             )
+
+            change_set.sync
+
+            if file.preservation?
+              Operations::File::Characterize.new.call(change_set)
+            end
+
+            change_set.sync
+
+            change_set.resource
           end
 
           def adapter_file(file)

--- a/spec/cho/transaction/operations/file/characterize_spec.rb
+++ b/spec/cho/transaction/operations/file/characterize_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Transaction::Operations::File::Characterize do
   let(:operation) { described_class.new }
   let(:collection) { create(:collection) }
   let(:change_set) { Work::FileChangeSet.new(resource) }
-  let(:fits_output) { File.read(Pathname.new(fixture_path).join('fits_output.xml')) }
 
   describe '#call' do
     context 'with a file' do
@@ -44,12 +43,6 @@ RSpec.describe Transaction::Operations::File::Characterize do
         expect(result).to be_failure
         expect(result.failure.message).to eq('Error characterizing file: Valkyrie::StorageAdapter::FileNotFound')
       end
-    end
-
-    def mock_fits_for_travis
-      return unless ENV['TRAVIS']
-
-      allow(Hydra::FileCharacterization).to receive(:characterize).and_return(fits_output)
     end
   end
 end

--- a/spec/cho/transaction/operations/file/save_spec.rb
+++ b/spec/cho/transaction/operations/file/save_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 RSpec.describe Transaction::Operations::File::Save do
   let(:operation) { described_class.new }
 
+  before { mock_fits_for_travis }
+
   describe '#call' do
     context 'with a successful save' do
       let!(:collection) { create(:collection) }
@@ -22,6 +24,18 @@ RSpec.describe Transaction::Operations::File::Save do
           expect(result.success).to eq(change_set)
           expect(result.success.member_ids.count).to eq(1)
         }.to change { Work::File.count }.by(2).and change { Work::FileSet.count }.by(1)
+      end
+
+      it 'persists the fits characterization to the preservation file' do
+        operation.call(change_set)
+
+        files = Work::File.all
+        expect(files.count).to eq(2) # Sanity
+        expect(files.select(&:preservation?).count).to eq(1) # Sanity
+
+        files.each do |f|
+          expect(f.fits_output.present?).to eq f.preservation?
+        end
       end
     end
 

--- a/spec/cho/transaction/operations/import/work_spec.rb
+++ b/spec/cho/transaction/operations/import/work_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Transaction::Operations::Import::Work do
     )
   end
 
+  before { mock_fits_for_travis }
+
   describe '#call' do
     context 'when there is no import work' do
       subject { operation.call(change_set) }
@@ -72,6 +74,18 @@ RSpec.describe Transaction::Operations::Import::Work do
           expect(result.success).to eq(change_set)
           expect(result.success.member_ids.count).to eq(1)
         }.to change { ::Work::File.count }.by(5).and change { ::Work::FileSet.count }.by(1)
+      end
+
+      it 'persists the fits characterization to the preservation file' do
+        operation.call(change_set)
+
+        files = ::Work::File.all
+        expect(files.count).to eq(5) # Sanity
+        expect(files.select(&:preservation?).count).to eq(1) # Sanity
+
+        files.each do |file|
+          expect(file.fits_output.present?).to eq file.preservation?
+        end
       end
     end
   end

--- a/spec/support/fits_mock.rb
+++ b/spec/support/fits_mock.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+def mock_fits_for_travis(output = nil)
+  mock_fits(output) if ENV['TRAVIS']
+end
+
+def mock_fits(output = nil)
+  allow(Hydra::FileCharacterization)
+    .to receive(:characterize)
+    .and_return(output || mock_fits_output)
+end
+
+def mock_fits_output
+  @mock_fits_output ||= File.read(
+    Pathname.new(fixture_path).join('fits_output.xml')
+  )
+end


### PR DESCRIPTION
## Description

Adds the FITs characterization output to Files and persists it. Works for CSV imports as well as GUI uploads. 

This commit also moves the fits mocking for travis into a spec support file for easy inclusion into any spec.

Connected to #620

## Changes

* operations:file:save adds fits characterization to the file if a preservation file
* operations:import:work adds fits characterizations to any preservation preservation file
* mocking fits for travis moved into its own spec support file
