### PR TITLE
Mock all the fits

### DIFF
--- a/spec/cho/transaction/operations/file/characterize_spec.rb
+++ b/spec/cho/transaction/operations/file/characterize_spec.rb
@@ -16,12 +16,11 @@ RSpec.describe Transaction::Operations::File::Characterize do
       let(:resource_params) { { label: 'abc123', file: temp_file } }
 
       before do
-        mock_fits_for_travis
         work_change_set.validate(resource_params)
         Transaction::Operations::File::Save.new.call(work_change_set)
       end
 
-      it 'returns Success' do
+      it 'returns Success', :with_fits do
         result = operation.call(change_set)
         expect(result).to be_success
         expect(result.success).to eq(change_set)

--- a/spec/cho/transaction/operations/file/save_spec.rb
+++ b/spec/cho/transaction/operations/file/save_spec.rb
@@ -5,8 +5,6 @@ require 'rails_helper'
 RSpec.describe Transaction::Operations::File::Save do
   let(:operation) { described_class.new }
 
-  before { mock_fits_for_travis }
-
   describe '#call' do
     context 'with a successful save' do
       let!(:collection) { create(:collection) }

--- a/spec/cho/transaction/operations/import/work_spec.rb
+++ b/spec/cho/transaction/operations/import/work_spec.rb
@@ -18,8 +18,6 @@ RSpec.describe Transaction::Operations::Import::Work do
     )
   end
 
-  before { mock_fits_for_travis }
-
   describe '#call' do
     context 'when there is no import work' do
       subject { operation.call(change_set) }

--- a/spec/support/fits_mock.rb
+++ b/spec/support/fits_mock.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-def mock_fits_for_travis(output = nil)
-  mock_fits(output) if ENV['TRAVIS']
-end
-
 def mock_fits(output = nil)
   allow(Hydra::FileCharacterization)
     .to receive(:characterize)
@@ -14,4 +10,10 @@ def mock_fits_output
   @mock_fits_output ||= File.read(
     Pathname.new(fixture_path).join('fits_output.xml')
   )
+end
+
+RSpec.configure do |config|
+  config.before do |example|
+    mock_fits if ENV['TRAVIS'] || !example.metadata.key?(:with_fits)
+  end
 end


### PR DESCRIPTION
## Description

Because the test suite runs reeeeealy slow if you're shelling out to fits all the time, let's just mock it for everything. Including the :with_fits keyword in a test scope will cause it to actually run, which we're only using in one test for now. Fits is always mocked in Travis.