### PR TITLE
Using documentation output for RSpec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,5 +1,5 @@
 --color
 --tty
---format progress
+--format documentation
 --profile
 --require spec_helper


### PR DESCRIPTION
## Description

Make RSpec's output a little more informative, showing the particular test that is being performed at the time. This could help with identifying errors in the test suite sooner.
