### PR TITLE
Install bundler

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -83,6 +83,17 @@ namespace :apache do
   end
 end
 
+namespace :rbenv do
+  desc 'Overrides task in capistrano-rbenv-install to install the correct version of the bundler gem'
+  task install_bundler: ['rbenv:map_bins'] do
+    on roles fetch(:rbenv_roles) do
+      next if test :gem, :query, "--quiet --installed --name-matches ^bundler (#{Bundler::VERSION})$"
+
+      execute :gem, :install, :bundler, "--quiet --no-document --version #{Bundler::VERSION}"
+    end
+  end
+end
+
 namespace :deploy do
   desc 'Verify yaml configuration files are present and contain the correct keys'
   task :check_configs do


### PR DESCRIPTION
## Description

Override the existing install_bundler task from the capistrano-rbenv-install gem to install the version of bundler that is used in the application. This avoids issues with incompatibilities between Ruby versions and versions of the bundler gem.
