### PR TITLE
Change Show, Edit, Cancel Links to Buttons for Accessibility

### DIFF
--- a/app/views/catalog/_document_edit_link.html.erb
+++ b/app/views/catalog/_document_edit_link.html.erb
@@ -1,1 +1,1 @@
-<%= link_to(t('cho.catalog.edit'), edit_cho_resource_path) if can? :edit, @document %>
+<%= button_to(t('cho.catalog.edit'), edit_cho_resource_path, method: 'get', class: 'btn btn-outline-secondary') if can? :edit, @document %>

--- a/app/views/collection/archival_collections/edit.html.erb
+++ b/app/views/collection/archival_collections/edit.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'collection/base/form', collection: @collection %>
 <%= render 'shared/form_delete', resource: @collection %>
-<%= link_to t('cho.archival_collection.edit.show'), polymorphic_path([:solr_document], id: @collection.id) %>
+<%= button_to t('cho.archival_collection.edit.show'), polymorphic_path([:solr_document], id: @collection.id), method: 'get', class: 'btn btn-outline-secondary' %>

--- a/app/views/collection/base/_form.html.erb
+++ b/app/views/collection/base/_form.html.erb
@@ -34,6 +34,6 @@
   <%= render '/work/submissions/errors', work: collection if collection.errors.any? %>
 
   <div class="actions">
-    <%= form.submit %>
+    <%= form.submit class: 'btn btn-outline-secondary' %>
   </div>
 <% end %>

--- a/app/views/collection/curated_collections/edit.html.erb
+++ b/app/views/collection/curated_collections/edit.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'collection/base/form', collection: @collection %>
 <%= render 'shared/form_delete', resource: @collection %>
-<%= link_to t('cho.curated_collection.edit.show'), polymorphic_path([:solr_document], id: @collection.id) %>
+<%= link_to t('cho.curated_collection.edit.show'), polymorphic_path([:solr_document], id: @collection.id), method: 'get', class: 'btn btn-outline-secondary' %>

--- a/app/views/collection/library_collections/edit.html.erb
+++ b/app/views/collection/library_collections/edit.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'collection/base/form', collection: @collection %>
 <%= render 'shared/form_delete', resource: @collection %>
-<%= link_to t('cho.library_collection.edit.show'), polymorphic_path([:solr_document], id: @collection.id) %>
+<%= link_to t('cho.library_collection.edit.show'), polymorphic_path([:solr_document], id: @collection.id), method: 'get', class: 'btn btn-outline-secondary' %>

--- a/app/views/shared/_form_delete.html.erb
+++ b/app/views/shared/_form_delete.html.erb
@@ -1,4 +1,4 @@
 <%= form_for(:delete, url: batch_delete_path, method: :post) do |form| %>
   <%= form.hidden_field :ids, multiple: true, value: resource.id %>
-  <%= form.submit t("cho.#{resource.model_name.i18n_key}.edit.delete_link") %>
+  <%= form.submit t("cho.#{resource.model_name.i18n_key}.edit.delete_link"), class: 'btn btn-outline-secondary' %>
 <% end %>

--- a/app/views/work/submissions/_form.html.erb
+++ b/app/views/work/submissions/_form.html.erb
@@ -14,6 +14,6 @@
   <%= render 'errors', work: work_form if work_form.errors.any? %>
 
   <div class="actions pt-4">
-    <%= form.submit work_form.submit_text %>
+    <%= form.submit work_form.submit_text, class: 'btn btn-outline-secondary' %>
   </div>
 <% end %>

--- a/app/views/work/submissions/edit.html.erb
+++ b/app/views/work/submissions/edit.html.erb
@@ -3,4 +3,4 @@
 
 <%= render partial: 'form', locals: { work_form: @work } %>
 <%= render 'shared/form_delete', resource: @work %>
-<%= link_to t('cho.work.edit.show_link'), polymorphic_path([:solr_document], id: @work.id) %>
+<%= button_to t('cho.work.edit.show_link'), polymorphic_path([:solr_document], id: @work.id), method: 'get', class: 'btn btn-outline-secondary' %>

--- a/spec/cho/collection/archival_collections/show_spec.rb
+++ b/spec/cho/collection/archival_collections/show_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Collection::Archival, type: :feature do
       expect(page).to have_content('Sample archival collection')
       expect(page).to have_content('default')
       expect(page).to have_content('public')
-      click_link('Edit')
+      click_button('Edit')
       expect(page).to have_field('archival_collection[title]', with: 'Archival Collection')
       expect(page).not_to have_link('Back')
     end

--- a/spec/cho/collection/curated_collections/show_spec.rb
+++ b/spec/cho/collection/curated_collections/show_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Collection::Curated, type: :feature do
       expect(page).to have_content('Sample curated collection')
       expect(page).to have_content('default')
       expect(page).to have_content('public')
-      click_link('Edit')
+      click_button('Edit')
       expect(page).to have_field('curated_collection[title]', with: 'Curated Collection')
       expect(page).not_to have_link('Back')
     end

--- a/spec/cho/collection/library_collections/show_spec.rb
+++ b/spec/cho/collection/library_collections/show_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Collection::Library, type: :feature do
       expect(page).to have_content('Sample library collection')
       expect(page).to have_content('default')
       expect(page).to have_content('public')
-      click_link('Edit')
+      click_button('Edit')
       expect(page).to have_field('library_collection[title]', with: 'Library Collection')
       expect(page).not_to have_link('Back')
     end

--- a/spec/cho/work/file_set/delete_spec.rb
+++ b/spec/cho/work/file_set/delete_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Deleting file sets', type: :feature do
     visit(polymorphic_path([:solr_document], id: Work::Submission.all.first.id))
     click_link('File Set to Delete')
     expect(page).to have_selector('td', text: 'hello_world.txt')
-    click_link('Edit')
+    click_button('Edit')
     click_button('Delete File Set')
     expect(page).to have_content('The following resources will be deleted')
     expect(page).to have_content(resource.title.first)

--- a/spec/cho/work/submissions/delete_spec.rb
+++ b/spec/cho/work/submissions/delete_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Deleting works', type: :feature do
   it 'removes the work and file from the system but retains its parent collection' do
     visit(polymorphic_path([:solr_document], id: resource.id))
     expect(page).to have_selector('li', text: 'hello_world.txt')
-    click_link('Edit')
+    click_button('Edit')
     click_button('Delete Resource')
     expect(page).to have_content('The following resources will be deleted')
     expect(page).to have_content(resource.title.first)

--- a/spec/cho/work/submissions/edit_spec.rb
+++ b/spec/cho/work/submissions/edit_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Editing works', type: :feature do
       expect(page).to have_field('work_submission_creator__agent', with: resource.creator.first[:agent])
       expect(page).to have_content('Editing Resource')
       expect(page).to have_selector('h2', text: 'Work to edit')
-      expect(page).to have_link('Show')
+      expect(page).to have_selector('input[type=submit][value=Show]')
       expect(page).to have_field('Description', type: 'textarea', with: nil)
       expect(page).not_to have_field('work_submission[file]')
       fill_in('work_submission[title]', with: 'Updated Work Title')

--- a/spec/cho/work/submissions/new_spec.rb
+++ b/spec/cho/work/submissions/new_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Work::Submission, type: :feature do
         expect(page).to have_blacklight_label(:creator_tesim)
         expect(page).to have_blacklight_field(:creator_tesim, 'Christopher Kringle (climbing)')
       end
-      expect(page).to have_link('Edit')
+      expect(page).to have_selector('input[type=submit][value=Edit]')
     end
   end
 
@@ -74,7 +74,7 @@ RSpec.describe Work::Submission, type: :feature do
       click_button('Create Resource')
       expect(page).to have_content('Required Title')
       expect(page).to have_content('Document')
-      expect(page).to have_link('Edit')
+      expect(page).to have_selector('input[type=submit][value=Edit]')
     end
   end
 
@@ -99,7 +99,7 @@ RSpec.describe Work::Submission, type: :feature do
       click_button('Create Resource')
       expect(page).to have_content('New Title')
       expect(page).to have_content('Generic')
-      expect(page).to have_link('Edit')
+      expect(page).to have_selector('input[type=submit][value=Edit]')
       expect(page).to have_selector('h2', text: 'Parts')
       expect(page).to have_content('hello_world.txt')
     end
@@ -130,7 +130,7 @@ RSpec.describe Work::Submission, type: :feature do
       click_button('Create Resource')
       expect(page).to have_content('Work with attached zip')
       expect(page).to have_content('Generic')
-      expect(page).to have_link('Edit')
+      expect(page).to have_selector('input[type=submit][value=Edit]')
       expect(page).to have_selector('h2', text: 'Parts')
       expect(page).to have_content('work1_preservation.tif')
     end
@@ -176,7 +176,7 @@ RSpec.describe Work::Submission, type: :feature do
       expect(page).to have_content('Generic')
       expect(page).to have_xpath("//img[@src='/files/work1_thumb.jpg']")
       expect(page).to have_xpath("//img[@alt='Work1 thumb']")
-      expect(page).to have_link('Edit')
+      expect(page).to have_selector('input[type=submit][value=Edit]')
       expect(page).to have_selector('h2', text: 'Parts')
       expect(page).to have_content('work1_00001_01_preservation.tif')
       expect(page).to have_content('work1_00001_02_preservation.tif')
@@ -218,7 +218,7 @@ RSpec.describe Work::Submission, type: :feature do
       expect(page).to have_content('Generic')
       expect(page).to have_xpath("//img[@src='/files/work1_00001_thumb.png']")
       expect(page).to have_xpath("//img[@alt='Work1 00001 thumb']")
-      expect(page).to have_link('Edit')
+      expect(page).to have_selector('input[type=submit][value=Edit]')
       expect(page).to have_selector('h2', text: 'Parts')
       expect(page).to have_link('work1_00001_preservation.tif')
 

--- a/spec/cho/work/submissions/show_spec.rb
+++ b/spec/cho/work/submissions/show_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Work::Submission, type: :feature do
       )
       expect(page).to have_selector('h2', text: 'Parts')
       expect(page).to have_content('hello_world.txt')
-      click_link('Edit')
+      click_button('Edit')
       expect(page).to have_field('work_submission[title]', with: 'An editable file')
       expect(page).not_to have_select('work_submission[work_type]', with_selected: 'Generic')
     end

--- a/spec/support/shared/collections.rb
+++ b/spec/support/shared/collections.rb
@@ -77,9 +77,9 @@ end
 
 RSpec.shared_examples 'a collection editable only by admins' do
   context 'when the current user is an admin' do
-    it 'shows the edit link' do
+    it 'shows the edit button' do
       visit(polymorphic_path([:solr_document], id: collection.id))
-      expect(page).to have_link('Edit')
+      expect(page).to have_selector('input[type=submit][value=Edit]')
     end
   end
 
@@ -87,7 +87,7 @@ RSpec.shared_examples 'a collection editable only by admins' do
     it 'disables the edit link' do
       visit(polymorphic_path([:solr_document], id: collection.id))
 
-      expect(page).not_to have_link I18n.t('cho.catalog.edit')
+      expect(page).not_to have_selector('input[type=submit][value=Edit]')
     end
   end
 
@@ -95,7 +95,7 @@ RSpec.shared_examples 'a collection editable only by admins' do
     it 'disables the edit link' do
       visit(polymorphic_path([:solr_document], id: collection.id))
 
-      expect(page).not_to have_link I18n.t('cho.catalog.edit')
+      expect(page).not_to have_selector('input[type=submit][value=Edit]')
     end
   end
 end

--- a/spec/views/archival_collections/edit.html.erb_spec.rb
+++ b/spec/views/archival_collections/edit.html.erb_spec.rb
@@ -24,6 +24,6 @@ RSpec.describe 'collection/archival_collections/edit', type: :view do
       assert_select 'legend', 'Workflow'
       assert_select 'legend', 'Access Level'
     end
-    assert_select 'a[href=?]', "/catalog/#{collection.id}"
+    assert_select 'form[action=?]', "/catalog/#{collection.id}"
   end
 end

--- a/spec/views/work_submissions/edit.html.erb_spec.rb
+++ b/spec/views/work_submissions/edit.html.erb_spec.rb
@@ -75,6 +75,6 @@ RSpec.describe 'work/submissions/edit', type: :view do
       assert_select 'input[name=?]', "work_submission[#{specific_field}][]"
       assert_select 'label[for=?]', 'work_submission_file', false
     end
-    assert_select 'a[href=?]', "/catalog/#{@work.id}"
+    assert_select 'form[action=?]', "/catalog/#{@work.id}"
   end
 end


### PR DESCRIPTION
Swaps the links for buttons on the show, edit UI elements in the forms based on accessibility feedback.


## Description

Based on accessibility testing feedback, the user though it would be better if the links were buttons. They would "jump out" a little better and be more recognizable than just links.

Connected to #868 

## Changes

* swap links for buttons 
* update the tests
