### PR TITLE
Adds Fieldset to Upload Button for Better Accessibility

### DIFF
--- a/app/views/work/submissions/_form.html.erb
+++ b/app/views/work/submissions/_form.html.erb
@@ -7,8 +7,10 @@
 
   <% if form.object.new_record %>
     <%= form.hidden_field :file, value: work_form.model.cached_file_data %>
-    <%= form.label :file, t('cho.form.file_selection') %>
-    <%= form.file_field :file %>
+    <%= field_set_tag t('cho.form.legend') do %>
+      <%= form.label :file, t('cho.form.file_selection') %>
+      <%= form.file_field :file %>
+    <% end %>
   <% end %>
 
   <%= render 'errors', work: work_form if work_form.errors.any? %>

--- a/config/locales/cho.yml
+++ b/config/locales/cho.yml
@@ -22,6 +22,7 @@ en:
       metadata: "Basic Metadata"
       workflow: "Workflow"
       access_level: "Access Level"
+      legend: "Upload Files"
       file_selection: "File Selection"
       required: "required"
     field_label:


### PR DESCRIPTION
Adds a fieldset to organize the label for the file browse and upload functionality of the form for better accessibility.

## Description

During user accessibility testing, the user didn't immediately find the upload button among all of the metadata fields. Suggestion was to add a fieldset to make it more noticeable and navigable.

Connected to #867 

## Changes

* Adds fieldset and legend
