### PR TITLE
Can delete Agents only if they have no members

### DIFF
--- a/app/cho/agent/change_set.rb
+++ b/app/cho/agent/change_set.rb
@@ -10,6 +10,8 @@ module Agent
 
     validates :given_name, :surname, with: :unique_name
 
+    delegate :member_ids, to: :resource
+
     def to_s
       "#{given_name} #{surname}"
     end

--- a/app/cho/agent/resource.rb
+++ b/app/cho/agent/resource.rb
@@ -16,5 +16,29 @@ module Agent
     def display_name
       "#{surname}#{NAME_SEPARATOR} #{given_name}"
     end
+
+    def member_ids
+      @member_ids ||= load_member_ids_from_solr
+    end
+
+    private
+
+      # @note this same information can be loaded from Postgres if you so desire:
+      #   SELECT id FROM orm_resources
+      #   WHERE metadata->'creator' @> '[{"agent": "#{id}"}]'
+      def load_member_ids_from_solr
+        solr_connection = Valkyrie::MetadataAdapter
+          .find(:index_solr)
+          .connection
+
+        query = {
+          q: "creator_agent_id_ssim:#{id}",
+          fl: 'id'
+        }
+
+        solr_connection.get('select', params: query)
+          .dig('response', 'docs')
+          .map { |doc| Valkyrie::ID.new doc['id'] }
+      end
   end
 end

--- a/app/devise/ability.rb
+++ b/app/devise/ability.rb
@@ -10,6 +10,7 @@ class Ability
     base_permissions
     authenticated_permissions
     admin_permissions
+    cannot_delete_agent_with_members
   ]
 
   def base_permissions
@@ -27,5 +28,11 @@ class Ability
 
   def admin_permissions
     can :manage, :all if current_user&.admin?
+  end
+
+  def cannot_delete_agent_with_members
+    cannot :delete, Agent::Resource do |agent|
+      agent.member_ids.any?
+    end
   end
 end

--- a/app/views/agent/resources/index.html.erb
+++ b/app/views/agent/resources/index.html.erb
@@ -17,6 +17,7 @@
         <td><%= link_to t('cho.agent.index.show'), agent %></td>
         <td><%= link_to(t('cho.agent.index.edit'), edit_agent_resource_path(agent)) if can? :edit, agent %></td>
         <td>
+          <%# @todo this contains an N+1 query bug, may need to be optimized %>
           <%= if can? :delete, agent
                 link_to(t('cho.agent.index.destroy'), agent,
                         method: :delete, data: { confirm: t('cho.agent.index.confirm') })

--- a/spec/cho/agent/agent_spec.rb
+++ b/spec/cho/agent/agent_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe Agent::Resource, type: :model do
                       given_name: 'sally',
                       surname: 'brown' }
 
+  let(:saved_model) { Valkyrie.config.metadata_adapter.persister.save(resource: model) }
+
   it_behaves_like 'a Valkyrie::Resource'
 
   it { is_expected.to respond_to(:given_name) }
@@ -19,7 +21,6 @@ RSpec.describe Agent::Resource, type: :model do
   context 'when saving with metadata' do
     subject { saved_model }
 
-    let(:saved_model) { Valkyrie.config.metadata_adapter.persister.save(resource: model) }
     let(:expected_metadata) { { given_name: 'sally',
                                 created_at: saved_model.created_at,
                                 internal_resource: 'Agent::Resource',
@@ -29,5 +30,24 @@ RSpec.describe Agent::Resource, type: :model do
                                 updated_at: saved_model.updated_at } }
 
     its(:attributes) { is_expected.to eq(expected_metadata) }
+  end
+
+  describe '#member_ids' do
+    context 'when the agent has no members' do
+      it 'returns an empty array' do
+        expect(saved_model.member_ids).to eq []
+      end
+    end
+
+    context 'when the agent has members' do
+      let!(:work) { create :work_submission, :with_creator }
+      let(:agent) { Agent::Resource.find(work.creator.first.fetch(:agent)) }
+
+      before { raise 'sanity' if agent.blank? }
+
+      it "returns an array of its members' Valkyrie IDs" do
+        expect(agent.member_ids).to eq [work.id]
+      end
+    end
   end
 end

--- a/spec/cho/agent/change_set_spec.rb
+++ b/spec/cho/agent/change_set_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 RSpec.describe Agent::ChangeSet, type: :model do
   subject(:change_set) { described_class.new(Agent::Resource.new) }
 
+  it { is_expected.to delegate_method(:member_ids).to(:resource) }
+
   describe '#validate' do
     context 'when given name is missing' do
       subject { change_set.errors }

--- a/spec/devise/ability_spec.rb
+++ b/spec/devise/ability_spec.rb
@@ -16,6 +16,25 @@ RSpec.describe Ability do
     let(:user) { build_stubbed :admin }
 
     it { is_expected.to be_able_to(:manage, :all) }
+
+    describe 'special rules for Agents' do
+      context 'given an agent with no members' do
+        let(:agent) { create :agent }
+
+        before { raise 'sanity' if agent.member_ids.any? }
+
+        it { is_expected.to be_able_to(:delete, agent) }
+      end
+
+      context 'given an agent with members' do
+        let(:work) { create :work, :with_creator }
+        let(:agent) { Agent::Resource.find(work.creator.first.fetch(:agent)) }
+
+        before { raise 'sanity' if agent.member_ids.empty? }
+
+        it { is_expected.not_to be_able_to(:delete, agent) }
+      end
+    end
   end
 
   describe '#authenticated_permissions' do


### PR DESCRIPTION
## Description

If an Agent has any members (for example, works they're listed as a creator upon), the delete link is hidden. Otherwise the delete link is visible, with a javascript "are you sure...?" confirmation.

Connected to #837 

## Changes

* Add method to fetch member ids of an Agent
* Update Ability class to ensure an Agent has no members before allowing it to be deleted
