### PR TITLE
Use registered group to govern access

### DIFF
--- a/app/devise/ability.rb
+++ b/app/devise/ability.rb
@@ -8,7 +8,6 @@ class Ability
 
   self.ability_logic += %i[
     base_permissions
-    authenticated_permissions
     admin_permissions
     cannot_delete_agent_with_members
   ]
@@ -20,10 +19,6 @@ class Ability
       devise_remote
       session
     ]
-  end
-
-  def authenticated_permissions
-    can :read, :all if current_user.login?
   end
 
   def admin_permissions

--- a/app/devise/user.rb
+++ b/app/devise/user.rb
@@ -32,6 +32,8 @@ class User < ApplicationRecord
     end
 
     def default_groups
-      [Repository::AccessLevel.public]
+      return [] if login.blank?
+
+      [Repository::AccessLevel.psu]
     end
 end

--- a/spec/devise/ability_spec.rb
+++ b/spec/devise/ability_spec.rb
@@ -16,31 +16,27 @@ RSpec.describe Ability do
     let(:user) { build_stubbed :admin }
 
     it { is_expected.to be_able_to(:manage, :all) }
-
-    describe 'special rules for Agents' do
-      context 'given an agent with no members' do
-        let(:agent) { create :agent }
-
-        before { raise 'sanity' if agent.member_ids.any? }
-
-        it { is_expected.to be_able_to(:delete, agent) }
-      end
-
-      context 'given an agent with members' do
-        let(:work) { create :work, :with_creator }
-        let(:agent) { Agent::Resource.find(work.creator.first.fetch(:agent)) }
-
-        before { raise 'sanity' if agent.member_ids.empty? }
-
-        it { is_expected.not_to be_able_to(:delete, agent) }
-      end
-    end
   end
 
-  describe '#authenticated_permissions' do
-    let(:user) { build_stubbed :psu_user }
+  describe '#cannot_delete_agent_with_members' do
+    let(:user) { build_stubbed :admin }
 
-    it { is_expected.to be_able_to(:read, :all) }
+    context 'given an agent with no members' do
+      let(:agent) { create :agent }
+
+      before { raise 'sanity' if agent.member_ids.any? }
+
+      it { is_expected.to be_able_to(:delete, agent) }
+    end
+
+    context 'given an agent with members' do
+      let(:work) { create :work, :with_creator }
+      let(:agent) { Agent::Resource.find(work.creator.first.fetch(:agent)) }
+
+      before { raise 'sanity' if agent.member_ids.empty? }
+
+      it { is_expected.not_to be_able_to(:delete, agent) }
+    end
   end
 
   describe '#base_permissions' do

--- a/spec/devise/user_spec.rb
+++ b/spec/devise/user_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe User, type: :model do
 
       it 'returns a list of groups from the database' do
         expect(user).not_to receive(:populate_attributes)
-        expect(user.groups).to contain_exactly('group1', 'group2', Repository::AccessLevel.public)
+        expect(user.groups).to contain_exactly('group1', 'group2', Repository::AccessLevel.psu)
       end
     end
 
@@ -47,7 +47,7 @@ RSpec.describe User, type: :model do
 
       it 'returns a list of groups from the database' do
         expect(PsuDir::LdapUser).to receive(:get_groups).with(user.login).and_return(groups)
-        expect(user.groups).to contain_exactly('group1', 'group2', Repository::AccessLevel.public)
+        expect(user.groups).to contain_exactly('group1', 'group2', Repository::AccessLevel.psu)
       end
     end
 
@@ -57,7 +57,7 @@ RSpec.describe User, type: :model do
 
       it 'returns a list of groups from the database' do
         expect(PsuDir::LdapUser).to receive(:get_groups).with(user.login).and_return(groups)
-        expect(user.groups).to contain_exactly('group1', 'group2', Repository::AccessLevel.public)
+        expect(user.groups).to contain_exactly('group1', 'group2', Repository::AccessLevel.psu)
       end
     end
 
@@ -66,7 +66,7 @@ RSpec.describe User, type: :model do
 
       it 'returns a the default list of groups' do
         expect(PsuDir::LdapUser).to receive(:get_groups).with(user.login).and_return([])
-        expect(user.groups).to contain_exactly(Repository::AccessLevel.public)
+        expect(user.groups).to contain_exactly(Repository::AccessLevel.psu)
       end
     end
   end


### PR DESCRIPTION
## Description

Blanket read ability should not be given to any registered user, only read access to resources that have explicitly granted such access to a registered user.

There also does not need to be a public group. Public membership is implied for all users.

## Changes

* replace public with psu as the default groups for registered users
* remove read access to any resource for authenticated users
