### PR TITLE
Adding a local CodeClimate config file

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,12 @@
+version: 2
+exclude_patterns:
+  - "config/"
+  - "db/"
+  - "**/node_modules/"
+  - "script/"
+  - "**/spec/"
+  - "**/vendor/"
+  - "babel.config.js"
+  - "app/cho/transaction/operations/file/process.rb"
+  - "app/cho/transaction/shared/save_with_change_set.rb"
+  - "app/cho/transaction/shared/save_with_resource.rb"


### PR DESCRIPTION
## Description

Adds a local CodeClimate config file to better track which files we exclude, and other future settings for the service.
