### PR TITLE
Add an edtf date to the core fields of test data dictionary

### DIFF
--- a/config/data_dictionary/data_dictionary_test.csv
+++ b/config/data_dictionary/data_dictionary_test.csv
@@ -14,3 +14,4 @@ map_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,n
 audio_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false
 alternate_ids,alternate_id,required_to_publish,unique,true,no_vocabulary,,Identifier,no_transformation,no_facet,help me,true
 creator,creator,optional,creator,true,creator_vocabulary,,Creator,no_transformation,linked_field,help me,true
+date_cataloged,date,optional,edtf_date,true,no_vocabulary,,Date Cataloged,no_transformation,date,help me,true

--- a/spec/blacklight/solr_document_spec.rb
+++ b/spec/blacklight/solr_document_spec.rb
@@ -91,6 +91,7 @@ RSpec.describe SolrDocument, type: :model do
       'description,' \
       'alternate_ids,' \
       'creator,' \
+      'date_cataloged,' \
       'acknowledgments,' \
       'audio_field,' \
       'created,' \
@@ -113,16 +114,16 @@ RSpec.describe SolrDocument, type: :model do
       }
     end
 
-    it { is_expected.to eq("#{csv_header}\nabc123,,my_title,,,,,,,,,value1||value2,xyx789,,,,\n") }
+    it { is_expected.to eq("#{csv_header}\nabc123,,my_title,,,,,,,,,,value1||value2,xyx789,,,,\n") }
 
     context 'with a collection containing works and file sets' do
       let(:collection) { create :library_collection }
       let(:work) { create :work, :with_file, home_collection_id: [collection.id], title: 'Work One' }
-      let(:work1_csv) { "#{work.id},Generic,Work One,,,,,,,,,,#{collection.id},,,," }
-      let(:file_set1_csv) { "#{work.member_ids.first},,hello_world.txt,,,,,,,,,,,,,," }
+      let(:work1_csv) { "#{work.id},Generic,Work One,,,,,,,,,,,#{collection.id},,,," }
+      let(:file_set1_csv) { "#{work.member_ids.first},,hello_world.txt,,,,,,,,,,,,,,," }
       let(:work2) { create :work, :with_file, home_collection_id: [collection.id], title: 'Work Two' }
-      let(:work2_csv) { "#{work2.id},Generic,Work Two,,,,,,,,,,#{collection.id},,,," }
-      let(:file_set2_csv) { "#{work2.member_ids.first},,hello_world.txt,,,,,,,,,,,,,," }
+      let(:work2_csv) { "#{work2.id},Generic,Work Two,,,,,,,,,,,#{collection.id},,,," }
+      let(:file_set2_csv) { "#{work2.member_ids.first},,hello_world.txt,,,,,,,,,,,,,,," }
 
       let(:document) do
         { 'internal_resource_tsim' => 'MyCollection', id: collection.id, title_tesim: ['my_collection'] }
@@ -154,8 +155,8 @@ RSpec.describe SolrDocument, type: :model do
       end
 
       let(:file_set) { create(:file_set) }
-      let(:work_csv) { 'abc123,,my_title,,,,,,,,,value1||value2,xyx789,,,,' }
-      let(:file_set_csv) { "#{file_set.id},,Original File Name,,,,,,,,,,,,,," }
+      let(:work_csv) { 'abc123,,my_title,,,,,,,,,,value1||value2,xyx789,,,,' }
+      let(:file_set_csv) { "#{file_set.id},,Original File Name,,,,,,,,,,,,,,," }
 
       before { file_set }
 

--- a/spec/cho/collection/change_set_behaviors_spec.rb
+++ b/spec/cho/collection/change_set_behaviors_spec.rb
@@ -93,6 +93,7 @@ RSpec.describe Collection::ChangeSetBehaviors do
         'title',
         'alternate_ids',
         'creator',
+        'date_cataloged',
         'acknowledgments',
         'narrative'
       )
@@ -109,6 +110,7 @@ RSpec.describe Collection::ChangeSetBehaviors do
         'title',
         'alternate_ids',
         'creator',
+        'date_cataloged',
         'acknowledgments',
         'narrative'
       )

--- a/spec/cho/data_dictionary/field_spec.rb
+++ b/spec/cho/data_dictionary/field_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe DataDictionary::Field, type: :model do
   describe '#core' do
     subject { described_class.core_fields.to_a.map(&:label) }
 
-    it { is_expected.to eq(['title', 'subtitle', 'description', 'alternate_ids', 'creator']) }
+    it { is_expected.to eq(['title', 'subtitle', 'description', 'alternate_ids', 'creator', 'date_cataloged']) }
   end
 
   describe '#multiple' do

--- a/spec/cho/schema/configuration_spec.rb
+++ b/spec/cho/schema/configuration_spec.rb
@@ -90,8 +90,8 @@ RSpec.describe Schema::Configuration, type: :model do
   describe '#core_field_ids' do
     it 'does not create more fields since the defaults were loaded' do
       expect {
-        expect(schema_configuration.core_field_ids('Generic').count).to eq(5)
-        expect(schema_configuration.core_field_count('Generic')).to eq(5)
+        expect(schema_configuration.core_field_ids('Generic').count).to eq(6)
+        expect(schema_configuration.core_field_count('Generic')).to eq(6)
       }.to change { Valkyrie.config.metadata_adapter.query_service.find_all.count }.by(0)
     end
   end
@@ -129,10 +129,10 @@ RSpec.describe Schema::Configuration, type: :model do
       it 'adds a Schema::MetadataField, a Work::Type, and a Schema::Metadata' do
         expect {
           schema_configuration.load_work_types
-        }.to change { Schema::MetadataField.all.count }.by(6) # 5 core fields + 1 other field
+        }.to change { Schema::MetadataField.all.count }.by(7) # 6 core fields + 1 other field
           .and change { Work::Type.all.count }.by(1)
           .and change { Schema::Metadata.all.count }.by(1)
-          .and change { Valkyrie.config.metadata_adapter.query_service.find_all.count }.by(8)
+          .and change { Valkyrie.config.metadata_adapter.query_service.find_all.count }.by(9)
         expect(title_field.display_name).to eq('my title')
       end
     end

--- a/spec/cho/schema/metadata_core_fields_spec.rb
+++ b/spec/cho/schema/metadata_core_fields_spec.rb
@@ -11,13 +11,14 @@ RSpec.describe Schema::MetadataCoreFields, type: :model do
                                             'subtitle',
                                             'description',
                                             'alternate_ids',
-                                            'creator'])
-    expect(core_fields.map(&:order_index)).to eq([0, 1, 2, 3, 4])
+                                            'creator',
+                                            'date_cataloged'])
+    expect(core_fields.map(&:order_index)).to eq([0, 1, 2, 3, 4, 5])
   end
 
   it 'saves the core fields' do
     saved_core_fields = core_fields.map { |field| Schema::MetadataField.find(field.id) }
-    expect(saved_core_fields.map(&:order_index)).to eq([0, 1, 2, 3, 4])
+    expect(saved_core_fields.map(&:order_index)).to eq([0, 1, 2, 3, 4, 5])
   end
 
   context 'multiple work types' do
@@ -26,7 +27,7 @@ RSpec.describe Schema::MetadataCoreFields, type: :model do
 
     it 'saves different core fields based on type' do
       core_field_ids = generic_core_fields.map(&:id) + document_core_fields.map(&:id)
-      expect(core_field_ids.uniq.count).to eq(10)
+      expect(core_field_ids.uniq.count).to eq(12)
     end
   end
 end

--- a/spec/cho/schema/work_type_configuration_spec.rb
+++ b/spec/cho/schema/work_type_configuration_spec.rb
@@ -46,11 +46,11 @@ RSpec.describe Schema::WorkTypeConfiguration, type: :model do
 
     it 'creates a field based on the work type' do
       expect(schema_fields.count).to eq(3)
-      expect(schema_fields[0].order_index).to eq(6)
+      expect(schema_fields[0].order_index).to eq(7)
       expect(schema_fields[0].label).to eq('generic_field')
       expect(schema_fields[0].work_type).to eq(work_type)
       expect(schema_fields[0].requirement_designation).to eq('optional')
-      expect(schema_fields[1].order_index).to eq(7)
+      expect(schema_fields[1].order_index).to eq(8)
       expect(schema_fields[1].label).to eq('home_collection_id')
       expect(schema_fields[1].work_type).to eq(work_type)
       expect(schema_fields[1].requirement_designation).to eq('required')
@@ -67,7 +67,7 @@ RSpec.describe Schema::WorkTypeConfiguration, type: :model do
 
       it 'creates a field based on the work type' do
         expect(schema_fields.count).to eq(3)
-        expect(schema_fields.map(&:order_index)).to contain_exactly(25, 6, 7)
+        expect(schema_fields.map(&:order_index)).to contain_exactly(25, 7, 8)
         expect(schema_fields.map(&:label)).to contain_exactly('subtitle', 'audio_field', 'home_collection_id')
         expect(schema_fields.map(&:work_type).uniq).to contain_exactly(work_type)
         expect(schema_fields.map(&:display_name)).to contain_exactly('Additional Info', nil, 'Collection')

--- a/spec/cho/work/file_set_change_set_spec.rb
+++ b/spec/cho/work/file_set_change_set_spec.rb
@@ -71,7 +71,8 @@ RSpec.describe Work::FileSetChangeSet do
         'description',
         'title',
         'alternate_ids',
-        'creator'
+        'creator',
+        'date_cataloged'
       )
     end
   end

--- a/spec/cho/work/import/update_spec.rb
+++ b/spec/cho/work/import/update_spec.rb
@@ -102,21 +102,22 @@ RSpec.describe 'Preview of CSV Update', type: :feature do
     # Create a new csv with updated values for testing
     let(:csv_update_file) do
       matrix = CSV.parse(SolrDocument.find('work1').export_as_csv)
+      col_idx = matrix.first.each_with_index.to_h # Look up column indexes by header
 
       matrix.each_with_index do |row, i|
         next if i == 0
 
-        row[2] = titles[i - 1]
-        row[3] = MetadataFactory.fancy_title
-        row[4] = Faker::Lorem.paragraph
+        row[col_idx['title']] = titles[i - 1]
+        row[col_idx['subtitle']] = MetadataFactory.fancy_title
+        row[col_idx['description']] = Faker::Lorem.paragraph
 
-        row[6] = if i == 1
-                   agent.display_name.to_s
-                 else
-                   "#{agent.display_name}#{CsvParsing::SUBVALUE_SEPARATOR}cli"
-                 end
+        row[col_idx['creator']] = if i == 1
+                                    agent.display_name.to_s
+                                  else
+                                    "#{agent.display_name}#{CsvParsing::SUBVALUE_SEPARATOR}cli"
+                                  end
 
-        row[9] = dates[i - 1]
+        row[col_idx['created']] = dates[i - 1]
       end
 
       Tempfile.open do |csv_file|
@@ -128,13 +129,14 @@ RSpec.describe 'Preview of CSV Update', type: :feature do
     # Create a new csv with incorrect updated values
     let(:csv_update_file_with_errors) do
       matrix = CSV.parse(SolrDocument.find('work1').export_as_csv)
+      col_idx = matrix.first.each_with_index.to_h # Look up column indexes by header
 
       matrix.each_with_index do |row, i|
         next if i == 0
 
-        row[2] = missing_titles[i - 1]
-        row[6] = [nil, nil, nil, nil, 'Dude, Bad Agent', nil][i - 1]
-        row[9] = bad_dates[i - 1]
+        row[col_idx['title']] = missing_titles[i - 1]
+        row[col_idx['creator']] = [nil, nil, nil, nil, 'Dude, Bad Agent', nil][i - 1]
+        row[col_idx['created']] = bad_dates[i - 1]
       end
 
       Tempfile.open do |csv_file|

--- a/spec/cho/work/submissions/change_set_spec.rb
+++ b/spec/cho/work/submissions/change_set_spec.rb
@@ -178,6 +178,7 @@ RSpec.describe Work::SubmissionChangeSet do
             'description',
             'alternate_ids',
             'creator',
+            'date_cataloged',
             'generic_field',
             'home_collection_id',
             'created'
@@ -200,6 +201,7 @@ RSpec.describe Work::SubmissionChangeSet do
               'description',
               'alternate_ids',
               'creator',
+              'date_cataloged',
               'home_collection_id',
               'created'
             ]
@@ -216,6 +218,7 @@ RSpec.describe Work::SubmissionChangeSet do
                                                                               'description',
                                                                               'generic_field',
                                                                               'alternate_ids',
+                                                                              'date_cataloged',
                                                                               'home_collection_id',
                                                                               'created',
                                                                               'title',

--- a/spec/cho/work/submissions/new_spec.rb
+++ b/spec/cho/work/submissions/new_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Work::Submission, type: :feature do
       fill_in('work_submission[subtitle][]', with: 'New subtitle')
       fill_in('work_submission[description][]', with: 'Description of new generic work.')
       fill_in('work_submission[alternate_ids][]', with: 'asdf_1234')
+      fill_in('work_submission[date_cataloged][]', with: '2019-06-03')
       fill_in('work_submission[generic_field][]', with: 'Sample generic field value')
       fill_in('work_submission[created][]', with: '2018-10-22')
       fill_in('work_submission[home_collection_id]', with: archival_collection.id)


### PR DESCRIPTION

## Description

We need an edtf date to be part of the _core_ data dictionary fields in order to test searching on them

## Changes

* copy `date_cataloged` over from dev data dictionary verbatim
* update a gazillion specs