### PR TITLE
Setting access rights in CSV

### DIFF
--- a/app/blacklight/catalog_controller.rb
+++ b/app/blacklight/catalog_controller.rb
@@ -180,14 +180,12 @@ class CatalogController < ApplicationController
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
     config.add_index_field 'work_type_ssim', label: I18n.t('cho.field_label.work_type')
-    config.add_index_field 'access_level_ssim', label: I18n.t('cho.field_label.access_level')
     config.add_index_field 'workflow_ssim', label: I18n.t('cho.field_label.workflow')
     config.add_index_field 'collection_type_ssim', label: I18n.t('cho.field_label.collection_type')
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
     config.add_show_field 'work_type_ssim', label: I18n.t('cho.field_label.work_type')
-    config.add_show_field 'access_level_ssim', label: I18n.t('cho.field_label.access_level')
     config.add_show_field 'workflow_ssim', label: I18n.t('cho.field_label.workflow')
     config.add_show_field 'collection_type_ssim', label: I18n.t('cho.field_label.collection_type')
 

--- a/app/cho/collection/change_set_behaviors.rb
+++ b/app/cho/collection/change_set_behaviors.rb
@@ -10,10 +10,6 @@ module Collection::ChangeSetBehaviors
     property :workflow, multiple: false, required: true
     validates :workflow, inclusion: { in: ::Collection::CommonFields::WORKFLOW }
     validates :workflow, presence: true
-
-    property :access_level, multiple: false, required: true
-    validates :access_level, inclusion: { in: Repository::AccessLevel.names }
-    validates :access_level, presence: true
   end
 
   # @return [Array<Schema::MetadataField>]

--- a/app/cho/collection/common_fields.rb
+++ b/app/cho/collection/common_fields.rb
@@ -9,6 +9,5 @@ module Collection::CommonFields
 
   included do
     attribute :workflow, Valkyrie::Types::Set.of(Valkyrie::Types::String.enum(*WORKFLOW))
-    attribute :access_level, Valkyrie::Types::Set.of(Valkyrie::Types::String.enum(*Repository::AccessLevel.names))
   end
 end

--- a/app/cho/controlled_vocabulary/access_rights.rb
+++ b/app/cho/controlled_vocabulary/access_rights.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module ControlledVocabulary
+  class AccessRights < Base
+    def self.list(*)
+      Repository::AccessLevel.names
+    end
+  end
+end

--- a/app/cho/controlled_vocabulary/factory.rb
+++ b/app/cho/controlled_vocabulary/factory.rb
@@ -18,7 +18,8 @@ module ControlledVocabulary
             default_key => ControlledVocabulary::None,
             cho_collections: ControlledVocabulary::Collections,
             cho_agents: ControlledVocabulary::Agents,
-            creator_vocabulary: ControlledVocabulary::Creators
+            creator_vocabulary: ControlledVocabulary::Creators,
+            access_rights: ControlledVocabulary::AccessRights
           }
         end
 

--- a/app/cho/data_dictionary/with_field_type.rb
+++ b/app/cho/data_dictionary/with_field_type.rb
@@ -3,66 +3,30 @@
 module DataDictionary::WithFieldType
   extend ActiveSupport::Concern
 
-  FieldTypes = Valkyrie::Types::String.enum('string', 'text', 'numeric', 'date',
-                                            'valkyrie_id', 'alternate_id', 'creator')
+  TYPES = %w(
+    string
+    text
+    numeric
+    date
+    valkyrie_id
+    alternate_id
+    creator
+    radio_button
+  ).freeze
+
+  FieldTypes = Valkyrie::Types::String.enum(*TYPES)
 
   included do
     attribute :field_type, FieldTypes
   end
 
-  def string!
-    self.field_type = 'string'
-  end
+  TYPES.each do |type|
+    define_method "#{type}!" do
+      self.field_type = type
+    end
 
-  def string?
-    field_type == 'string'
-  end
-
-  def text!
-    self.field_type = 'text'
-  end
-
-  def text?
-    field_type == 'text'
-  end
-
-  def numeric!
-    self.field_type = 'numeric'
-  end
-
-  def numeric?
-    field_type == 'numeric'
-  end
-
-  def date!
-    self.field_type = 'date'
-  end
-
-  def date?
-    field_type == 'date'
-  end
-
-  def valkyrie_id!
-    self.field_type = 'valkyrie_id'
-  end
-
-  def valkyrie_id?
-    field_type == 'valkyrie_id'
-  end
-
-  def alternate_id!
-    self.field_type = 'alternate_id'
-  end
-
-  def alternate_id?
-    field_type == 'alternate_id'
-  end
-
-  def creator!
-    self.field_type = 'creator'
-  end
-
-  def creator?
-    field_type == 'creator'
+    define_method "#{type}?" do
+      field_type == type
+    end
   end
 end

--- a/app/cho/metrics/collection.rb
+++ b/app/cho/metrics/collection.rb
@@ -58,7 +58,7 @@ module Metrics
           title: [I18n.t("#{i18n_key}.title")],
           description: [I18n.t("#{i18n_key}.description")],
           workflow: 'default',
-          access_level: ::Repository::AccessLevel.public
+          access_rights: ::Repository::AccessLevel.public
         }
       end
 

--- a/app/cho/schema/input_field.rb
+++ b/app/cho/schema/input_field.rb
@@ -6,7 +6,7 @@ module Schema
 
     attr_reader :form, :metadata_field
 
-    delegate :text?, :required?, :valkyrie_id?, :linked_field?, :creator?, :label, to: :metadata_field
+    delegate :text?, :required?, :valkyrie_id?, :linked_field?, :creator?, :radio_button?, :label, to: :metadata_field
 
     # @param [ActionView::Helpers::FormBuilder] form
     # @param [Schema::MetadataField] metadata_field
@@ -20,7 +20,7 @@ module Schema
     end
 
     def partial
-      if text? || valkyrie_id? || creator?
+      if text? || valkyrie_id? || creator? || radio_button?
         metadata_field.field_type
       else
         'string'

--- a/app/cho/transaction/operations/access_controls/access_level.rb
+++ b/app/cho/transaction/operations/access_controls/access_level.rb
@@ -4,11 +4,14 @@ module Transaction::Operations::AccessControls
   class AccessLevel
     include Dry::Transaction::Operation
 
+    # @note the function of this transaction is completely dependent on the :access_rights data dictionary
+    # term. If that term is not present in the data dictionary, and is not defined on the resources we
+    # want to govern with these rights, this function will not work.
     def call(change_set)
-      return Success(change_set) if change_set.try(:access_level).blank?
+      return Success(change_set) if change_set.try(:access_rights).blank?
 
       remaining_groups = change_set.read_groups - Repository::AccessLevel.names
-      change_set.read_groups = (remaining_groups | [change_set.access_level])
+      change_set.read_groups = (remaining_groups | Array.wrap(change_set.access_rights))
       Success(change_set)
     rescue StandardError => e
       Failure(Transaction::Rejection.new('Error applying access level', e))

--- a/app/cho/validation/access_rights.rb
+++ b/app/cho/validation/access_rights.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Validation
+  class AccessRights < Base
+    def validate(field_value)
+      self.errors = []
+      return true if field_value.blank?
+
+      (Array.wrap(field_value) - Repository::AccessLevel.names).each do |invalid_level|
+        errors << "#{invalid_level} is not a valid access right"
+      end
+      errors.empty?
+    end
+  end
+end

--- a/app/cho/validation/factory.rb
+++ b/app/cho/validation/factory.rb
@@ -20,7 +20,8 @@ module Validation
             edtf_date: Validation::EDTFDate,
             creator: Validation::Creator,
             unique: Validation::Unique,
-            character_encoding: Validation::CharacterEncoding
+            character_encoding: Validation::CharacterEncoding,
+            access_rights: Validation::AccessRights
           }
         end
 

--- a/app/views/collection/base/_form.html.erb
+++ b/app/views/collection/base/_form.html.erb
@@ -16,24 +16,6 @@
     <% end %>
   </fieldset>
 
-  <fieldset>
-    <legend><%= t('cho.form.access_level') %></legend>
-    <%= form.label "access_level_#{Repository::AccessLevel.public}".to_sym do %>
-      <%= form.radio_button :access_level, Repository::AccessLevel.public %>
-      <%= Vocab::AccessLevel.Public.label %>
-    <% end %>
-
-    <%= form.label "access_level_#{Repository::AccessLevel.psu}".to_sym do %>
-      <%= form.radio_button :access_level, Repository::AccessLevel.psu %>
-      <%= Vocab::AccessLevel.PennState.label %>
-    <% end %>
-
-    <%= form.label "access_level_#{Repository::AccessLevel.restricted}".to_sym do %>
-      <%= form.radio_button :access_level, Repository::AccessLevel.restricted %>
-      <%= Vocab::AccessLevel.Restricted.label %>
-    <% end %>
-  </fieldset>
-
   <%= render '/work/submissions/errors', work: collection if collection.errors.any? %>
 
   <div class="actions">

--- a/app/views/shared/input_partials/_radio_button.html.erb
+++ b/app/views/shared/input_partials/_radio_button.html.erb
@@ -1,0 +1,16 @@
+<%# This is tied directly to access rights. We can refactor later if we need different kinds of buttons %>
+
+<%= form.label "access_rights_#{Repository::AccessLevel.public}".to_sym do %>
+  <%= form.radio_button :access_rights, Repository::AccessLevel.public %>
+  <%= Vocab::AccessLevel.Public.label %>
+<% end %>
+
+<%= form.label "access_rights_#{Repository::AccessLevel.psu}".to_sym do %>
+  <%= form.radio_button :access_rights, Repository::AccessLevel.psu %>
+  <%= Vocab::AccessLevel.PennState.label %>
+<% end %>
+
+<%= form.label "access_rights_#{Repository::AccessLevel.restricted}".to_sym do %>
+  <%= form.radio_button :access_rights, Repository::AccessLevel.restricted %>
+  <%= Vocab::AccessLevel.Restricted.label %>
+<% end %>

--- a/config/data_dictionary/data_dictionary_development.csv
+++ b/config/data_dictionary/data_dictionary_development.csv
@@ -26,7 +26,7 @@ place,string,optional,no_validation,true,no_vocabulary,,Place of Publication,no_
 series,string,optional,no_validation,true,no_vocabulary,,Series,no_transformation,no_facet,help me,false
 box,string,optional,no_validation,true,no_vocabulary,,Box and Folder,no_transformation,no_facet,help me,false
 finding_aid,string,optional,no_validation,true,no_vocabulary,,Finding Aid,no_transformation,no_facet,help me,false
-access_rights,string,optional,no_validation,true,no_vocabulary,,Access Rights,no_transformation,no_facet,help me,false
+access_rights,radio_button,optional,access_rights,false,access_rights,,Access Rights,no_transformation,no_facet,help me,false
 alternate_title,string,optional,no_validation,true,no_vocabulary,,Alternate Title,no_transformation,no_facet,help me,false
 scale,string,optional,no_validation,true,no_vocabulary,,Scale,no_transformation,no_facet,help me,false
 projection,string,optional,no_validation,true,no_vocabulary,,Projection,no_transformation,no_facet,help me,false

--- a/config/data_dictionary/data_dictionary_production.csv
+++ b/config/data_dictionary/data_dictionary_production.csv
@@ -26,7 +26,7 @@ place,string,optional,no_validation,true,no_vocabulary,,Place of Publication,no_
 series,string,optional,no_validation,true,no_vocabulary,,Series,no_transformation,no_facet,help me,false
 box,string,optional,no_validation,true,no_vocabulary,,Box and Folder,no_transformation,no_facet,help me,false
 finding_aid,string,optional,no_validation,true,no_vocabulary,,Finding Aid,no_transformation,no_facet,help me,false
-access_rights,string,optional,no_validation,true,no_vocabulary,,Access Rights,no_transformation,no_facet,help me,false
+access_rights,radio_button,optional,access_rights,false,access_rights,,Access Rights,no_transformation,no_facet,help me,false
 alternate_title,string,optional,no_validation,true,no_vocabulary,,Alternate Title,no_transformation,no_facet,help me,false
 scale,string,optional,no_validation,true,no_vocabulary,,Scale,no_transformation,no_facet,help me,false
 projection,string,optional,no_validation,true,no_vocabulary,,Projection,no_transformation,no_facet,help me,false

--- a/config/data_dictionary/data_dictionary_test.csv
+++ b/config/data_dictionary/data_dictionary_test.csv
@@ -12,6 +12,7 @@ still_image_field,string,optional,no_validation,true,no_vocabulary,,,no_transfor
 moving_image_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false
 map_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false
 audio_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false
+access_rights,radio_button,optional,access_rights,false,access_rights,,Access Rights,no_transformation,no_facet,help me,false
 alternate_ids,alternate_id,required_to_publish,unique,true,no_vocabulary,,Identifier,no_transformation,no_facet,help me,true
 creator,creator,optional,creator,true,creator_vocabulary,,Creator,no_transformation,linked_field,help me,true
 date_cataloged,date,optional,edtf_date,true,no_vocabulary,,Date Cataloged,no_transformation,date,help me,true

--- a/config/data_dictionary/schema_fields.yml
+++ b/config/data_dictionary/schema_fields.yml
@@ -5,6 +5,8 @@ development: &development
         order_index: 2
       narrative:
         order_index: 1
+      access_rights:
+        order_index: 3
     work_type: 'false'
   - schema: 'FileSet'
     fields: []
@@ -18,6 +20,8 @@ development: &development
       home_collection_id:
         requirement_designation: 'required'
         order_index: 1
+      access_rights:
+        order_index: 2
   - schema: 'Document'
     file:
       create: Transaction::File::Create
@@ -234,6 +238,8 @@ test:
         order_index: 2
       narrative:
         order_index: 1
+      access_rights:
+        order_index: 3
     work_type: 'false'
   - schema: 'FileSet'
     fields: []

--- a/config/locales/cho.yml
+++ b/config/locales/cho.yml
@@ -21,7 +21,7 @@ en:
     form:
       metadata: "Basic Metadata"
       workflow: "Workflow"
-      access_level: "Access Level"
+      access_rights: "Access Level"
       legend: "Upload Files"
       file_selection: "File Selection"
       required: "required"
@@ -32,7 +32,7 @@ en:
       workflow: "Workflow"
       default: "Publish Immediately"
       mediated: "Mediated"
-      access_level: "Access Level"
+      access_rights: "Access Level"
       title: "Title"
       required: "required"
       member_of_collections: "Collections"

--- a/lib/tasks/ingest.rake
+++ b/lib/tasks/ingest.rake
@@ -31,7 +31,7 @@ namespace :cho do
       collection = Collection::Archival.new(
         title: "Collection for #{id}",
         alternate_ids: [id],
-        access_level: Repository::AccessLevel.public,
+        access_rights: Repository::AccessLevel.public,
         workflow: 'default'
       )
       change_set_persister.persister.save(resource: collection)

--- a/spec/blacklight/solr_document_spec.rb
+++ b/spec/blacklight/solr_document_spec.rb
@@ -92,6 +92,7 @@ RSpec.describe SolrDocument, type: :model do
       'alternate_ids,' \
       'creator,' \
       'date_cataloged,' \
+      'access_rights,' \
       'acknowledgments,' \
       'audio_field,' \
       'created,' \
@@ -114,16 +115,16 @@ RSpec.describe SolrDocument, type: :model do
       }
     end
 
-    it { is_expected.to eq("#{csv_header}\nabc123,,my_title,,,,,,,,,,value1||value2,xyx789,,,,\n") }
+    it { is_expected.to eq("#{csv_header}\nabc123,,my_title,,,,,,,,,,,value1||value2,xyx789,,,,\n") }
 
     context 'with a collection containing works and file sets' do
       let(:collection) { create :library_collection }
       let(:work) { create :work, :with_file, home_collection_id: [collection.id], title: 'Work One' }
-      let(:work1_csv) { "#{work.id},Generic,Work One,,,,,,,,,,,#{collection.id},,,," }
-      let(:file_set1_csv) { "#{work.member_ids.first},,hello_world.txt,,,,,,,,,,,,,,," }
+      let(:work1_csv) { "#{work.id},Generic,Work One,,,,,,,,,,,,#{collection.id},,,," }
+      let(:file_set1_csv) { "#{work.member_ids.first},,hello_world.txt,,,,,,,,,,,,,,,," }
       let(:work2) { create :work, :with_file, home_collection_id: [collection.id], title: 'Work Two' }
-      let(:work2_csv) { "#{work2.id},Generic,Work Two,,,,,,,,,,,#{collection.id},,,," }
-      let(:file_set2_csv) { "#{work2.member_ids.first},,hello_world.txt,,,,,,,,,,,,,,," }
+      let(:work2_csv) { "#{work2.id},Generic,Work Two,,,,,,,,,,,,#{collection.id},,,," }
+      let(:file_set2_csv) { "#{work2.member_ids.first},,hello_world.txt,,,,,,,,,,,,,,,," }
 
       let(:document) do
         { 'internal_resource_tsim' => 'MyCollection', id: collection.id, title_tesim: ['my_collection'] }
@@ -155,8 +156,8 @@ RSpec.describe SolrDocument, type: :model do
       end
 
       let(:file_set) { create(:file_set) }
-      let(:work_csv) { 'abc123,,my_title,,,,,,,,,,value1||value2,xyx789,,,,' }
-      let(:file_set_csv) { "#{file_set.id},,Original File Name,,,,,,,,,,,,,,," }
+      let(:work_csv) { 'abc123,,my_title,,,,,,,,,,,value1||value2,xyx789,,,,' }
+      let(:file_set_csv) { "#{file_set.id},,Original File Name,,,,,,,,,,,,,,,," }
 
       before { file_set }
 

--- a/spec/cho/collection/change_set_behaviors_spec.rb
+++ b/spec/cho/collection/change_set_behaviors_spec.rb
@@ -30,14 +30,12 @@ RSpec.describe Collection::ChangeSetBehaviors do
   describe '#multiple?' do
     it 'has one title and description' do
       expect(change_set).not_to be_multiple(:workflow)
-      expect(change_set).not_to be_multiple(:access_level)
     end
   end
 
   describe '#required?' do
     it 'has required fields' do
       expect(change_set).to be_required(:workflow)
-      expect(change_set).to be_required(:access_level)
     end
   end
 
@@ -45,7 +43,6 @@ RSpec.describe Collection::ChangeSetBehaviors do
     before { change_set.prepopulate! }
 
     its(:workflow) { is_expected.to be_nil }
-    its(:access_level) { is_expected.to be_nil }
   end
 
   describe '#validate' do
@@ -65,19 +62,12 @@ RSpec.describe Collection::ChangeSetBehaviors do
       its(:full_messages) { is_expected.to include('Workflow is not included in the list') }
     end
 
-    context 'with an unsupported access_level' do
-      let(:params) { { title: 'title', access_level: 'foo' } }
-
-      its(:full_messages) { is_expected.to include('Access level is not included in the list') }
-    end
-
     context 'with all required fields' do
       let(:params) do
         {
           title: 'Title',
           description: 'My collection',
-          workflow: 'default',
-          access_level: Repository::AccessLevel.public
+          workflow: 'default'
         }
       end
 
@@ -95,6 +85,7 @@ RSpec.describe Collection::ChangeSetBehaviors do
         'creator',
         'date_cataloged',
         'acknowledgments',
+        'access_rights',
         'narrative'
       )
     end
@@ -112,6 +103,7 @@ RSpec.describe Collection::ChangeSetBehaviors do
         'creator',
         'date_cataloged',
         'acknowledgments',
+        'access_rights',
         'narrative'
       )
     end

--- a/spec/cho/collection/common_fields_spec.rb
+++ b/spec/cho/collection/common_fields_spec.rb
@@ -17,16 +17,6 @@ RSpec.describe Collection::CommonFields, type: :model do
 
   it { is_expected.to respond_to(:id) }
   it { is_expected.to respond_to(:workflow) }
-  it { is_expected.to respond_to(:access_level) }
-
-  describe '#access_level=' do
-    it 'can be set' do
-      expect { collection.access_level = Repository::AccessLevel.public }.not_to raise_error
-      expect { collection.access_level = Repository::AccessLevel.psu }.not_to raise_error
-      expect { collection.access_level = Repository::AccessLevel.restricted }.not_to raise_error
-      expect { collection.access_level = 'bogus' }.to raise_error(Dry::Types::ConstraintError)
-    end
-  end
 
   describe '#workflow' do
     it 'can be set' do

--- a/spec/cho/controlled_vocabulary/access_rights_spec.rb
+++ b/spec/cho/controlled_vocabulary/access_rights_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ControlledVocabulary::AccessRights, type: :model do
+  describe '::list' do
+    subject { described_class.list }
+
+    it { is_expected.to contain_exactly('public', 'registered', 'private') }
+  end
+end

--- a/spec/cho/controlled_vocabulary/factory_spec.rb
+++ b/spec/cho/controlled_vocabulary/factory_spec.rb
@@ -46,12 +46,22 @@ RSpec.describe ControlledVocabulary::Factory, type: :model do
       described_class.vocabularies = vocabularies
     end
 
-    it { is_expected.to eq([:no_vocabulary, :cho_collections, :cho_agents, :creator_vocabulary]) }
+    it { is_expected.to eq([:no_vocabulary, :cho_collections, :cho_agents, :creator_vocabulary, :access_rights]) }
 
     context 'valid vocabularies set' do
       let(:vocabularies) { { abc: MyVocab.new, other: OtherVocab.new } }
 
-      it { is_expected.to eq([:abc, :other, :no_vocabulary, :cho_collections, :cho_agents, :creator_vocabulary]) }
+      specify do
+        expect(described_class.vocabularies.keys).to contain_exactly(
+          :abc,
+          :other,
+          :no_vocabulary,
+          :cho_collections,
+          :cho_agents,
+          :creator_vocabulary,
+          :access_rights
+        )
+      end
     end
   end
 

--- a/spec/cho/data_dictionary/with_field_type_spec.rb
+++ b/spec/cho/data_dictionary/with_field_type_spec.rb
@@ -15,73 +15,30 @@ RSpec.describe DataDictionary::WithFieldType, type: :model do
     ActiveSupport::Dependencies.remove_constant('MyFieldModel')
   end
 
-  context 'field_type is set to text' do
-    before { model.text! }
-
-    it { is_expected.to be_text }
-    it { is_expected.not_to be_string }
-    it { is_expected.not_to be_date }
-    it { is_expected.not_to be_numeric }
-    it { is_expected.not_to be_valkyrie_id }
-    it { is_expected.not_to be_creator }
+  describe '::TYPES' do
+    specify do
+      expect(DataDictionary::WithFieldType::TYPES).to contain_exactly(
+        'string',
+        'text',
+        'numeric',
+        'date',
+        'valkyrie_id',
+        'alternate_id',
+        'creator',
+        'radio_button'
+      )
+    end
   end
 
-  context 'field_type is set to date' do
-    before { model.date! }
-
-    it { is_expected.not_to be_text }
-    it { is_expected.not_to be_string }
-    it { is_expected.to be_date }
-    it { is_expected.not_to be_numeric }
-    it { is_expected.not_to be_valkyrie_id }
-    it { is_expected.not_to be_creator }
+  describe 'setting a field type' do
+    specify do
+      expect(model.text?).to be(false)
+      model.text!
+      expect(model.text?).to be(true)
+    end
   end
 
-  context 'field_type is set to numeric' do
-    before { model.numeric! }
-
-    it { is_expected.not_to be_text }
-    it { is_expected.not_to be_string }
-    it { is_expected.not_to be_date }
-    it { is_expected.to be_numeric }
-    it { is_expected.not_to be_valkyrie_id }
-    it { is_expected.not_to be_creator }
-  end
-
-  context 'field_type is set to string' do
-    before { model.string! }
-
-    it { is_expected.not_to be_text }
-    it { is_expected.to be_string }
-    it { is_expected.not_to be_date }
-    it { is_expected.not_to be_numeric }
-    it { is_expected.not_to be_valkyrie_id }
-    it { is_expected.not_to be_creator }
-  end
-
-  context 'field_type is set to a Valkyrie ID' do
-    before { model.valkyrie_id! }
-
-    it { is_expected.not_to be_text }
-    it { is_expected.not_to be_string }
-    it { is_expected.not_to be_date }
-    it { is_expected.not_to be_numeric }
-    it { is_expected.to be_valkyrie_id }
-    it { is_expected.not_to be_creator }
-  end
-
-  context 'field_type is set to a Valkyrie ID' do
-    before { model.creator! }
-
-    it { is_expected.not_to be_text }
-    it { is_expected.not_to be_string }
-    it { is_expected.not_to be_date }
-    it { is_expected.not_to be_numeric }
-    it { is_expected.not_to be_valkyrie_id }
-    it { is_expected.to be_creator }
-  end
-
-  context 'field_type is bogus' do
+  describe 'setting a field to a bogus type' do
     it 'raises an error' do
       expect { MyFieldModel.new(field_type: 'bogus') }.to raise_error(Dry::Struct::Error)
     end

--- a/spec/cho/schema/configuration_spec.rb
+++ b/spec/cho/schema/configuration_spec.rb
@@ -53,7 +53,8 @@ RSpec.describe Schema::Configuration, type: :model do
           'schema' => 'Collection',
           'fields' => {
             'acknowledgments' => { 'order_index' => 2 },
-            'narrative' => { 'order_index' => 1 }
+            'narrative' => { 'order_index' => 1 },
+            'access_rights' => { 'order_index' => 3 }
           },
           'work_type' => 'false'
         },

--- a/spec/cho/transaction/operations/access_controls/access_level_spec.rb
+++ b/spec/cho/transaction/operations/access_controls/access_level_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe Transaction::Operations::AccessControls::AccessLevel do
   before(:all) do
     class AccessResource < Valkyrie::Resource
       include Repository::Access::ResourceControls
-      attribute :access_level
+      attribute :access_rights
     end
 
     class AccessChangeSet < Valkyrie::ChangeSet
       include Repository::Access::ChangeSetBehaviors
-      property :access_level
-      validates :access_level, inclusion: { in: Repository::AccessLevel.names }
+      property :access_rights
+      validates :access_rights, inclusion: { in: Repository::AccessLevel.names }
     end
   end
 
@@ -28,7 +28,7 @@ RSpec.describe Transaction::Operations::AccessControls::AccessLevel do
     context 'when changing from public default to Penn State' do
       specify do
         expect(change_set.read_groups).to contain_exactly(Repository::AccessLevel.public)
-        change_set.access_level = Repository::AccessLevel.psu
+        change_set.access_rights = Repository::AccessLevel.psu
         result = described_class.new.call(change_set)
         expect(result.success.read_groups).to contain_exactly(Repository::AccessLevel.psu)
       end
@@ -37,7 +37,7 @@ RSpec.describe Transaction::Operations::AccessControls::AccessLevel do
     context 'when changing from public default to private' do
       specify do
         expect(change_set.read_groups).to contain_exactly(Repository::AccessLevel.public)
-        change_set.access_level = Repository::AccessLevel.restricted
+        change_set.access_rights = Repository::AccessLevel.restricted
         result = described_class.new.call(change_set)
         expect(result.success.read_groups).to contain_exactly(Repository::AccessLevel.restricted)
       end
@@ -47,7 +47,7 @@ RSpec.describe Transaction::Operations::AccessControls::AccessLevel do
       before { change_set.read_groups = [Repository::AccessLevel.psu] }
 
       specify do
-        change_set.access_level = Repository::AccessLevel.restricted
+        change_set.access_rights = Repository::AccessLevel.restricted
         result = described_class.new.call(change_set)
         expect(result.success.read_groups).to contain_exactly(Repository::AccessLevel.restricted)
       end
@@ -57,7 +57,7 @@ RSpec.describe Transaction::Operations::AccessControls::AccessLevel do
       before { change_set.read_groups = [Repository::AccessLevel.psu] }
 
       specify do
-        change_set.access_level = Repository::AccessLevel.public
+        change_set.access_rights = Repository::AccessLevel.public
         result = described_class.new.call(change_set)
         expect(result.success.read_groups).to contain_exactly(Repository::AccessLevel.public)
       end
@@ -67,7 +67,7 @@ RSpec.describe Transaction::Operations::AccessControls::AccessLevel do
       before { change_set.read_groups = [Repository::AccessLevel.restricted] }
 
       specify do
-        change_set.access_level = Repository::AccessLevel.psu
+        change_set.access_rights = Repository::AccessLevel.psu
         result = described_class.new.call(change_set)
         expect(result.success.read_groups).to contain_exactly(Repository::AccessLevel.psu)
       end
@@ -77,7 +77,7 @@ RSpec.describe Transaction::Operations::AccessControls::AccessLevel do
       before { change_set.read_groups = [Repository::AccessLevel.restricted] }
 
       specify do
-        change_set.access_level = Repository::AccessLevel.public
+        change_set.access_rights = Repository::AccessLevel.public
         result = described_class.new.call(change_set)
         expect(result.success.read_groups).to contain_exactly(Repository::AccessLevel.public)
       end
@@ -87,7 +87,7 @@ RSpec.describe Transaction::Operations::AccessControls::AccessLevel do
       before { change_set.read_groups = [Repository::AccessLevel.restricted, 'group1', 'group2'] }
 
       specify do
-        change_set.access_level = Repository::AccessLevel.psu
+        change_set.access_rights = Repository::AccessLevel.psu
         result = described_class.new.call(change_set)
         expect(result.success.read_groups).to contain_exactly(Repository::AccessLevel.psu, 'group1', 'group2')
       end
@@ -95,19 +95,19 @@ RSpec.describe Transaction::Operations::AccessControls::AccessLevel do
 
     context 'when no changes are made' do
       before do
-        change_set.access_level = Repository::AccessLevel.restricted
+        change_set.access_rights = Repository::AccessLevel.restricted
         change_set.read_groups = [Repository::AccessLevel.restricted]
       end
 
       specify do
         result = described_class.new.call(change_set)
         expect(result.success.read_groups).to contain_exactly(Repository::AccessLevel.restricted)
-        expect(result.success.access_level).to eq(Repository::AccessLevel.restricted)
+        expect(result.success.access_rights).to eq(Repository::AccessLevel.restricted)
       end
     end
 
     context 'when something unexpected happens' do
-      before { allow(change_set).to receive(:access_level).and_raise(StandardError, 'I fell down') }
+      before { allow(change_set).to receive(:access_rights).and_raise(StandardError, 'I fell down') }
 
       it 'returns a failure' do
         result = described_class.new.call(change_set)

--- a/spec/cho/validation/access_rights_spec.rb
+++ b/spec/cho/validation/access_rights_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Validation::AccessRights do
+  describe '#validate' do
+    subject { validation_instance.validate(access_level) }
+
+    let(:validation_instance) { described_class.new }
+
+    context 'with a valid access level' do
+      let(:access_level) { Repository::AccessLevel.public }
+
+      it 'is valid' do
+        expect(validation_instance.validate(access_level)).to be_truthy
+        expect(validation_instance.errors).to be_empty
+      end
+    end
+
+    context 'with an invalid access level' do
+      let(:access_level) { 'bogus' }
+
+      it 'is not valid' do
+        expect(validation_instance.validate(access_level)).to be_falsey
+        expect(validation_instance.errors).to contain_exactly('bogus is not a valid access right')
+      end
+    end
+
+    context 'with a null access level' do
+      let(:access_level) { nil }
+
+      it 'is valid' do
+        expect(validation_instance.validate(access_level)).to be_truthy
+        expect(validation_instance.errors).to be_empty
+      end
+    end
+  end
+end

--- a/spec/cho/validation/factory_spec.rb
+++ b/spec/cho/validation/factory_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe Validation::Factory, type: :model do
           'resource_exists',
           'unique',
           'edtf_date',
-          'character_encoding'
+          'character_encoding',
+          'access_rights'
         )
       end
     end
@@ -79,7 +80,8 @@ RSpec.describe Validation::Factory, type: :model do
           'resource_exists',
           'edtf_date',
           'unique',
-          'character_encoding'
+          'character_encoding',
+          'access_rights'
         )
       end
     end

--- a/spec/cho/work/import/create_spec.rb
+++ b/spec/cho/work/import/create_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe 'Preview of CSV Import', type: :feature do
           "#{agent1.display_name}#{CsvParsing::SUBVALUE_SEPARATOR}bsl",
           "#{agent2.display_name}#{CsvParsing::SUBVALUE_SEPARATOR}cli",
           agent3.display_name.to_s
-        ]
+        ],
+        access_rights: ['public', 'public', 'public']
       )
     end
 
@@ -78,18 +79,21 @@ RSpec.describe 'Preview of CSV Import', type: :feature do
       end
       expect(page).to have_content('My Work 1')
       expect(page).to have_content("#{agent1.display_name}, blasting")
+      expect(page).to have_content('public')
       click_link('my collection')
       within('div#members') do
         click_link('My Work 2')
       end
       expect(page).to have_content('My Work 2')
       expect(page).to have_content("#{agent2.display_name}, climbing")
+      expect(page).to have_content('public')
       click_link('my collection')
       within('div#members') do
         click_link('My Work 3')
       end
       expect(page).to have_content('My Work 3')
       expect(page).to have_content(agent3.display_name.to_s)
+      expect(page).to have_content('public')
 
       # Verify each work has a file set and a file
       Work::Submission.all.each do |work|

--- a/spec/factories/archival_collections.rb
+++ b/spec/factories/archival_collections.rb
@@ -6,15 +6,15 @@ FactoryBot.define do
     subtitle { 'subtitle for an archival collection' }
     description { 'Sample archival collection' }
     workflow { 'default' }
-    access_level { Repository::AccessLevel.public }
+    access_rights { Repository::AccessLevel.public }
 
     factory :psu_collection do
-      access_level { Repository::AccessLevel.psu }
+      access_rights { Repository::AccessLevel.psu }
       read_groups { [Repository::AccessLevel.psu] }
     end
 
     factory :private_collection, aliases: [:restricted_collection] do
-      access_level { Repository::AccessLevel.restricted }
+      access_rights { Repository::AccessLevel.restricted }
       read_groups { [] }
     end
   end

--- a/spec/factories/curated_collections.rb
+++ b/spec/factories/curated_collections.rb
@@ -6,15 +6,15 @@ FactoryBot.define do
     description { 'Sample curated collection' }
     subtitle { 'subtitle for a curated collection' }
     workflow { 'default' }
-    access_level { Repository::AccessLevel.public }
+    access_rights { Repository::AccessLevel.public }
 
     factory :psu_curated_collection do
-      access_level { Repository::AccessLevel.psu }
+      access_rights { Repository::AccessLevel.psu }
       read_groups { [Repository::AccessLevel.psu] }
     end
 
     factory :private_curated_collection, aliases: [:restricted_curated_collection] do
-      access_level { Repository::AccessLevel.restricted }
+      access_rights { Repository::AccessLevel.restricted }
       read_groups { [] }
     end
   end

--- a/spec/factories/library_collections.rb
+++ b/spec/factories/library_collections.rb
@@ -6,15 +6,15 @@ FactoryBot.define do
     description { 'Sample library collection' }
     subtitle { 'subtitle for a library collection' }
     workflow { 'default' }
-    access_level { Repository::AccessLevel.public }
+    access_rights { Repository::AccessLevel.public }
 
     factory :psu_library_collection do
-      access_level { Repository::AccessLevel.psu }
+      access_rights { Repository::AccessLevel.psu }
       read_groups { [Repository::AccessLevel.psu] }
     end
 
     factory :private_library_collection, aliases: [:restricted_library_collection] do
-      access_level { Repository::AccessLevel.restricted }
+      access_rights { Repository::AccessLevel.restricted }
       read_groups { [] }
     end
   end

--- a/spec/support/shared/controllers.rb
+++ b/spec/support/shared/controllers.rb
@@ -7,7 +7,7 @@ RSpec.shared_examples 'a collection controller' do
       subtitle: 'use only for testing',
       description: 'A sample collection',
       workflow: 'default',
-      access_level: Repository::AccessLevel.public
+      access_rights: Repository::AccessLevel.public
     }
   end
 
@@ -68,7 +68,7 @@ RSpec.shared_examples 'a collection controller' do
           subtitle: 'use only for testing',
           description: 'An updated sample collection',
           workflow: 'default',
-          access_level: Repository::AccessLevel.public
+          access_rights: Repository::AccessLevel.public
         }
       end
 

--- a/spec/views/archival_collections/edit.html.erb_spec.rb
+++ b/spec/views/archival_collections/edit.html.erb_spec.rb
@@ -17,12 +17,11 @@ RSpec.describe 'collection/archival_collections/edit', type: :view do
       assert_select 'input[name=?]', 'archival_collection[subtitle][]'
       assert_select 'textarea[name=?]', 'archival_collection[description][]'
       assert_select 'input[name=?]', 'archival_collection[workflow]'
-      assert_select 'input[name=?]', 'archival_collection[access_level]'
+      assert_select 'input[name=?]', 'archival_collection[access_rights]'
       # Added to make sure accessibility changes are in place
       assert_select 'legend', 'Basic Metadata'
       assert_select 'label[for=?]', 'archival_collection_title', text: /\s.* required/
       assert_select 'legend', 'Workflow'
-      assert_select 'legend', 'Access Level'
     end
     assert_select 'form[action=?]', "/catalog/#{collection.id}"
   end

--- a/spec/views/archival_collections/new.html.erb_spec.rb
+++ b/spec/views/archival_collections/new.html.erb_spec.rb
@@ -16,12 +16,11 @@ RSpec.describe 'collection/archival_collections/new', type: :view do
       assert_select 'input[name=?]', 'archival_collection[subtitle][]'
       assert_select 'textarea[name=?]', 'archival_collection[description][]'
       assert_select 'input[name=?]', 'archival_collection[workflow]'
-      assert_select 'input[name=?]', 'archival_collection[access_level]'
+      assert_select 'input[name=?]', 'archival_collection[access_rights]'
       # Added to make sure accessibility changes are in place
       assert_select 'legend', 'Basic Metadata'
       assert_select 'label[for=?]', 'archival_collection_title', text: /\s.* required/
       assert_select 'legend', 'Workflow'
-      assert_select 'legend', 'Access Level'
     end
   end
 end

--- a/spec/views/curated_collections/edit.html.erb_spec.rb
+++ b/spec/views/curated_collections/edit.html.erb_spec.rb
@@ -17,12 +17,11 @@ RSpec.describe 'collection/curated_collections/edit', type: :view do
       assert_select 'input[name=?]', 'curated_collection[subtitle][]'
       assert_select 'textarea[name=?]', 'curated_collection[description][]'
       assert_select 'input[name=?]', 'curated_collection[workflow]'
-      assert_select 'input[name=?]', 'curated_collection[access_level]'
+      assert_select 'input[name=?]', 'curated_collection[access_rights]'
       # Added to make sure accessibility changes are in place
       assert_select 'legend', 'Basic Metadata'
       assert_select 'label[for=?]', 'curated_collection_title', text: /\s.* required/
       assert_select 'legend', 'Workflow'
-      assert_select 'legend', 'Access Level'
     end
     assert_select 'a[href=?]', "/catalog/#{collection.id}"
   end

--- a/spec/views/curated_collections/new.html.erb_spec.rb
+++ b/spec/views/curated_collections/new.html.erb_spec.rb
@@ -16,12 +16,11 @@ RSpec.describe 'collection/curated_collections/new', type: :view do
       assert_select 'input[name=?]', 'curated_collection[subtitle][]'
       assert_select 'textarea[name=?]', 'curated_collection[description][]'
       assert_select 'input[name=?]', 'curated_collection[workflow]'
-      assert_select 'input[name=?]', 'curated_collection[access_level]'
+      assert_select 'input[name=?]', 'curated_collection[access_rights]'
       # Added to make sure accessibility changes are in place
       assert_select 'legend', 'Basic Metadata'
       assert_select 'label[for=?]', 'curated_collection_title', text: /\s.* required/
       assert_select 'legend', 'Workflow'
-      assert_select 'legend', 'Access Level'
     end
   end
 end

--- a/spec/views/library_collections/edit.html.erb_spec.rb
+++ b/spec/views/library_collections/edit.html.erb_spec.rb
@@ -17,12 +17,11 @@ RSpec.describe 'collection/library_collections/edit', type: :view do
       assert_select 'input[name=?]', 'library_collection[subtitle][]'
       assert_select 'textarea[name=?]', 'library_collection[description][]'
       assert_select 'input[name=?]', 'library_collection[workflow]'
-      assert_select 'input[name=?]', 'library_collection[access_level]'
+      assert_select 'input[name=?]', 'library_collection[access_rights]'
       # Added to make sure accessibility changes are in place
       assert_select 'legend', 'Basic Metadata'
       assert_select 'label[for=?]', 'library_collection_title', text: /\s.* required/
       assert_select 'legend', 'Workflow'
-      assert_select 'legend', 'Access Level'
     end
     assert_select 'a[href=?]', "/catalog/#{collection.id}"
   end

--- a/spec/views/library_collections/new.html.erb_spec.rb
+++ b/spec/views/library_collections/new.html.erb_spec.rb
@@ -16,12 +16,11 @@ RSpec.describe 'collection/library_collections/new', type: :view do
       assert_select 'input[name=?]', 'library_collection[subtitle][]'
       assert_select 'textarea[name=?]', 'library_collection[description][]'
       assert_select 'input[name=?]', 'library_collection[workflow]'
-      assert_select 'input[name=?]', 'library_collection[access_level]'
+      assert_select 'input[name=?]', 'library_collection[access_rights]'
       # Added to make sure accessibility changes are in place
       assert_select 'legend', 'Basic Metadata'
       assert_select 'label[for=?]', 'library_collection_title', text: /\s.* required/
       assert_select 'legend', 'Workflow'
-      assert_select 'legend', 'Access Level'
     end
   end
 end


### PR DESCRIPTION
## Description

Adds support for setting access rights in a CSV when adding new works to a collection.

Access rights is added to the data dictionary as a special kind of property that is linked to a `Repository::AccessLevel`. Setting the kind of access right will trigger behaviors such as limiting a resource (collection or work) to registered or private users.

Connected to #976 

## Changes

* adding access_rights to data dictionary
* Add radio_button field type used only for access rights at this time
* Adding validation and controlled vocabularies
* Replace access_level with access_rights where appropriate
* Making config changes to dev and prod data dictionaries

## Caveats

The access_rights property is tightly coupled with the repository access level concept, and functions will not work as expected unless this coupling is maintained. For example, changing access_rights to a different name would break these features. Future enhancements could make this coupling more transparent or flexible.
