### PR TITLE
Extracted text only added to "All Fields" search

### DIFF
--- a/app/blacklight/catalog_search_behavior.rb
+++ b/app/blacklight/catalog_search_behavior.rb
@@ -22,9 +22,16 @@ module CatalogSearchBehavior
 
     # the {!lucene} gives us the OR syntax
     def new_query
-      "{!lucene}#{internal_query(query_all_query_fields)} "\
-      "#{internal_query(search_metadata_from_file_sets)} "\
-      "#{internal_query(search_extracted_text_from_files)}"
+      query_parts = [
+        "{!lucene}#{internal_query(query_all_query_fields)}",
+        internal_query(search_metadata_from_file_sets)
+      ]
+
+      if blacklight_params[:search_field] == 'all_fields'
+        query_parts << internal_query(search_extracted_text_from_files)
+      end
+
+      query_parts.join(' ')
     end
 
     # @note The _query_ allows for another parser, i.e. dismax.

--- a/spec/blacklight/catalog_spec.rb
+++ b/spec/blacklight/catalog_spec.rb
@@ -111,13 +111,30 @@ RSpec.describe CatalogController, type: :feature do
       create(:work_submission, :with_file_and_extracted_text,
              filename: 'example_extracted_text.txt',
              title: 'Sample Extracted Text Work')
+
+      create(:work_submission, :with_file,
+             title: 'Words in the title')
     end
 
-    it 'returns the work containing the extracted text' do
-      visit(root_path)
-      search_for 'words'
-      within('#documents') do
-        expect(page).to have_link('Sample Extracted Text Work')
+    context 'when searching on "All Fields"' do
+      it 'returns the work containing the extracted text' do
+        visit(root_path)
+        search_for 'words', in: 'All Fields'
+        within('#documents') do
+          expect(page).to have_link('Sample Extracted Text Work')
+          expect(page).to have_link('Words in the title')
+        end
+      end
+    end
+
+    context 'when searching a more specific field' do
+      it 'does not include the extracted text in the search' do
+        visit(root_path)
+        search_for 'words', in: 'Title'
+        within('#documents') do
+          expect(page).not_to have_link('Sample Extracted Text Work')
+          expect(page).to have_link('Words in the title')
+        end
       end
     end
   end


### PR DESCRIPTION
## Description

Extracted text was previously being added to every Blacklight search, which was leading to some very unexpected results. Now, we only add extracted text to the query if "All Fields" is the selected search field.

Connected to #1005 