### PR TITLE
Rename Repository::Access to Repository::AccessControls

### DIFF
--- a/app/cho/collection/change_set_behaviors.rb
+++ b/app/cho/collection/change_set_behaviors.rb
@@ -4,7 +4,7 @@ module Collection::ChangeSetBehaviors
   extend ActiveSupport::Concern
   include DataDictionary::FieldsForChangeSet
   include Work::WithErrorMessages
-  include Repository::Access::ChangeSetBehaviors
+  include Repository::AccessControls::ChangeSetBehaviors
 
   included do
     property :workflow, multiple: false, required: true

--- a/app/cho/collection/common_fields.rb
+++ b/app/cho/collection/common_fields.rb
@@ -3,7 +3,7 @@
 module Collection::CommonFields
   extend ActiveSupport::Concern
   include DataDictionary::FieldsForObject
-  include Repository::Access::ResourceControls
+  include Repository::AccessControls::Fields
 
   WORKFLOW = ['default', 'mediated'].freeze
 

--- a/app/cho/controlled_vocabulary/access_rights.rb
+++ b/app/cho/controlled_vocabulary/access_rights.rb
@@ -3,7 +3,7 @@
 module ControlledVocabulary
   class AccessRights < Base
     def self.list(*)
-      Repository::AccessLevel.names
+      Repository::AccessControls::AccessLevel.names
     end
   end
 end

--- a/app/cho/metrics/collection.rb
+++ b/app/cho/metrics/collection.rb
@@ -58,7 +58,7 @@ module Metrics
           title: [I18n.t("#{i18n_key}.title")],
           description: [I18n.t("#{i18n_key}.description")],
           workflow: 'default',
-          access_rights: ::Repository::AccessLevel.public
+          access_rights: ::Repository::AccessControls::AccessLevel.public
         }
       end
 

--- a/app/cho/repository/access_controls/access_level.rb
+++ b/app/cho/repository/access_controls/access_level.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Repository
+module Repository::AccessControls
   class AccessLevel
     attr_reader :uri
 

--- a/app/cho/repository/access_controls/change_set_behaviors.rb
+++ b/app/cho/repository/access_controls/change_set_behaviors.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Repository::Access::ChangeSetBehaviors
+module Repository::AccessControls::ChangeSetBehaviors
   extend ActiveSupport::Concern
 
   included do

--- a/app/cho/repository/access_controls/fields.rb
+++ b/app/cho/repository/access_controls/fields.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Repository::Access::ResourceControls
+module Repository::AccessControls::Fields
   extend ActiveSupport::Concern
 
   DEFAULT_SYSTEM_USER = 'system'
@@ -9,7 +9,7 @@ module Repository::Access::ResourceControls
     # These are attributes defined in Blacklight's access controls, which are based off of Hydra's
     attribute :discover_groups, Valkyrie::Types::Set
     attribute :discover_users, Valkyrie::Types::Set
-    attribute :read_groups, Valkyrie::Types::Set.default([Repository::AccessLevel.public])
+    attribute :read_groups, Valkyrie::Types::Set.default([Repository::AccessControls::AccessLevel.public])
     attribute :read_users, Valkyrie::Types::Set
     attribute :download_groups, Valkyrie::Types::Set
     attribute :download_users, Valkyrie::Types::Set

--- a/app/cho/transaction/operations/access_controls/access_level.rb
+++ b/app/cho/transaction/operations/access_controls/access_level.rb
@@ -10,7 +10,7 @@ module Transaction::Operations::AccessControls
     def call(change_set)
       return Success(change_set) if change_set.try(:access_rights).blank?
 
-      remaining_groups = change_set.read_groups - Repository::AccessLevel.names
+      remaining_groups = change_set.read_groups - Repository::AccessControls::AccessLevel.names
       change_set.read_groups = (remaining_groups | Array.wrap(change_set.access_rights))
       Success(change_set)
     rescue StandardError => e

--- a/app/cho/transaction/operations/access_controls/permissions.rb
+++ b/app/cho/transaction/operations/access_controls/permissions.rb
@@ -7,7 +7,8 @@ module Transaction::Operations::AccessControls
     # @return [Valkyrie::ChangeSet]
     # @note duplicate members can be removed by the underlying resource model
     def call(change_set)
-      return Success(change_set) unless change_set.class.ancestors.include?(Repository::Access::ChangeSetBehaviors)
+      return Success(change_set) unless
+        change_set.class.ancestors.include?(Repository::AccessControls::ChangeSetBehaviors)
 
       change_set.read_users |= [change_set.system_creator]
       Success(change_set)

--- a/app/cho/validation/access_rights.rb
+++ b/app/cho/validation/access_rights.rb
@@ -6,7 +6,7 @@ module Validation
       self.errors = []
       return true if field_value.blank?
 
-      (Array.wrap(field_value) - Repository::AccessLevel.names).each do |invalid_level|
+      (Array.wrap(field_value) - Repository::AccessControls::AccessLevel.names).each do |invalid_level|
         errors << "#{invalid_level} is not a valid access right"
       end
       errors.empty?

--- a/app/cho/work/file_set.rb
+++ b/app/cho/work/file_set.rb
@@ -5,7 +5,7 @@
 # File sets are indexed both in Solr and and Postgres using the {IndexingAdapter}.
 class Work::FileSet < Valkyrie::Resource
   enable_optimistic_locking
-  include Repository::Access::ResourceControls
+  include Repository::AccessControls::Fields
   include CommonQueries
   include DataDictionary::FieldsForObject
 

--- a/app/cho/work/file_set_change_set.rb
+++ b/app/cho/work/file_set_change_set.rb
@@ -15,7 +15,7 @@ module Work
     include WithValidMembers
     include WithFormFields
     include Work::WithErrorMessages
-    include Repository::Access::ChangeSetBehaviors
+    include Repository::AccessControls::ChangeSetBehaviors
 
     delegate :url_helpers, to: 'Rails.application.routes'
 

--- a/app/cho/work/submission.rb
+++ b/app/cho/work/submission.rb
@@ -6,7 +6,7 @@
 module Work
   class Submission < Valkyrie::Resource
     enable_optimistic_locking
-    include Repository::Access::ResourceControls
+    include Repository::AccessControls::Fields
     include DataDictionary::FieldsForObject
     include CommonQueries
 

--- a/app/cho/work/submission_change_set.rb
+++ b/app/cho/work/submission_change_set.rb
@@ -39,7 +39,7 @@ module Work
     include WithValidMembers
     include WithFormFields
     include Work::WithErrorMessages
-    include Repository::Access::ChangeSetBehaviors
+    include Repository::AccessControls::ChangeSetBehaviors
 
     delegate :url_helpers, to: 'Rails.application.routes'
 

--- a/app/devise/user.rb
+++ b/app/devise/user.rb
@@ -34,6 +34,6 @@ class User < ApplicationRecord
     def default_groups
       return [] if login.blank?
 
-      [Repository::AccessLevel.psu]
+      [Repository::AccessControls::AccessLevel.psu]
     end
 end

--- a/app/views/shared/input_partials/_radio_button.html.erb
+++ b/app/views/shared/input_partials/_radio_button.html.erb
@@ -1,16 +1,16 @@
 <%# This is tied directly to access rights. We can refactor later if we need different kinds of buttons %>
 
-<%= form.label "access_rights_#{Repository::AccessLevel.public}".to_sym do %>
-  <%= form.radio_button :access_rights, Repository::AccessLevel.public %>
+<%= form.label "access_rights_#{Repository::AccessControls::AccessLevel.public}".to_sym do %>
+  <%= form.radio_button :access_rights, Repository::AccessControls::AccessLevel.public %>
   <%= Vocab::AccessLevel.Public.label %>
 <% end %>
 
-<%= form.label "access_rights_#{Repository::AccessLevel.psu}".to_sym do %>
-  <%= form.radio_button :access_rights, Repository::AccessLevel.psu %>
+<%= form.label "access_rights_#{Repository::AccessControls::AccessLevel.psu}".to_sym do %>
+  <%= form.radio_button :access_rights, Repository::AccessControls::AccessLevel.psu %>
   <%= Vocab::AccessLevel.PennState.label %>
 <% end %>
 
-<%= form.label "access_rights_#{Repository::AccessLevel.restricted}".to_sym do %>
-  <%= form.radio_button :access_rights, Repository::AccessLevel.restricted %>
+<%= form.label "access_rights_#{Repository::AccessControls::AccessLevel.restricted}".to_sym do %>
+  <%= form.radio_button :access_rights, Repository::AccessControls::AccessLevel.restricted %>
   <%= Vocab::AccessLevel.Restricted.label %>
 <% end %>

--- a/lib/tasks/ingest.rake
+++ b/lib/tasks/ingest.rake
@@ -31,7 +31,7 @@ namespace :cho do
       collection = Collection::Archival.new(
         title: "Collection for #{id}",
         alternate_ids: [id],
-        access_rights: Repository::AccessLevel.public,
+        access_rights: Repository::AccessControls::AccessLevel.public,
         workflow: 'default'
       )
       change_set_persister.persister.save(resource: collection)

--- a/spec/cho/collection/archival_collections/new_spec.rb
+++ b/spec/cho/collection/archival_collections/new_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Collection::Archival, type: :feature do
       expect(page).to have_content('new subtitle')
       expect(page).to have_content('Description of new collection')
       expect(page).to have_content('mediated')
-      expect(page).to have_content(Repository::AccessLevel.psu)
+      expect(page).to have_content(Repository::AccessControls::AccessLevel.psu)
     end
   end
 

--- a/spec/cho/collection/archival_collections/show_spec.rb
+++ b/spec/cho/collection/archival_collections/show_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Collection::Archival, type: :feature do
       expect(page).to have_content('subtitle for an archival collection')
       expect(page).to have_content('Sample archival collection')
       expect(page).to have_content('default')
-      expect(page).to have_content(Repository::AccessLevel.public)
+      expect(page).to have_content(Repository::AccessControls::AccessLevel.public)
       click_button('Edit')
       expect(page).to have_field('archival_collection[title]', with: 'Archival Collection')
       expect(page).not_to have_link('Back')

--- a/spec/cho/collection/curated_collections/new_spec.rb
+++ b/spec/cho/collection/curated_collections/new_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Collection::Curated, type: :feature do
       expect(page).to have_content('new subtitle')
       expect(page).to have_content('Description of new collection')
       expect(page).to have_content('mediated')
-      expect(page).to have_content(Repository::AccessLevel.psu)
+      expect(page).to have_content(Repository::AccessControls::AccessLevel.psu)
     end
   end
 

--- a/spec/cho/collection/curated_collections/show_spec.rb
+++ b/spec/cho/collection/curated_collections/show_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Collection::Curated, type: :feature do
       expect(page).to have_content('subtitle for a curated collection')
       expect(page).to have_content('Sample curated collection')
       expect(page).to have_content('default')
-      expect(page).to have_content(Repository::AccessLevel.public)
+      expect(page).to have_content(Repository::AccessControls::AccessLevel.public)
       click_button('Edit')
       expect(page).to have_field('curated_collection[title]', with: 'Curated Collection')
       expect(page).not_to have_link('Back')

--- a/spec/cho/collection/library_collections/new_spec.rb
+++ b/spec/cho/collection/library_collections/new_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Collection::Library, type: :feature do
       expect(page).to have_content('new subtitle')
       expect(page).to have_content('Description of new collection')
       expect(page).to have_content('mediated')
-      expect(page).to have_content(Repository::AccessLevel.psu)
+      expect(page).to have_content(Repository::AccessControls::AccessLevel.psu)
     end
   end
 

--- a/spec/cho/collection/library_collections/show_spec.rb
+++ b/spec/cho/collection/library_collections/show_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Collection::Library, type: :feature do
       expect(page).to have_content('subtitle for a library collection')
       expect(page).to have_content('Sample library collection')
       expect(page).to have_content('default')
-      expect(page).to have_content(Repository::AccessLevel.public)
+      expect(page).to have_content(Repository::AccessControls::AccessLevel.public)
       click_button('Edit')
       expect(page).to have_field('library_collection[title]', with: 'Library Collection')
       expect(page).not_to have_link('Back')

--- a/spec/cho/repository/access_controls/access_level_spec.rb
+++ b/spec/cho/repository/access_controls/access_level_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Repository::AccessLevel do
+RSpec.describe Repository::AccessControls::AccessLevel do
   describe '::uris' do
     specify do
       expect(described_class.uris).to contain_exactly(

--- a/spec/cho/repository/access_controls/change_set_behaviors_spec.rb
+++ b/spec/cho/repository/access_controls/change_set_behaviors_spec.rb
@@ -2,16 +2,16 @@
 
 require 'rails_helper'
 
-RSpec.describe Repository::Access::ChangeSetBehaviors do
+RSpec.describe Repository::AccessControls::ChangeSetBehaviors do
   subject(:change_set) { ControlledChangeSet.new(ControlledResource.new) }
 
   before(:all) do
     class ControlledResource < Valkyrie::Resource
-      include Repository::Access::ResourceControls
+      include Repository::AccessControls::Fields
     end
 
     class ControlledChangeSet < Valkyrie::ChangeSet
-      include Repository::Access::ChangeSetBehaviors
+      include Repository::AccessControls::ChangeSetBehaviors
     end
   end
 
@@ -21,7 +21,7 @@ RSpec.describe Repository::Access::ChangeSetBehaviors do
   end
 
   describe '#system_creator' do
-    its(:system_creator) { is_expected.to be(Repository::Access::ResourceControls::DEFAULT_SYSTEM_USER) }
+    its(:system_creator) { is_expected.to be(Repository::AccessControls::Fields::DEFAULT_SYSTEM_USER) }
 
     it { is_expected.to be_required(:system_creator) }
     it { is_expected.not_to be_multiple(:system_creator) }
@@ -56,7 +56,7 @@ RSpec.describe Repository::Access::ChangeSetBehaviors do
   end
 
   describe '#read_groups' do
-    its(:read_groups) { is_expected.to contain_exactly(Repository::AccessLevel.public) }
+    its(:read_groups) { is_expected.to contain_exactly(Repository::AccessControls::AccessLevel.public) }
 
     it { is_expected.not_to be_required(:read_groups) }
     it { is_expected.to be_multiple(:read_groups) }

--- a/spec/cho/repository/access_controls/fields_spec.rb
+++ b/spec/cho/repository/access_controls/fields_spec.rb
@@ -2,10 +2,10 @@
 
 require 'rails_helper'
 
-RSpec.describe Repository::Access::ResourceControls do
+RSpec.describe Repository::AccessControls::Fields do
   before(:all) do
     class ControlledResource < Valkyrie::Resource
-      include Repository::Access::ResourceControls
+      include Repository::AccessControls::Fields
     end
   end
 
@@ -96,7 +96,7 @@ RSpec.describe Repository::Access::ResourceControls do
 
     it 'is public when not set' do
       resource = resource_klass.new
-      expect(resource.read_groups).to contain_exactly(Repository::AccessLevel.public)
+      expect(resource.read_groups).to contain_exactly(Repository::AccessControls::AccessLevel.public)
     end
   end
 
@@ -155,7 +155,7 @@ RSpec.describe Repository::Access::ResourceControls do
   describe '#system_creator' do
     it 'defaults to the default system user' do
       resource = resource_klass.new
-      expect(resource.system_creator).to eq(Repository::Access::ResourceControls::DEFAULT_SYSTEM_USER)
+      expect(resource.system_creator).to eq(Repository::AccessControls::Fields::DEFAULT_SYSTEM_USER)
     end
   end
 end

--- a/spec/cho/transaction/operations/access_controls/access_level_spec.rb
+++ b/spec/cho/transaction/operations/access_controls/access_level_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe Transaction::Operations::AccessControls::AccessLevel do
 
   before(:all) do
     class AccessResource < Valkyrie::Resource
-      include Repository::Access::ResourceControls
+      include Repository::AccessControls::Fields
       attribute :access_rights
     end
 
     class AccessChangeSet < Valkyrie::ChangeSet
-      include Repository::Access::ChangeSetBehaviors
+      include Repository::AccessControls::ChangeSetBehaviors
       property :access_rights
-      validates :access_rights, inclusion: { in: Repository::AccessLevel.names }
+      validates :access_rights, inclusion: { in: Repository::AccessControls::AccessLevel.names }
     end
   end
 
@@ -27,82 +27,82 @@ RSpec.describe Transaction::Operations::AccessControls::AccessLevel do
   describe '#call' do
     context 'when changing from public default to Penn State' do
       specify do
-        expect(change_set.read_groups).to contain_exactly(Repository::AccessLevel.public)
-        change_set.access_rights = Repository::AccessLevel.psu
+        expect(change_set.read_groups).to contain_exactly(Repository::AccessControls::AccessLevel.public)
+        change_set.access_rights = Repository::AccessControls::AccessLevel.psu
         result = described_class.new.call(change_set)
-        expect(result.success.read_groups).to contain_exactly(Repository::AccessLevel.psu)
+        expect(result.success.read_groups).to contain_exactly(Repository::AccessControls::AccessLevel.psu)
       end
     end
 
     context 'when changing from public default to private' do
       specify do
-        expect(change_set.read_groups).to contain_exactly(Repository::AccessLevel.public)
-        change_set.access_rights = Repository::AccessLevel.restricted
+        expect(change_set.read_groups).to contain_exactly(Repository::AccessControls::AccessLevel.public)
+        change_set.access_rights = Repository::AccessControls::AccessLevel.restricted
         result = described_class.new.call(change_set)
-        expect(result.success.read_groups).to contain_exactly(Repository::AccessLevel.restricted)
+        expect(result.success.read_groups).to contain_exactly(Repository::AccessControls::AccessLevel.restricted)
       end
     end
 
     context 'when changing from Penn State to private' do
-      before { change_set.read_groups = [Repository::AccessLevel.psu] }
+      before { change_set.read_groups = [Repository::AccessControls::AccessLevel.psu] }
 
       specify do
-        change_set.access_rights = Repository::AccessLevel.restricted
+        change_set.access_rights = Repository::AccessControls::AccessLevel.restricted
         result = described_class.new.call(change_set)
-        expect(result.success.read_groups).to contain_exactly(Repository::AccessLevel.restricted)
+        expect(result.success.read_groups).to contain_exactly(Repository::AccessControls::AccessLevel.restricted)
       end
     end
 
     context 'when changing from Penn State to public' do
-      before { change_set.read_groups = [Repository::AccessLevel.psu] }
+      before { change_set.read_groups = [Repository::AccessControls::AccessLevel.psu] }
 
       specify do
-        change_set.access_rights = Repository::AccessLevel.public
+        change_set.access_rights = Repository::AccessControls::AccessLevel.public
         result = described_class.new.call(change_set)
-        expect(result.success.read_groups).to contain_exactly(Repository::AccessLevel.public)
+        expect(result.success.read_groups).to contain_exactly(Repository::AccessControls::AccessLevel.public)
       end
     end
 
     context 'when changing from private to Penn State' do
-      before { change_set.read_groups = [Repository::AccessLevel.restricted] }
+      before { change_set.read_groups = [Repository::AccessControls::AccessLevel.restricted] }
 
       specify do
-        change_set.access_rights = Repository::AccessLevel.psu
+        change_set.access_rights = Repository::AccessControls::AccessLevel.psu
         result = described_class.new.call(change_set)
-        expect(result.success.read_groups).to contain_exactly(Repository::AccessLevel.psu)
+        expect(result.success.read_groups).to contain_exactly(Repository::AccessControls::AccessLevel.psu)
       end
     end
 
     context 'when changing from private to public' do
-      before { change_set.read_groups = [Repository::AccessLevel.restricted] }
+      before { change_set.read_groups = [Repository::AccessControls::AccessLevel.restricted] }
 
       specify do
-        change_set.access_rights = Repository::AccessLevel.public
+        change_set.access_rights = Repository::AccessControls::AccessLevel.public
         result = described_class.new.call(change_set)
-        expect(result.success.read_groups).to contain_exactly(Repository::AccessLevel.public)
+        expect(result.success.read_groups).to contain_exactly(Repository::AccessControls::AccessLevel.public)
       end
     end
 
     context 'when changing access levels with other read groups present' do
-      before { change_set.read_groups = [Repository::AccessLevel.restricted, 'group1', 'group2'] }
+      before { change_set.read_groups = [Repository::AccessControls::AccessLevel.restricted, 'group1', 'group2'] }
 
       specify do
-        change_set.access_rights = Repository::AccessLevel.psu
+        change_set.access_rights = Repository::AccessControls::AccessLevel.psu
         result = described_class.new.call(change_set)
-        expect(result.success.read_groups).to contain_exactly(Repository::AccessLevel.psu, 'group1', 'group2')
+        expect(result.success.read_groups).to contain_exactly(Repository::AccessControls::AccessLevel.psu, 'group1', 'group2')
       end
     end
 
     context 'when no changes are made' do
       before do
-        change_set.access_rights = Repository::AccessLevel.restricted
-        change_set.read_groups = [Repository::AccessLevel.restricted]
+        change_set.access_rights = Repository::AccessControls::AccessLevel.restricted
+        change_set.read_groups = [Repository::AccessControls::AccessLevel.restricted]
       end
 
       specify do
         result = described_class.new.call(change_set)
-        expect(result.success.read_groups).to contain_exactly(Repository::AccessLevel.restricted)
-        expect(result.success.access_rights).to eq(Repository::AccessLevel.restricted)
+        expect(result.success.read_groups).to contain_exactly(Repository::AccessControls::AccessLevel.restricted)
+        expect(result.success.access_rights).to eq(Repository::AccessControls::AccessLevel.restricted)
       end
     end
 

--- a/spec/cho/transaction/operations/access_controls/permissions_spec.rb
+++ b/spec/cho/transaction/operations/access_controls/permissions_spec.rb
@@ -5,11 +5,11 @@ require 'rails_helper'
 RSpec.describe Transaction::Operations::AccessControls::Permissions do
   before(:all) do
     class PermissionsResource < Valkyrie::Resource
-      include Repository::Access::ResourceControls
+      include Repository::AccessControls::Fields
     end
 
     class PermissionsChangeSet < Valkyrie::ChangeSet
-      include Repository::Access::ChangeSetBehaviors
+      include Repository::AccessControls::ChangeSetBehaviors
     end
   end
 

--- a/spec/cho/transaction/operations/access_controls/system_creator_spec.rb
+++ b/spec/cho/transaction/operations/access_controls/system_creator_spec.rb
@@ -5,11 +5,11 @@ require 'rails_helper'
 RSpec.describe Transaction::Operations::AccessControls::SystemCreator do
   before(:all) do
     class SystemCreatorResource < Valkyrie::Resource
-      include Repository::Access::ResourceControls
+      include Repository::AccessControls::Fields
     end
 
     class SystemCreatorChangeSet < Valkyrie::ChangeSet
-      include Repository::Access::ChangeSetBehaviors
+      include Repository::AccessControls::ChangeSetBehaviors
     end
   end
 
@@ -50,7 +50,7 @@ RSpec.describe Transaction::Operations::AccessControls::SystemCreator do
         before { change_set.current_user = user }
 
         it 'updates the system creator' do
-          expect(change_set.system_creator).to eq(Repository::Access::ResourceControls::DEFAULT_SYSTEM_USER)
+          expect(change_set.system_creator).to eq(Repository::AccessControls::Fields::DEFAULT_SYSTEM_USER)
           result = described_class.new.call(change_set)
           expect(result).to be_success
           expect(result.success.system_creator).to eq(user.login)

--- a/spec/cho/validation/access_rights_spec.rb
+++ b/spec/cho/validation/access_rights_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Validation::AccessRights do
     let(:validation_instance) { described_class.new }
 
     context 'with a valid access level' do
-      let(:access_level) { Repository::AccessLevel.public }
+      let(:access_level) { Repository::AccessControls::AccessLevel.public }
 
       it 'is valid' do
         expect(validation_instance.validate(access_level)).to be_truthy

--- a/spec/devise/user_spec.rb
+++ b/spec/devise/user_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe User, type: :model do
 
       it 'returns a list of groups from the database' do
         expect(user).not_to receive(:populate_attributes)
-        expect(user.groups).to contain_exactly('group1', 'group2', Repository::AccessLevel.psu)
+        expect(user.groups).to contain_exactly('group1', 'group2', Repository::AccessControls::AccessLevel.psu)
       end
     end
 
@@ -47,7 +47,7 @@ RSpec.describe User, type: :model do
 
       it 'returns a list of groups from the database' do
         expect(PsuDir::LdapUser).to receive(:get_groups).with(user.login).and_return(groups)
-        expect(user.groups).to contain_exactly('group1', 'group2', Repository::AccessLevel.psu)
+        expect(user.groups).to contain_exactly('group1', 'group2', Repository::AccessControls::AccessLevel.psu)
       end
     end
 
@@ -57,7 +57,7 @@ RSpec.describe User, type: :model do
 
       it 'returns a list of groups from the database' do
         expect(PsuDir::LdapUser).to receive(:get_groups).with(user.login).and_return(groups)
-        expect(user.groups).to contain_exactly('group1', 'group2', Repository::AccessLevel.psu)
+        expect(user.groups).to contain_exactly('group1', 'group2', Repository::AccessControls::AccessLevel.psu)
       end
     end
 
@@ -66,7 +66,7 @@ RSpec.describe User, type: :model do
 
       it 'returns a the default list of groups' do
         expect(PsuDir::LdapUser).to receive(:get_groups).with(user.login).and_return([])
-        expect(user.groups).to contain_exactly(Repository::AccessLevel.psu)
+        expect(user.groups).to contain_exactly(Repository::AccessControls::AccessLevel.psu)
       end
     end
   end

--- a/spec/factories/archival_collections.rb
+++ b/spec/factories/archival_collections.rb
@@ -6,15 +6,15 @@ FactoryBot.define do
     subtitle { 'subtitle for an archival collection' }
     description { 'Sample archival collection' }
     workflow { 'default' }
-    access_rights { Repository::AccessLevel.public }
+    access_rights { Repository::AccessControls::AccessLevel.public }
 
     factory :psu_collection do
-      access_rights { Repository::AccessLevel.psu }
-      read_groups { [Repository::AccessLevel.psu] }
+      access_rights { Repository::AccessControls::AccessLevel.psu }
+      read_groups { [Repository::AccessControls::AccessLevel.psu] }
     end
 
     factory :private_collection, aliases: [:restricted_collection] do
-      access_rights { Repository::AccessLevel.restricted }
+      access_rights { Repository::AccessControls::AccessLevel.restricted }
       read_groups { [] }
     end
   end

--- a/spec/factories/curated_collections.rb
+++ b/spec/factories/curated_collections.rb
@@ -6,15 +6,15 @@ FactoryBot.define do
     description { 'Sample curated collection' }
     subtitle { 'subtitle for a curated collection' }
     workflow { 'default' }
-    access_rights { Repository::AccessLevel.public }
+    access_rights { Repository::AccessControls::AccessLevel.public }
 
     factory :psu_curated_collection do
-      access_rights { Repository::AccessLevel.psu }
-      read_groups { [Repository::AccessLevel.psu] }
+      access_rights { Repository::AccessControls::AccessLevel.psu }
+      read_groups { [Repository::AccessControls::AccessLevel.psu] }
     end
 
     factory :private_curated_collection, aliases: [:restricted_curated_collection] do
-      access_rights { Repository::AccessLevel.restricted }
+      access_rights { Repository::AccessControls::AccessLevel.restricted }
       read_groups { [] }
     end
   end

--- a/spec/factories/library_collections.rb
+++ b/spec/factories/library_collections.rb
@@ -6,15 +6,15 @@ FactoryBot.define do
     description { 'Sample library collection' }
     subtitle { 'subtitle for a library collection' }
     workflow { 'default' }
-    access_rights { Repository::AccessLevel.public }
+    access_rights { Repository::AccessControls::AccessLevel.public }
 
     factory :psu_library_collection do
-      access_rights { Repository::AccessLevel.psu }
-      read_groups { [Repository::AccessLevel.psu] }
+      access_rights { Repository::AccessControls::AccessLevel.psu }
+      read_groups { [Repository::AccessControls::AccessLevel.psu] }
     end
 
     factory :private_library_collection, aliases: [:restricted_library_collection] do
-      access_rights { Repository::AccessLevel.restricted }
+      access_rights { Repository::AccessControls::AccessLevel.restricted }
       read_groups { [] }
     end
   end

--- a/spec/factories/shared_traits.rb
+++ b/spec/factories/shared_traits.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   trait :restricted_to_penn_state do
-    read_groups { [Repository::AccessLevel.psu] }
+    read_groups { [Repository::AccessControls::AccessLevel.psu] }
   end
 
   trait :restricted do

--- a/spec/support/shared/controllers.rb
+++ b/spec/support/shared/controllers.rb
@@ -7,7 +7,7 @@ RSpec.shared_examples 'a collection controller' do
       subtitle: 'use only for testing',
       description: 'A sample collection',
       workflow: 'default',
-      access_rights: Repository::AccessLevel.public
+      access_rights: Repository::AccessControls::AccessLevel.public
     }
   end
 
@@ -68,7 +68,7 @@ RSpec.shared_examples 'a collection controller' do
           subtitle: 'use only for testing',
           description: 'An updated sample collection',
           workflow: 'default',
-          access_rights: Repository::AccessLevel.public
+          access_rights: Repository::AccessControls::AccessLevel.public
         }
       end
 


### PR DESCRIPTION
## Description

In keeping with the transaction operation namespace, the Access module is renamed to AccessControls. Access levels are now contained within that namespace, as well as ResourceControls is renamed to just Fields which better correlates with other similar classes.

This keeps the naming conventions more consistent throughout the application.
