### PR TITLE
Enable default values on change sets and resources

### DIFF
--- a/app/cho/data_dictionary/field.rb
+++ b/app/cho/data_dictionary/field.rb
@@ -54,6 +54,8 @@ module DataDictionary
         Valkyrie::Types::Set.of(Valkyrie::Types::ID)
       elsif date?
         Valkyrie::Types::Set.of(Valkyrie::Types::Date)
+      elsif default_value.present?
+        Valkyrie::Types::Set.default([default_value])
       else
         Valkyrie::Types::Set.optional
       end
@@ -69,6 +71,8 @@ module DataDictionary
         Valkyrie::Types::Set.of(Valkyrie::Types::ID)
       elsif date?
         Valkyrie::Types::Set.of(Valkyrie::Types::Date)
+      elsif default_value.present?
+        Valkyrie::Types::Set.default([default_value]).meta(ordered: true)
       else
         Valkyrie::Types::Set.meta(ordered: true)
       end

--- a/app/views/shared/input_partials/_radio_button.html.erb
+++ b/app/views/shared/input_partials/_radio_button.html.erb
@@ -1,16 +1,22 @@
 <%# This is tied directly to access rights. We can refactor later if we need different kinds of buttons %>
 
 <%= form.label "access_rights_#{Repository::AccessControls::AccessLevel.public}".to_sym do %>
-  <%= form.radio_button :access_rights, Repository::AccessControls::AccessLevel.public %>
+  <%= form.radio_button :access_rights,
+                        Repository::AccessControls::AccessLevel.public,
+                        checked: form.object.access_rights.include?(Repository::AccessControls::AccessLevel.public) %>
   <%= Vocab::AccessLevel.Public.label %>
 <% end %>
 
 <%= form.label "access_rights_#{Repository::AccessControls::AccessLevel.psu}".to_sym do %>
-  <%= form.radio_button :access_rights, Repository::AccessControls::AccessLevel.psu %>
+  <%= form.radio_button :access_rights,
+                        Repository::AccessControls::AccessLevel.psu,
+                        checked: form.object.access_rights.include?(Repository::AccessControls::AccessLevel.psu) %>
   <%= Vocab::AccessLevel.PennState.label %>
 <% end %>
 
 <%= form.label "access_rights_#{Repository::AccessControls::AccessLevel.restricted}".to_sym do %>
-  <%= form.radio_button :access_rights, Repository::AccessControls::AccessLevel.restricted %>
+  <%= form.radio_button :access_rights,
+                        Repository::AccessControls::AccessLevel.restricted,
+                        checked: form.object.access_rights.include?(Repository::AccessControls::AccessLevel.restricted) %>
   <%= Vocab::AccessLevel.Restricted.label %>
 <% end %>

--- a/config/data_dictionary/data_dictionary_development.csv
+++ b/config/data_dictionary/data_dictionary_development.csv
@@ -26,7 +26,7 @@ place,string,optional,no_validation,true,no_vocabulary,,Place of Publication,no_
 series,string,optional,no_validation,true,no_vocabulary,,Series,no_transformation,no_facet,help me,false
 box,string,optional,no_validation,true,no_vocabulary,,Box and Folder,no_transformation,no_facet,help me,false
 finding_aid,string,optional,no_validation,true,no_vocabulary,,Finding Aid,no_transformation,no_facet,help me,false
-access_rights,radio_button,optional,access_rights,false,access_rights,,Access Rights,no_transformation,no_facet,help me,false
+access_rights,radio_button,optional,access_rights,false,access_rights,public,Access Rights,no_transformation,no_facet,help me,false
 alternate_title,string,optional,no_validation,true,no_vocabulary,,Alternate Title,no_transformation,no_facet,help me,false
 scale,string,optional,no_validation,true,no_vocabulary,,Scale,no_transformation,no_facet,help me,false
 projection,string,optional,no_validation,true,no_vocabulary,,Projection,no_transformation,no_facet,help me,false

--- a/config/data_dictionary/data_dictionary_production.csv
+++ b/config/data_dictionary/data_dictionary_production.csv
@@ -26,7 +26,7 @@ place,string,optional,no_validation,true,no_vocabulary,,Place of Publication,no_
 series,string,optional,no_validation,true,no_vocabulary,,Series,no_transformation,no_facet,help me,false
 box,string,optional,no_validation,true,no_vocabulary,,Box and Folder,no_transformation,no_facet,help me,false
 finding_aid,string,optional,no_validation,true,no_vocabulary,,Finding Aid,no_transformation,no_facet,help me,false
-access_rights,radio_button,optional,access_rights,false,access_rights,,Access Rights,no_transformation,no_facet,help me,false
+access_rights,radio_button,optional,access_rights,false,access_rights,public,Access Rights,no_transformation,no_facet,help me,false
 alternate_title,string,optional,no_validation,true,no_vocabulary,,Alternate Title,no_transformation,no_facet,help me,false
 scale,string,optional,no_validation,true,no_vocabulary,,Scale,no_transformation,no_facet,help me,false
 projection,string,optional,no_validation,true,no_vocabulary,,Projection,no_transformation,no_facet,help me,false

--- a/config/data_dictionary/data_dictionary_test.csv
+++ b/config/data_dictionary/data_dictionary_test.csv
@@ -12,7 +12,7 @@ still_image_field,string,optional,no_validation,true,no_vocabulary,,,no_transfor
 moving_image_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false
 map_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false
 audio_field,string,optional,no_validation,true,no_vocabulary,,,no_transformation,no_facet,help me,false
-access_rights,radio_button,optional,access_rights,false,access_rights,,Access Rights,no_transformation,no_facet,help me,false
+access_rights,radio_button,optional,access_rights,false,access_rights,public,Access Rights,no_transformation,no_facet,help me,false
 alternate_ids,alternate_id,required_to_publish,unique,true,no_vocabulary,,Identifier,no_transformation,no_facet,help me,true
 creator,creator,optional,creator,true,creator_vocabulary,,Creator,no_transformation,linked_field,help me,true
 date_cataloged,date,optional,edtf_date,true,no_vocabulary,,Date Cataloged,no_transformation,date,help me,true

--- a/spec/blacklight/solr_document_spec.rb
+++ b/spec/blacklight/solr_document_spec.rb
@@ -120,11 +120,11 @@ RSpec.describe SolrDocument, type: :model do
     context 'with a collection containing works and file sets' do
       let(:collection) { create :library_collection }
       let(:work) { create :work, :with_file, home_collection_id: [collection.id], title: 'Work One' }
-      let(:work1_csv) { "#{work.id},Generic,Work One,,,,,,,,,,,,#{collection.id},,,," }
-      let(:file_set1_csv) { "#{work.member_ids.first},,hello_world.txt,,,,,,,,,,,,,,,," }
+      let(:work1_csv) { "#{work.id},Generic,Work One,,,,,,public,,,,,,#{collection.id},,,," }
+      let(:file_set1_csv) { "#{work.member_ids.first},,hello_world.txt,,,,,,public,,,,,,,,,," }
       let(:work2) { create :work, :with_file, home_collection_id: [collection.id], title: 'Work Two' }
-      let(:work2_csv) { "#{work2.id},Generic,Work Two,,,,,,,,,,,,#{collection.id},,,," }
-      let(:file_set2_csv) { "#{work2.member_ids.first},,hello_world.txt,,,,,,,,,,,,,,,," }
+      let(:work2_csv) { "#{work2.id},Generic,Work Two,,,,,,public,,,,,,#{collection.id},,,," }
+      let(:file_set2_csv) { "#{work2.member_ids.first},,hello_world.txt,,,,,,public,,,,,,,,,," }
 
       let(:document) do
         { 'internal_resource_tsim' => 'MyCollection', id: collection.id, title_tesim: ['my_collection'] }
@@ -157,7 +157,7 @@ RSpec.describe SolrDocument, type: :model do
 
       let(:file_set) { create(:file_set) }
       let(:work_csv) { 'abc123,,my_title,,,,,,,,,,,value1||value2,xyx789,,,,' }
-      let(:file_set_csv) { "#{file_set.id},,Original File Name,,,,,,,,,,,,,,,," }
+      let(:file_set_csv) { "#{file_set.id},,Original File Name,,,,,,public,,,,,,,,,," }
 
       before { file_set }
 

--- a/spec/cho/collection/archival_collections/edit_spec.rb
+++ b/spec/cho/collection/archival_collections/edit_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Collection::Archival, type: :feature do
       expect(page).to have_field('Description', type: 'textarea', with: 'Sample archival collection')
       fill_in('archival_collection[title]', with: 'Updated Archival Collection Title')
       fill_in('archival_collection[description][]', with: 'Updated archival collection description')
+      expect(find("#archival_collection_access_rights_#{Repository::AccessControls::AccessLevel.public}")).to be_checked
       click_button('Update Archival collection')
       expect(page).to have_content('Updated Archival Collection Title')
       expect(page).to have_content('Updated archival collection description')

--- a/spec/cho/collection/archival_collections/new_spec.rb
+++ b/spec/cho/collection/archival_collections/new_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Collection::Archival, type: :feature do
       fill_in('archival_collection[title]', with: 'New Title')
       fill_in('archival_collection[subtitle][]', with: 'new subtitle')
       fill_in('archival_collection[description][]', with: 'Description of new collection')
+      expect(find("#archival_collection_access_rights_#{Repository::AccessControls::AccessLevel.public}")).to be_checked
       choose('Mediated')
       choose('PSU Access')
       click_button('Create Archival collection')

--- a/spec/cho/collection/curated_collections/edit_spec.rb
+++ b/spec/cho/collection/curated_collections/edit_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Collection::Curated, type: :feature do
       expect(page).to have_field('Description', type: 'textarea', with: 'Sample curated collection')
       fill_in('curated_collection[title]', with: 'Updated Curated Collection Title')
       fill_in('curated_collection[description][]', with: 'Updated curated collection description')
+      expect(find("#curated_collection_access_rights_#{Repository::AccessControls::AccessLevel.public}")).to be_checked
       click_button('Update Curated collection')
       expect(page).to have_content('Updated Curated Collection Title')
       expect(page).to have_content('Updated curated collection description')

--- a/spec/cho/collection/curated_collections/new_spec.rb
+++ b/spec/cho/collection/curated_collections/new_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Collection::Curated, type: :feature do
       fill_in('curated_collection[title]', with: 'New Title')
       fill_in('curated_collection[subtitle][]', with: 'new subtitle')
       fill_in('curated_collection[description][]', with: 'Description of new collection')
+      expect(find("#curated_collection_access_rights_#{Repository::AccessControls::AccessLevel.public}")).to be_checked
       choose('Mediated')
       choose('PSU Access')
       click_button('Create Curated collection')

--- a/spec/cho/collection/library_collections/edit_spec.rb
+++ b/spec/cho/collection/library_collections/edit_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Collection::Library, type: :feature do
       expect(page).to have_field('Description', type: 'textarea', with: 'Sample library collection')
       fill_in('library_collection[title]', with: 'Updated Library Collection Title')
       fill_in('library_collection[description][]', with: 'Updated library collection description')
+      expect(find("#library_collection_access_rights_#{Repository::AccessControls::AccessLevel.public}")).to be_checked
       click_button('Update Library collection')
       expect(page).to have_content('Updated Library Collection Title')
       expect(page).to have_content('Updated library collection description')

--- a/spec/cho/collection/library_collections/new_spec.rb
+++ b/spec/cho/collection/library_collections/new_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Collection::Library, type: :feature do
       fill_in('library_collection[title]', with: 'New Title')
       fill_in('library_collection[subtitle][]', with: 'new subtitle')
       fill_in('library_collection[description][]', with: 'Description of new collection')
+      expect(find("#library_collection_access_rights_#{Repository::AccessControls::AccessLevel.public}")).to be_checked
       choose('Mediated')
       choose('PSU Access')
       click_button('Create Library collection')

--- a/spec/cho/data_dictionary/field_spec.rb
+++ b/spec/cho/data_dictionary/field_spec.rb
@@ -84,8 +84,10 @@ RSpec.describe DataDictionary::Field, type: :model do
 
     its(:solr_field) { is_expected.to eq('abc123_label_tesim') }
     its(:solr_search_field) { is_expected.to eq('abc123_label_tesim') }
-    its(:change_set_property_type) { is_expected.to eq(Valkyrie::Types::Set.optional) }
-    its(:resource_property_type) { is_expected.to eq(Valkyrie::Types::Set.meta(ordered: true)) }
+    its(:change_set_property_type) { is_expected.to eq(Valkyrie::Types::Set.default([model.default_value])) }
+    its(:resource_property_type) {
+      is_expected.to eq(Valkyrie::Types::Set.default([model.default_value]).meta(ordered: true))
+    }
   end
 
   context 'with a date field' do
@@ -120,8 +122,10 @@ RSpec.describe DataDictionary::Field, type: :model do
 
     its(:solr_field) { is_expected.to eq('abc123_label_tesim') }
     its(:solr_search_field) { is_expected.to eq('abc123_label_tesim') }
-    its(:change_set_property_type) { is_expected.to eq(Valkyrie::Types::Set.optional) }
-    its(:resource_property_type) { is_expected.to eq(Valkyrie::Types::Set.meta(ordered: true)) }
+    its(:change_set_property_type) { is_expected.to eq(Valkyrie::Types::Set.default([model.default_value])) }
+    its(:resource_property_type) {
+      is_expected.to eq(Valkyrie::Types::Set.default([model.default_value]).meta(ordered: true))
+    }
   end
 
   context 'when saving with metadata' do


### PR DESCRIPTION
## Description

Leverages a data dictionary field's default value on both change sets and resources. This allows us to specify a default value for access rights, as well as render the edit form with the access rights value selected in the radio button.

Connected to #477 and #1012 

## Changes

* adds a field's default value to both the change set and Valkyrie::Resource
* updates the radio_button partial to display with the object's access rights value selected by the radio button