### PR TITLE
Update resources via CSV

### DIFF
--- a/app/cho/csv/importer.rb
+++ b/app/cho/csv/importer.rb
@@ -26,6 +26,7 @@ module Csv
       return false unless valid_list?
 
       change_set_list.each do |change_set|
+        update_member_hashes(change_set)
         result = change_set_persister.validate_and_save(change_set: change_set, resource_params: {})
         if result.errors.blank?
           created << result
@@ -42,6 +43,17 @@ module Csv
         state = change_set_list.map(&:valid?).reduce(:'&')
         errors << 'Invalid items in list' unless state
         state
+      end
+
+      def update_member_hashes(change_set)
+        (change_set.try(:file_set_hashes) || []).map do |file_set_change_set|
+          result = change_set_persister.validate_and_save(change_set: file_set_change_set, resource_params: {})
+          if result.errors.blank?
+            created << result
+          else
+            errors << result
+          end
+        end
       end
 
       def change_set_persister

--- a/spec/cho/work/import/csv_controller_spec.rb
+++ b/spec/cho/work/import/csv_controller_spec.rb
@@ -63,11 +63,13 @@ RSpec.describe Work::Import::CsvController, type: :controller do
         expect(call).to render_template('dry_run_results')
         expect(response).to be_success
         expect(assigns(:presenter)).to be_a(Work::Import::CsvDryRunResultsPresenter)
-        expect(assigns(:presenter).change_set_list.map(&:valid?)).to eq([false, false])
+        expect(assigns(:presenter).change_set_list.map(&:valid?)).to eq([false, false, true, true])
         expect(assigns(:presenter).change_set_list.map(&:errors).map(&:messages)).to eq(
           [
             { work_type_id: ["can't be blank"] },
-            { home_collection_id: ['bad does not exist'], title: ["can't be blank"] }
+            { home_collection_id: ['bad does not exist'], title: ["can't be blank"] },
+            {},
+            {}
           ]
         )
         expect(File).to be_exist(assigns(:file_name))


### PR DESCRIPTION
## Description

Updating existing resources from a CSV failed due the lack of a bag. Bags are now ignored during the csv update process and a work's file sets are updated based on the metadata exported from the csv.

Connected to #888 

## Changes

* any bag reference during a csv update is considered a "failure" and
  will be ignored

* Csv::Importer now updates contained file sets for each work

## Notes

We didn't need any new tests because the existing tests were already exercising this part of the code; however, I believe they were passing because the bag was always present. By forcing `bag` to be a `Dry::Monads::Result::Failure` if we're doing an update, makes `CsvDryRun` build file set hashes on the work from the csv.

There's also a bit of reliance on `file_set_hashes` in the importer since this class is also used for agents and potentially other future non-work resources. There might be a more elegant way of handling that, but this seems to do the trick for now.