### PR TITLE
Consistent look for buttons

### DIFF
--- a/app/assets/stylesheets/cho/blacklight.scss
+++ b/app/assets/stylesheets/cho/blacklight.scss
@@ -20,12 +20,16 @@
 // addresses insufficient color contrast
 .dl-invert dt { color: $gray-middle; }
 
-// Button visited link color
-.btn-danger:visited,
-.btn-primary:visited { color: $primary-white; }
 
 // Button background color
 .btn-primary { background-color: $btn-primary-color; }
+
+// Button hover color
+.btn-primary:hover { background-color: $psul-dark-blue; }
+
+// Button visited link color
+.btn-danger:visited,
+.btn-primary:visited { color: $primary-white; }
 
 // Adds the colored focus around the Bootstrap dropdown
 .dropdown-toggle:focus {

--- a/app/views/agent/import/csv/create.html.erb
+++ b/app/views/agent/import/csv/create.html.erb
@@ -9,6 +9,6 @@
   <%= form.file_field :file %>
 
   <div class="actions">
-    <%= form.submit t('cho.csv.agent.create.submit') %>
+    <%= form.submit t('cho.csv.agent.create.submit'), class: 'btn btn-primary' %>
   </div>
 <% end %>

--- a/app/views/agent/import/csv/dry_run_results.html.erb
+++ b/app/views/agent/import/csv/dry_run_results.html.erb
@@ -26,6 +26,6 @@
 <%= form_tag({ controller: 'csv', action: 'import' }, class: 'form-inline') do %>
   <%= hidden_field_tag(:file_name, @file_name) %>
   <%= hidden_field_tag(:update, @presenter.update?) %>
-  <%= submit_tag(t('cho.csv.agent.dry_run.submit'), disabled: @presenter.invalid?) %>
+  <%= submit_tag(t('cho.csv.agent.dry_run.submit'), class: 'btn btn-primary', disabled: @presenter.invalid?) %>
   <%= link_to t('cho.csv.agent.dry_run.cancel'), :back, class: 'btn btn-link' %>
 <% end %>

--- a/app/views/agent/import/csv/update.html.erb
+++ b/app/views/agent/import/csv/update.html.erb
@@ -9,6 +9,6 @@
   <%= form.file_field :file %>
 
   <div class="actions">
-    <%= form.submit t('cho.csv.agent.update.submit') %>
+    <%= form.submit t('cho.csv.agent.update.submit'), class: 'btn btn-primary' %>
   </div>
 <% end %>

--- a/app/views/agent/resources/index.html.erb
+++ b/app/views/agent/resources/index.html.erb
@@ -14,12 +14,13 @@
       <tr>
         <td><%= agent.given_name %></td>
         <td><%= agent.surname %></td>
-        <td><%= link_to t('cho.agent.index.show'), agent %></td>
-        <td><%= link_to(t('cho.agent.index.edit'), edit_agent_resource_path(agent)) if can? :edit, agent %></td>
+        <td><%= link_to t('cho.agent.index.show'), agent, class: 'btn btn-primary' %></td>
+        <td><%= link_to(t('cho.agent.index.edit'), edit_agent_resource_path(agent), class: 'btn btn-outline-secondary') if can? :edit, agent %></td>
         <td>
           <%# @todo this contains an N+1 query bug, may need to be optimized %>
           <%= if can? :delete, agent
                 link_to(t('cho.agent.index.destroy'), agent,
+                        class: 'btn btn-link',
                         method: :delete, data: { confirm: t('cho.agent.index.confirm') })
               end %>
         </td>
@@ -30,5 +31,5 @@
 
 <br />
 
-<%= link_to t('cho.agent.index.download'), agent_resources_path(format: :csv) %>
-<%= link_to(t('cho.agent.index.new'), new_agent_resource_path) if can? :create, Agent %>
+<%= link_to t('cho.agent.index.download'), agent_resources_path(format: :csv), class: 'btn btn-primary' %>
+<%= link_to(t('cho.agent.index.new'), new_agent_resource_path) if can? :create, Agent, class: 'btn btn-outline-secondary' %>

--- a/app/views/catalog/_document_edit_link.html.erb
+++ b/app/views/catalog/_document_edit_link.html.erb
@@ -1,1 +1,1 @@
-<%= button_to(t('cho.catalog.edit'), edit_cho_resource_path, method: 'get', class: 'btn btn-outline-secondary') if can? :edit, @document %>
+<%= button_to(t('cho.catalog.edit'), edit_cho_resource_path, method: 'get', class: 'btn btn-primary') if can? :edit, @document %>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,8 +1,8 @@
 <%# Overriding Blacklight to render edit link %>
 
 <% if current_search_session %>
-  <div id="appliedParams" class="clearfix constraints-container ml-3">
-    <%= link_back_to_catalog(label: 'Back to Search Results', class: 'btn btn-outline-secondary') %>
+  <div id="appliedParams">
+    <%= link_back_to_catalog(label: 'Back to Search Results', class: 'btn btn-link') %>
     <%= render 'previous_next_doc' if @search_context %>
   </div>
 <% end %>

--- a/app/views/collection/archival_collections/edit.html.erb
+++ b/app/views/collection/archival_collections/edit.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'collection/base/form', collection: @collection %>
 <%= render 'shared/form_delete', resource: @collection %>
-<%= button_to t('cho.archival_collection.edit.show'), polymorphic_path([:solr_document], id: @collection.id), method: 'get', class: 'btn btn-outline-secondary' %>
+<%= button_to t('cho.archival_collection.edit.show'), polymorphic_path([:solr_document], id: @collection.id), method: 'get', class: 'btn btn-link' %>

--- a/app/views/collection/base/_form.html.erb
+++ b/app/views/collection/base/_form.html.erb
@@ -19,6 +19,6 @@
   <%= render '/work/submissions/errors', work: collection if collection.errors.any? %>
 
   <div class="actions">
-    <%= form.submit class: 'btn btn-outline-secondary' %>
+    <%= form.submit class: 'btn btn-primary' %>
   </div>
 <% end %>

--- a/app/views/collection/curated_collections/edit.html.erb
+++ b/app/views/collection/curated_collections/edit.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'collection/base/form', collection: @collection %>
 <%= render 'shared/form_delete', resource: @collection %>
-<%= link_to t('cho.curated_collection.edit.show'), polymorphic_path([:solr_document], id: @collection.id), method: 'get', class: 'btn btn-outline-secondary' %>
+<%= link_to t('cho.curated_collection.edit.show'), polymorphic_path([:solr_document], id: @collection.id), method: 'get', class: 'btn btn-link' %>

--- a/app/views/collection/library_collections/edit.html.erb
+++ b/app/views/collection/library_collections/edit.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'collection/base/form', collection: @collection %>
 <%= render 'shared/form_delete', resource: @collection %>
-<%= link_to t('cho.library_collection.edit.show'), polymorphic_path([:solr_document], id: @collection.id), method: 'get', class: 'btn btn-outline-secondary' %>
+<%= link_to t('cho.library_collection.edit.show'), polymorphic_path([:solr_document], id: @collection.id), method: 'get', class: 'btn btn-link' %>

--- a/app/views/work/file_sets/_form.html.erb
+++ b/app/views/work/file_sets/_form.html.erb
@@ -7,6 +7,6 @@
   <%= render 'errors', file_set: file_set_form if file_set_form.errors.any? %>
 
   <div class="actions pt-4">
-    <%= form.submit t('cho.file_set.edit.submit'), class: 'btn btn-outline-secondary' %>
+    <%= form.submit t('cho.file_set.edit.submit'), class: 'btn btn-primary' %>
   </div>
 <% end %>

--- a/app/views/work/file_sets/edit.html.erb
+++ b/app/views/work/file_sets/edit.html.erb
@@ -3,4 +3,4 @@
 
 <%= render partial: 'form', locals: { file_set_form: @file_set } %>
 <%= render 'shared/form_delete', resource: @file_set %>
-<%= link_to t('cho.work.edit.show_link'), polymorphic_path([:solr_document], id: @file_set.id), class: 'btn btn-outline-secondary' %>
+<%= link_to t('cho.work.edit.show_link'), polymorphic_path([:solr_document], id: @file_set.id), class: 'btn btn-link' %>

--- a/app/views/work/import/csv/create.html.erb
+++ b/app/views/work/import/csv/create.html.erb
@@ -9,6 +9,6 @@
   <%= form.file_field :file %>
 
   <div class="actions">
-    <%= form.submit t('cho.csv.work.create.submit') %>
+    <%= form.submit t('cho.csv.work.create.submit'), class: 'btn btn-primary' %>
   </div>
 <% end %>

--- a/app/views/work/import/csv/dry_run_results.html.erb
+++ b/app/views/work/import/csv/dry_run_results.html.erb
@@ -39,6 +39,6 @@
 <%= form_tag({ controller: 'csv', action: 'import' }, class: 'form-inline') do %>
   <%= hidden_field_tag(:file_name, @file_name) %>
   <%= hidden_field_tag(:update, @presenter.update?) %>
-  <%= submit_tag(t('cho.csv.work.dry_run.submit'), disabled: @presenter.invalid?) %>
+  <%= submit_tag(t('cho.csv.work.dry_run.submit'), class: 'btn btn-primary', disabled: @presenter.invalid?) %>
   <%= link_to t('cho.csv.work.dry_run.cancel'), :back, class: 'btn btn-link' %>
 <% end %>

--- a/app/views/work/import/csv/update.html.erb
+++ b/app/views/work/import/csv/update.html.erb
@@ -9,6 +9,6 @@
   <%= form.file_field :file %>
 
   <div class="actions">
-    <%= form.submit t('cho.csv.work.update.submit') %>
+    <%= form.submit t('cho.csv.work.update.submit'), class: 'btn btn-primary' %>
   </div>
 <% end %>

--- a/app/views/work/submissions/_form.html.erb
+++ b/app/views/work/submissions/_form.html.erb
@@ -16,6 +16,6 @@
   <%= render 'errors', work: work_form if work_form.errors.any? %>
 
   <div class="actions pt-4">
-    <%= form.submit work_form.submit_text, class: 'btn btn-outline-secondary' %>
+    <%= form.submit work_form.submit_text, class: 'btn btn-primary' %>
   </div>
 <% end %>

--- a/app/views/work/submissions/edit.html.erb
+++ b/app/views/work/submissions/edit.html.erb
@@ -3,4 +3,4 @@
 
 <%= render partial: 'form', locals: { work_form: @work } %>
 <%= render 'shared/form_delete', resource: @work %>
-<%= button_to t('cho.work.edit.show_link'), polymorphic_path([:solr_document], id: @work.id), method: 'get', class: 'btn btn-outline-secondary' %>
+<%= button_to t('cho.work.edit.show_link'), polymorphic_path([:solr_document], id: @work.id), method: 'get', class: 'btn btn-link' %>


### PR DESCRIPTION
Updates the partials with buttons to follow a primary, secondary, tertiary pattern to unify the look and feel of the user interface.

## Description

Updating the interface to use buttons consistently based on Bootstrap. primary buttons for primary actions like create, secondary outline buttons for things like delete if on a create page, and make link buttons look like links for things like show.

Connected to #960 

## Changes

* whole lotta CSS class refinement
