### PR TITLE
Override Valkyrie::Persistence::Shared::JSONValueMapper::DateValue

### DIFF
--- a/app/valkyrie/date_time_json_value.rb
+++ b/app/valkyrie/date_time_json_value.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Prepended to JSONValueMapper::DateValue class methods to return only DateTime objects with a timestamp
+# and not just an iso8601 date string. This fixes issues where strings that are value EDTF dates such
+# as '2001-01-01' are not cast to DateTime objects, but are instead retained as strings for later
+# processing as EDTF dates.
+
+require 'date'
+
+module DateTimeJSONValue
+  def handles?(value)
+    date, time = value.split('T')
+    return false unless time
+
+    ::DateTime.iso8601(date)
+  rescue StandardError
+    false
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,5 +27,10 @@ module Cho
     config.storage_directory = Pathname.new(ENV['storage_directory']).expand_path
     config.network_ingest_directory = Pathname.new(ENV['network_ingest_directory']).expand_path
     config.extraction_directory = Pathname.new(ENV['extraction_directory']).expand_path
+
+    # Inject new behaviors into existing classes without having to override the entire class itself.
+    config.to_prepare do
+      Valkyrie::Persistence::Shared::JSONValueMapper::DateValue.singleton_class.send(:prepend, DateTimeJSONValue)
+    end
   end
 end

--- a/spec/cho/work/submissions/multiple_fields_spec.rb
+++ b/spec/cho/work/submissions/multiple_fields_spec.rb
@@ -54,13 +54,6 @@ RSpec.describe 'Works with multiple fields', with_named_js: :multiple_fields, ty
       expect(page).to have_selector("dd.blacklight-#{field}_tesim", text: content)
     end
 
-    # @note guards against scenarios in which the dates in each attribute are the same.
-    def date_display
-      [attributes1[:created], attributes2[:created]].uniq.map do |date|
-        "datetime-#{date.strftime('%Y-%m-%d')}T00:00:00.000Z"
-      end.join(' and ')
-    end
-
     it 'updates each field with the new information' do
       visit(root_path)
       click_link('Create Resource')
@@ -94,7 +87,7 @@ RSpec.describe 'Works with multiple fields', with_named_js: :multiple_fields, ty
         content: "id-#{attributes1[:alternate_ids]} and id-#{attributes2[:alternate_ids]}"
       )
       verify_multiple(:generic_field)
-      verify_multiple(:created, content: date_display)
+      verify_multiple(:created)
       verify_multiple(
         :creator,
         content:

--- a/spec/valkyrie/date_time_json_value_spec.rb
+++ b/spec/valkyrie/date_time_json_value_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'active_support'
+require_relative '../../../cho/app/valkyrie/date_time_json_value'
+
+RSpec.describe DateTimeJSONValue do
+  subject { MyValueMapper.handles?(value) }
+
+  before(:all) do
+    class MyValueMapper
+    end
+
+    MyValueMapper.singleton_class.send(:prepend, described_class)
+  end
+
+  after(:all) do
+    ActiveSupport::Dependencies.remove_constant('MyValueMapper')
+  end
+
+  context 'when a string has a date with a valid timestamp' do
+    let(:value) { '2019-06-11T23:11:13-04:00' }
+
+    it { is_expected.to be_truthy }
+  end
+
+  context 'with a string representation of a DateTime' do
+    let(:value) { DateTime.now.to_s }
+
+    it { is_expected.to be_truthy }
+  end
+
+  context 'when a string has a date without a valid timestamp' do
+    let(:value) { '2019-06-11 23:11:13 UTC' }
+
+    it { is_expected.to be_falsey }
+  end
+
+  context 'when a string has only a full date' do
+    let(:value) { '2112-12-21' }
+
+    it { is_expected.to be_falsey }
+  end
+
+  context 'when a string has a year and month' do
+    let(:value) { '1999-12' }
+
+    it { is_expected.to be_falsey }
+  end
+
+  context 'when a string has only a year' do
+    let(:value) { '1999' }
+
+    it { is_expected.to be_falsey }
+  end
+
+  context 'with something other than a string' do
+    let(:value) { 2 }
+
+    it { is_expected.to be_falsey }
+  end
+end


### PR DESCRIPTION
## Description

Allows iso8601 dates that do not have time stamps, such as 1956-12-31, to be returned as strings and not DateTime objects. This allow for EDTF date-style processing at other points in the application.

Connected to #1035 