### PR TITLE
Set the current user when creating works and file sets

### DIFF
--- a/app/cho/csv/controller_behavior.rb
+++ b/app/cho/csv/controller_behavior.rb
@@ -51,7 +51,8 @@ module Csv::ControllerBehavior
       @import_csv ||= Transaction::Operations::Import::Csv.new.call(
         csv_dry_run: csv_dry_run,
         file: params[:file_name],
-        update: update?
+        update: update?,
+        current_user: current_user
       )
     end
 

--- a/app/cho/csv/importer.rb
+++ b/app/cho/csv/importer.rb
@@ -4,7 +4,7 @@ module Csv
   # Runs the import process assuming each item in the list is valid
   #  Each item in the list is a change set that can be persisted
   #
-  # importer = Csv::Importer.new(change_set_list)
+  # importer = Csv::Importer.new(change_set_list: change_set_list)
   # if importer.run
   #   puts "The import was successful"
   # else
@@ -13,11 +13,12 @@ module Csv
   # end
   #
   class Importer
-    attr_reader :change_set_list, :errors, :created
+    attr_reader :change_set_list, :errors, :created, :current_user
 
-    def initialize(change_set_list, change_set_persister = nil)
+    def initialize(change_set_list: change_set_list, change_set_persister: nil, current_user: nil)
       @change_set_list = change_set_list
       @change_set_persister = change_set_persister
+      @current_user = current_user
       @errors = []
       @created = []
     end
@@ -27,7 +28,7 @@ module Csv
 
       change_set_list.each do |change_set|
         update_member_hashes(change_set)
-        result = change_set_persister.validate_and_save(change_set: change_set, resource_params: {})
+        result = change_set_persister.validate_and_save(change_set: change_set, resource_params: resource_params)
         if result.errors.blank?
           created << result
         else
@@ -54,6 +55,10 @@ module Csv
             errors << result
           end
         end
+      end
+
+      def resource_params
+        { current_user: current_user }
       end
 
       def change_set_persister

--- a/app/cho/shared/valkyrie_controller_behaviors.rb
+++ b/app/cho/shared/valkyrie_controller_behaviors.rb
@@ -10,7 +10,7 @@ module ValkyrieControllerBehaviors
   end
 
   def validate_save_and_respond(change_set, error_view)
-    change_set.current_user = current_user if change_set.try(:current_user)
+    change_set.current_user = current_user if change_set.respond_to?(:current_user)
     updated_change_set = change_set_persister.validate_and_save(
       change_set: change_set,
       resource_params: resource_params

--- a/app/cho/transaction/operations/import/csv.rb
+++ b/app/cho/transaction/operations/import/csv.rb
@@ -8,9 +8,9 @@ module Transaction
       class Csv
         include Dry::Transaction::Operation
 
-        def call(csv_dry_run:, file:, update:)
+        def call(csv_dry_run:, file:, update:, current_user: nil)
           dry_run = csv_dry_run.new(file, update: update)
-          importer = ::Csv::Importer.new(dry_run.results)
+          importer = ::Csv::Importer.new(change_set_list: dry_run.results, current_user: current_user)
           importer.run
           delete_bag(dry_run)
 

--- a/spec/cho/collection/archival_collections/new_spec.rb
+++ b/spec/cho/collection/archival_collections/new_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Collection::Archival, type: :feature do
       expect(page).to have_content('Description of new collection')
       expect(page).to have_content('mediated')
       expect(page).to have_content(Repository::AccessControls::AccessLevel.psu)
+      expect(Collection::Archival.all.first.system_creator).to eq(current_user)
     end
   end
 

--- a/spec/cho/collection/curated_collections/new_spec.rb
+++ b/spec/cho/collection/curated_collections/new_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Collection::Curated, type: :feature do
       expect(page).to have_content('Description of new collection')
       expect(page).to have_content('mediated')
       expect(page).to have_content(Repository::AccessControls::AccessLevel.psu)
+      expect(Collection::Curated.all.first.system_creator).to eq(current_user)
     end
   end
 

--- a/spec/cho/collection/library_collections/new_spec.rb
+++ b/spec/cho/collection/library_collections/new_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Collection::Library, type: :feature do
       expect(page).to have_content('Description of new collection')
       expect(page).to have_content('mediated')
       expect(page).to have_content(Repository::AccessControls::AccessLevel.psu)
+      expect(Collection::Library.all.first.system_creator).to eq(current_user)
     end
   end
 

--- a/spec/cho/csv/importer_spec.rb
+++ b/spec/cho/csv/importer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Csv::Importer do
   let(:change_set_list) { [Work::SubmissionChangeSet.new(Work::Submission.new(work_hash_1)),
                            Work::SubmissionChangeSet.new(Work::Submission.new(work_hash_2))] }
 
-  let(:importer) { described_class.new(change_set_list) }
+  let(:importer) { described_class.new(change_set_list: change_set_list) }
 
   it 'creates the works' do
     status = false
@@ -39,7 +39,7 @@ RSpec.describe Csv::Importer do
   context 'error during save' do
     let(:bad_persister) { ChangeSetPersister.new(metadata_adapter: bad_meta_adapter, storage_adapter: nil) }
     let(:bad_meta_adapter) { instance_double('Valkyrie::Persistence::Postgres::MetadataAdapter') }
-    let(:importer) { described_class.new(change_set_list, bad_persister) }
+    let(:importer) { described_class.new(change_set_list: change_set_list, change_set_persister: bad_persister) }
 
     before do
       allow(bad_meta_adapter)

--- a/spec/cho/work/import/create_spec.rb
+++ b/spec/cho/work/import/create_spec.rb
@@ -99,8 +99,10 @@ RSpec.describe 'Preview of CSV Import', type: :feature do
       Work::Submission.all.each do |work|
         expect(work.batch_id).to eq('batch1_2018-07-12')
         expect(work.member_ids.count).to eq(1)
+        expect(work.system_creator).to eq(current_user)
         file_set = Work::FileSet.find(Valkyrie::ID.new(work.member_ids.first))
         expect(file_set.member_ids.count).to eq(1)
+        expect(file_set.system_creator).to eq(current_user)
         file = Work::File.find(Valkyrie::ID.new(file_set.member_ids.first))
         expect(file_set.title).to contain_exactly(file.original_filename)
         expect(file.original_filename).to eq("#{work.alternate_ids.first}_preservation.tif")
@@ -182,6 +184,7 @@ RSpec.describe 'Preview of CSV Import', type: :feature do
       # Verify each work has a file set and a file
       imported_work = Work::Submission.all.first
       expect(imported_work.title).to eq(['My Work1'])
+      expect(imported_work.system_creator).to eq(current_user)
       file_sets = imported_work.member_ids.map do |id|
         Work::FileSet.find(Valkyrie::ID.new(id))
       end
@@ -196,6 +199,7 @@ RSpec.describe 'Preview of CSV Import', type: :feature do
         ['My Work1_00002_01'],
         ['My Work1_00002_02']
       )
+      expect(file_sets.map(&:system_creator).uniq).to contain_exactly(current_user)
       filenames = file_sets.map do |file_set|
         file_set.member_ids.map { |id| Work::File.find(Valkyrie::ID.new(id)).original_filename }
       end

--- a/spec/cho/work/submissions/new_spec.rb
+++ b/spec/cho/work/submissions/new_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe Work::Submission, type: :feature do
         expect(page).to have_blacklight_field(:creator_tesim).with("Kringle, Christopher, #{role.label}")
       end
       expect(page).to have_selector('input[type=submit][value=Edit]')
+      expect(Work::Submission.all.first.system_creator).to eq(current_user)
     end
   end
 

--- a/spec/support/selectors.rb
+++ b/spec/support/selectors.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Selectors
+  def current_user
+    find('#dropdownMenuButton').text
+  rescue Capybara::ElementNotFound
+    nil
+  end
+end
+
+RSpec.configure do |config|
+  config.include Selectors, type: :feature
+end


### PR DESCRIPTION
## Description

Sets the current user when creating works and file sets.

Connected to #975 

## Changes

* current user wasn't being applied to the change set even if it did have the method available
* current user also needed to be applied to file sets created in transactions
* current user should be passed along during csv import
