### PR TITLE
piwik id is configurable by application.yml

### DIFF
--- a/app/assets/javascripts/matomo.js.erb
+++ b/app/assets/javascripts/matomo.js.erb
@@ -9,7 +9,7 @@ _paq.push(['enableLinkTracking']);
 (function() {
   var u="//analytics.libraries.psu.edu/piwik/";
   _paq.push(['setTrackerUrl', u+'piwik.php']);
-  _paq.push(['setSiteId', '2']);
+  _paq.push(['setSiteId', '<%= ENV.fetch('piwik_id', 2) %>']);
   var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
   g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
 })();

--- a/app/cho/repository/configuration.rb
+++ b/app/cho/repository/configuration.rb
@@ -11,7 +11,8 @@ module Repository
         { 'virtual_host' => { required: true } },
         { 'network_ingest_directory' => { required: true, directory: { writable: false } } },
         { 'extraction_directory' => { required: true, directory: { writable: true } } },
-        { 'storage_directory' => { required: true, directory: { writable: true } } }
+        { 'storage_directory' => { required: true, directory: { writable: true } } },
+        { 'piwik_id' => { required: true } }
       ]
     }.freeze
 

--- a/config/application.yml
+++ b/config/application.yml
@@ -8,6 +8,7 @@ development:
   network_ingest_directory: 'tmp/ingest-development'
   extraction_directory: 'tmp/extract-development'
   storage_directory: 'public/files'
+  piwik_id: '2'
 test:
   service_name: "example-test"
   service_instance: "example-test"
@@ -15,6 +16,7 @@ test:
   network_ingest_directory: 'tmp/ingest-test'
   extraction_directory: 'tmp/extract-test'
   storage_directory: 'public/files'
+  piwik_id: '2'
 production:
   service_name: "example-test"
   service_instance: "example-test"
@@ -22,3 +24,4 @@ production:
   network_ingest_directory: 'tmp/ingest-test'
   extraction_directory: 'tmp/extract-test'
   storage_directory: 'public/files'
+  piwik_id: '2'


### PR DESCRIPTION
## Description

Piwik id had been hard-coded to 2. It is now configurable via application.yml

In order for this to take effect, we will need to talk to the devops folks. The following key-value should be added to application.yml in chef on the following servers

```
# QA
piwik_id: '2'

# Stage
piwik_id: '5'

# Production
piwik_id: '6'
```

(Note that Figaro likes all values to be strings)

Connected to #951 
