### PR TITLE
Collection Landing Page in two Columns without Resources

### DIFF
--- a/app/views/catalog/_show_collection_archival.html.erb
+++ b/app/views/catalog/_show_collection_archival.html.erb
@@ -1,3 +1,5 @@
+<%= document.description_data_dictionary_field.first %>
+
 <% @document.transformed_fields.each do |field| %>
   <% if field.present? %>
     <%= render partial: "shared/transformation_partials/#{field.display_transformation}",
@@ -5,7 +7,7 @@
   <% end %>
 <% end %>
 
-<%= render partial: 'show', locals: { document: @document } %>
+<%#= render partial: 'show', locals: { document: @document } %>
 
 <% unless @document_facade.members.empty? %>
   <%= render partial: 'members', locals: { facade: @document_facade } %>

--- a/app/views/catalog/_show_collection_archival.html.erb
+++ b/app/views/catalog/_show_collection_archival.html.erb
@@ -1,13 +1,24 @@
-<%= document.description_data_dictionary_field.first %>
+<%# Create a method similar to fields_to_render for core fields
+# https://github.com/projectblacklight/blacklight/blob/8de6ad03af4180c116ed1b559750f538deafa6dd/app/presenters/blacklight/document_presenter.rb#L9
+# https://github.com/projectblacklight/blacklight/blob/8f1b3f2a4c7cbd69a5f6a4a74c8c34bf7d209042/app/views/catalog/_show.html.erb
+%>
 
-<% @document.transformed_fields.each do |field| %>
-  <% if field.present? %>
-    <%= render partial: "shared/transformation_partials/#{field.display_transformation}",
-               locals: { presenter: field } %>
-  <% end %>
-<% end %>
-
-<%#= render partial: 'show', locals: { document: @document } %>
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-sm-12 col-md-7">
+      <p><%= document.description_data_dictionary_field.first %></p>
+    </div>
+    <div class="col-sm-12 col-md-5">
+      <%= render partial: 'show', locals: { document: @document } %>
+      <% @document.transformed_fields.each do |field| %>
+        <% if field.present? %>
+          <%= render partial: "shared/transformation_partials/#{field.display_transformation}",
+                     locals: { presenter: field } %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>
 
 <% unless @document_facade.members.empty? %>
   <%= render partial: 'members', locals: { facade: @document_facade } %>

--- a/app/views/catalog/_show_collection_archival.html.erb
+++ b/app/views/catalog/_show_collection_archival.html.erb
@@ -1,14 +1,10 @@
-<%# Create a method similar to fields_to_render for core fields
-# https://github.com/projectblacklight/blacklight/blob/8de6ad03af4180c116ed1b559750f538deafa6dd/app/presenters/blacklight/document_presenter.rb#L9
-# https://github.com/projectblacklight/blacklight/blob/8f1b3f2a4c7cbd69a5f6a4a74c8c34bf7d209042/app/views/catalog/_show.html.erb
-%>
-
 <div class="container-fluid">
   <div class="row">
     <div class="col-sm-12 col-md-7">
       <p><%= document.description_data_dictionary_field.first %></p>
     </div>
     <div class="col-sm-12 col-md-5">
+      <h2><%= t('cho.collection.metadata.title') %></h2>
       <%= render partial: 'show', locals: { document: @document } %>
       <% @document.transformed_fields.each do |field| %>
         <% if field.present? %>
@@ -19,7 +15,6 @@
     </div>
   </div>
 </div>
-
 <% unless @document_facade.members.empty? %>
   <%= render partial: 'members', locals: { facade: @document_facade } %>
 <% end %>

--- a/app/views/catalog/_show_collection_archival.html.erb
+++ b/app/views/catalog/_show_collection_archival.html.erb
@@ -15,6 +15,3 @@
     </div>
   </div>
 </div>
-<% unless @document_facade.members.empty? %>
-  <%= render partial: 'members', locals: { facade: @document_facade } %>
-<% end %>

--- a/app/views/catalog/_show_collection_library.html.erb
+++ b/app/views/catalog/_show_collection_library.html.erb
@@ -15,6 +15,3 @@
     </div>
   </div>
 </div>
-<% unless @document_facade.members.empty? %>
-  <%= render partial: 'members', locals: { facade: @document_facade } %>
-<% end %>

--- a/app/views/catalog/_show_collection_library.html.erb
+++ b/app/views/catalog/_show_collection_library.html.erb
@@ -1,12 +1,20 @@
-<% @document.transformed_fields.each do |field| %>
-  <% if field.present? %>
-    <%= render partial: "shared/transformation_partials/#{field.display_transformation}",
-               locals: { presenter: field } %>
-  <% end %>
-<% end %>
-
-<%= render partial: 'show', locals: { document: @document } %>
-
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-sm-12 col-md-7">
+      <p><%= document.description_data_dictionary_field.first %></p>
+    </div>
+    <div class="col-sm-12 col-md-5">
+      <h2><%= t('cho.collection.metadata.title') %></h2>
+      <%= render partial: 'show', locals: { document: @document } %>
+      <% @document.transformed_fields.each do |field| %>
+        <% if field.present? %>
+          <%= render partial: "shared/transformation_partials/#{field.display_transformation}",
+                     locals: { presenter: field } %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>
 <% unless @document_facade.members.empty? %>
   <%= render partial: 'members', locals: { facade: @document_facade } %>
 <% end %>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -28,7 +28,3 @@
     <% end %>
   </div>
 </div>
-
-<% content_for(:sidebar) do %>
-  <%= render_document_sidebar_partial %>
-<% end %>

--- a/config/locales/cho.yml
+++ b/config/locales/cho.yml
@@ -73,6 +73,8 @@ en:
         download_representative_link: 'Download Work'
         download_text_link: 'Download Plain Text'
     collection:
+      metadata:
+        title: "Collection Information"
       members:
         title: "Title"
         date_created: "Date Created"

--- a/spec/cho/collection/archival_collections/show_spec.rb
+++ b/spec/cho/collection/archival_collections/show_spec.rb
@@ -36,7 +36,9 @@ RSpec.describe Collection::Archival, type: :feature do
     it_behaves_like 'a restricted resource', with_user: :restricted_user
   end
 
-  it_behaves_like 'a collection with works'
+  # it_behaves_like 'a collection with works'
+
+  it_behaves_like 'a collection with a landing page'
 
   it_behaves_like 'a collection editable only by admins'
 end

--- a/spec/cho/collection/curated_collections/show_spec.rb
+++ b/spec/cho/collection/curated_collections/show_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Collection::Curated, type: :feature do
     it_behaves_like 'a restricted resource', with_user: :restricted_user
   end
 
-  it_behaves_like 'a collection with works'
+  # it_behaves_like 'a collection with works'
 
   it_behaves_like 'a collection editable only by admins'
 end

--- a/spec/cho/collection/library_collections/show_spec.rb
+++ b/spec/cho/collection/library_collections/show_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Collection::Library, type: :feature do
     it_behaves_like 'a restricted resource', with_user: :restricted_user
   end
 
-  it_behaves_like 'a collection with works'
+  # it_behaves_like 'a collection with works'
 
   it_behaves_like 'a collection editable only by admins'
 end

--- a/spec/cho/work/import/create_spec.rb
+++ b/spec/cho/work/import/create_spec.rb
@@ -72,28 +72,30 @@ RSpec.describe 'Preview of CSV Import', type: :feature do
         expect(page).to have_selector('li a', text: 'My Work 3')
       end
 
+      # Commenting out the members code until NEW collection landing page is finished
+      #
       # Inspect the collection and its members
-      visit(polymorphic_path([:solr_document], id: collection.id))
-      within('div#members') do
-        click_link('My Work 1')
-      end
-      expect(page).to have_content('My Work 1')
-      expect(page).to have_content("#{agent1.display_name}, blasting")
-      expect(page).to have_content('public')
-      click_link('my collection')
-      within('div#members') do
-        click_link('My Work 2')
-      end
-      expect(page).to have_content('My Work 2')
-      expect(page).to have_content("#{agent2.display_name}, climbing")
-      expect(page).to have_content('public')
-      click_link('my collection')
-      within('div#members') do
-        click_link('My Work 3')
-      end
-      expect(page).to have_content('My Work 3')
-      expect(page).to have_content(agent3.display_name.to_s)
-      expect(page).to have_content('public')
+      # visit(polymorphic_path([:solr_document], id: collection.id))
+      # within('div#members') do
+      #   click_link('My Work 1')
+      # end
+      # expect(page).to have_content('My Work 1')
+      # expect(page).to have_content("#{agent1.display_name}, blasting")
+      # expect(page).to have_content('public')
+      # click_link('my collection')
+      # within('div#members') do
+      #   click_link('My Work 2')
+      # end
+      # expect(page).to have_content('My Work 2')
+      # expect(page).to have_content("#{agent2.display_name}, climbing")
+      # expect(page).to have_content('public')
+      # click_link('my collection')
+      # within('div#members') do
+      #   click_link('My Work 3')
+      # end
+      # expect(page).to have_content('My Work 3')
+      # expect(page).to have_content(agent3.display_name.to_s)
+      # expect(page).to have_content('public')
 
       # Verify each work has a file set and a file
       Work::Submission.all.each do |work|

--- a/spec/support/shared/collections.rb
+++ b/spec/support/shared/collections.rb
@@ -1,27 +1,38 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples 'a collection with works' do
-  before do
-    (1..20).each do |count|
-      create(:work, title: "Work #{count}", home_collection_id: [collection.id])
-    end
-  end
+# Commenting out the collections with resources until collection landing pages are complete
+#
+# RSpec.shared_examples 'a collection with works' do
+#   before do
+#     (1..20).each do |count|
+#       create(:work, title: "Work #{count}", home_collection_id: [collection.id])
+#     end
+#   end
+#
+#   it 'displays a paginated listing of its works' do
+#     visit(polymorphic_path([:solr_document], id: collection.id))
+#     expect(page).to have_content('Resources in this Collection')
+#     within('div#members') do
+#       expect(page).to have_link('Work 1')
+#       expect(page).not_to have_link('Work 20')
+#     end
+#     within('div.pagination') do
+#       expect(page).to have_link('2')
+#       click_link('Next')
+#     end
+#     within('div#members') do
+#       expect(page).not_to have_link('Work 5')
+#       expect(page).to have_link('Work 20')
+#     end
+#   end
+# end
 
-  it 'displays a paginated listing of its works' do
+RSpec.shared_examples 'a collection with a landing page' do
+  it 'has a title' do
     visit(polymorphic_path([:solr_document], id: collection.id))
-    expect(page).to have_content('Resources in this Collection')
-    within('div#members') do
-      expect(page).to have_link('Work 1')
-      expect(page).not_to have_link('Work 20')
-    end
-    within('div.pagination') do
-      expect(page).to have_link('2')
-      click_link('Next')
-    end
-    within('div#members') do
-      expect(page).not_to have_link('Work 5')
-      expect(page).to have_link('Work 20')
-    end
+    expect(page).to have_selector('h1')
+    expect(page).to have_selector('p')
+    expect(page).to have_selector('dt')
   end
 end
 


### PR DESCRIPTION
## Description

This is a small step in our Collection landing pages tickets. Still using the Blacklight partials and the search context (catalog) to display the show page. However, we have the title of the collection at the top and the description in the first column. Collection metadata goes into the second column.

Title and description are duplicated in the metadata output, but will be resolved in future work on the collection landing pages.

This paves the way for the representative image, browse button, searching the collection, etc.

Connected to #896 

## Changes

* Removes the tools partial from the display to give more room for the two column layout
* Adds the collection title to an `<h1>` at the top of the page
* Grabs the description field contents and displays it under the title in the first column
* Uses the default Blacklight show partials to outpout the metadata
* Adds a `<h2>` for the metadata

