### PR TITLE
Adding a viewing context to works in collections

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,6 +48,7 @@ Metrics/BlockLength:
     - 'lib/tasks/**/*'
     - 'config/initializers/valkyrie.rb'
     - 'app/blacklight/catalog_controller.rb'
+    - 'config/routes.rb'
 
 # This is due to a bug in Rubocop. A future version of Niftany, which will include an updated
 # version of Rubocop, should fix this.

--- a/app/cho/collection/url_helper_behavior.rb
+++ b/app/cho/collection/url_helper_behavior.rb
@@ -2,8 +2,17 @@
 
 # @note Overrides Blacklight::UrlHelperBehavior in Collection::ResourcesController
 module Collection::UrlHelperBehavior
-  # @note Blacklight can't determine the tracking path because we're nesting it. So we just hard code it.
+  # @note Blacklight can't determine the tracking path because we're using nested routes, so we're just hard coding it.
   def controller_tracking_method
     'track_archival_collection_resources_path'
+  end
+
+  # @note urls should be within the scope of the Collection::ResourcesController. This could have been accomplished
+  # in Blacklight::SearchState.url_for_document by using a config.show.route setting, but we couldn't figure out
+  # how to do it.
+  def url_for_document(doc, options = {})
+    return if doc.nil?
+
+    archival_collection_resource_path(options.merge(id: doc.id))
   end
 end

--- a/app/views/collection/resources/show.html.erb
+++ b/app/views/collection/resources/show.html.erb
@@ -1,6 +1,6 @@
 <% if current_search_session %>
   <div id="appliedParams">
-    <%= link_back_to_catalog(label: t('cho.catalog.link_back'), class: 'btn btn-link') %>
+    <%= link_back_to_catalog(label: t('cho.collection.resources.link_back'), class: 'btn btn-link') %>
     <%= render 'previous_next_doc' if @search_context %>
   </div>
 <% end %>

--- a/config/locales/cho.yml
+++ b/config/locales/cho.yml
@@ -2,6 +2,7 @@ en:
   cho:
     catalog:
       edit: "Edit"
+      link_back: "Back to Search Results"
     file_set:
       edit:
         delete_link: "Delete File Set"
@@ -88,6 +89,8 @@ en:
         finding_aid: "Finding Aid"
         collection_home: "Collection Home"
         browse:  "Browse"
+      resources:
+        link_back: "Back to Collection Search"
     archival_collection:
       edit:
         delete_link: "Delete Archival Collection"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,8 +31,18 @@ Rails.application.routes.draw do
   resources :work_file_sets, as: 'file_sets', path: '/file_sets', only: [:edit, :update],
                              controller: 'work/file_sets'
   resources :archival_collections, except: [:show, :index, :destroy], controller: 'collection/archival_collections' do
+    # Duplicates the same routing syntax for the searching in CatalogController, but in a nested context such that
+    # `/archival_collections/:archival_collection_id/resources` serves as a search and browse endpoint for an
+    # individual collection.
     resource :resources, only: [:index], as: 'resources', path: 'resources', controller: 'collection/resources' do
       concerns :searchable
+    end
+
+    # Duplicates the same routing syntax for displaying solr documents in CatalogController, but in a nested
+    # context such that `/archival_collections/:archival_collection_id/resources/:id` displays an individual work
+    # within a collection.
+    resources :resources, only: [:show], path: 'resources', controller: 'collection/resources' do
+      concerns :exportable
     end
   end
 

--- a/spec/cho/collection/archival_collections/browse_spec.rb
+++ b/spec/cho/collection/archival_collections/browse_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Collection::Archival, type: :feature do
 
   context 'when the collection has many works' do
     let(:query) { page.find('.document-position-0').find_all('a').first.text }
+    let(:resource_title) { page.find('.document-position-3').find_all('a').first.text }
 
     before do
       Array.new(15) do
@@ -21,6 +22,13 @@ RSpec.describe Collection::Archival, type: :feature do
       expect(page).to have_link('Finding Aid')
       expect(page).to have_content('Search within collection')
       expect(page).to have_content('1 - 10 of 15')
+      click_link(resource_title)
+      expect(page).to have_content(resource_title)
+      expect(page).to have_link('Back to Collection Search')
+      expect(page).to have_blacklight_label(:home_collection_id_tesim)
+      expect(page).to have_blacklight_label(:description_tesim)
+      expect(page).to have_blacklight_label(:created_tesim)
+      expect(page).to have_blacklight_label(:access_rights_tesim)
     end
 
     it 'searches for works within the collection' do

--- a/spec/cho/collection/resources_routing_spec.rb
+++ b/spec/cho/collection/resources_routing_spec.rb
@@ -11,5 +11,14 @@ RSpec.describe Collection::ResourcesController, type: :routing do
         archival_collection_id: '1'
       )
     end
+
+    it 'routes to #show' do
+      expect(get: '/archival_collections/1/resources/2').to route_to(
+        controller: 'collection/resources',
+        action: 'show',
+        archival_collection_id: '1',
+        id: '2'
+      )
+    end
   end
 end


### PR DESCRIPTION
## Description

Expands the nested resources controller to include a show view. This enables viewing a work within its containing collection and serves as a mechanism for browsing through paginated lists of works in a collection.

Connected to #807

## Changes

* adds a route to `/archival_collections/:archival_collection_id/resources/:id`
* distinguishes between the catalog search/browse and the collection search/browse

## Caveats

There may be some unintended confusion the search results from a catalog search and those from a collection search. They appear to be mostly separate, however, there might be some yet-to-be-seen issues. Also, file sets still display within the context of the catalog controller and not their containing resource. 