### PR TITLE
Update to Valkyrie 2.0 (for real this time)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ end
 # Main gems
 gem 'blacklight', '~> 7.0'
 gem 'rails', '~> 5.1.6'
-gem 'valkyrie', '=2.0.0.RC10'
+gem 'valkyrie', '~> 2.0'
 
 # For Blacklight with Sprockets
 gem 'bootstrap', '~> 4.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,7 +211,7 @@ GEM
     dry-configurable (0.8.3)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.4, >= 0.4.7)
-    dry-container (0.7.0)
+    dry-container (0.7.1)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.1, >= 0.1.3)
     dry-core (0.4.7)
@@ -222,7 +222,7 @@ GEM
       dry-core (~> 0.4)
       dry-equalizer (~> 0.2)
     dry-inflector (0.1.2)
-    dry-logic (1.0.0)
+    dry-logic (1.0.2)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.2)
       dry-equalizer (~> 0.2)
@@ -651,7 +651,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.5.0)
     validatable (1.6.7)
-    valkyrie (2.0.0.RC10)
+    valkyrie (2.0.0)
       activemodel
       activesupport
       disposable (~> 0.4.5)
@@ -761,7 +761,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   twitter-typeahead-rails (= 0.11.1.pre.corejavascript)
   uglifier (>= 1.3.0)
-  valkyrie (= 2.0.0.RC10)
+  valkyrie (~> 2.0)
   web-console (>= 3.3.0)
   webdrivers
   webpacker (~> 4.0)


### PR DESCRIPTION
## Description

Now that Valkyrie 2.0 is officially out, we can use the released gem and not the release candidate.