### PR TITLE
More robust collection image path generation

### DIFF
--- a/app/cho/collection/representative_image_presenter.rb
+++ b/app/cho/collection/representative_image_presenter.rb
@@ -45,7 +45,10 @@ module Collection
       def base_url_path
         @base_url_path = begin
                            filesystem_path
-                             .relative_path_from(Rails.root.join('public'))
+                             .to_s
+                             .split('public/')
+                             .last
+                             .gsub(/^\/|\/$/, '') # strip any leading/trailing slashes
                          end
       end
 


### PR DESCRIPTION
## Description

The original code I'd written to generate a URL for the collection representative images was a little too tricky for its own good and appeared to get confused with the symlinked directory in production. This new version is dumber, which in this case should be a good thing.

Connected to #897 
