### PR TITLE
Validate form input asynchronously

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,8 @@
   "env": {
     "browser": true,
     "es6": true,
-    "jest": true
+    "jest": true,
+    "jquery": true
   },
   "extends": "standard",
   "globals": {

--- a/app/cho/validation/unique.rb
+++ b/app/cho/validation/unique.rb
@@ -18,7 +18,7 @@ module Validation
     private
 
       def unchanged_edit?
-        return false unless change_set.resource.persisted?
+        return false unless change_set.present? && change_set.resource.persisted?
 
         change_set.send(field) == change_set.resource.send(field)
       end

--- a/app/cho/validation/validations_controller.rb
+++ b/app/cho/validation/validations_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Validation
+  class ValidationsController < ApplicationController
+    skip_authorize_resource only: :validate
+
+    before_action do
+      head :unprocessable_entity unless validator_class
+    end
+
+    def validate
+      if validator.validate(params.fetch(:value, nil))
+        render json: { valid: true }
+      else
+        render json: { valid: false, errors: validator.errors }
+      end
+    end
+
+    private
+
+      def validator
+        @validator ||= validator_class.new
+      end
+
+      def validator_class
+        Validation::Factory.lookup(params.fetch(:validation).to_sym)
+      end
+  end
+end

--- a/app/javascript/controllers/fields_controller.js
+++ b/app/javascript/controllers/fields_controller.js
@@ -14,6 +14,7 @@
 //   </div>
 
 import { Controller } from 'stimulus'
+import Validator from './validator'
 
 export default class extends Controller {
   connect () {
@@ -36,12 +37,20 @@ export default class extends Controller {
     event.target.parentElement.remove()
   }
 
+  // By default, Stimulus listens to change events on inputs and will execute this method
+  validate (event) {
+    let validator = new Validator(event.target)
+    validator.call()
+  }
+
   // @return [HTMLElement] cloned field taken from the first input group.
   get newField () {
     let clone = this.inputGroups.item(0).cloneNode(true)
     Array.from(clone.getElementsByClassName('form-control')).forEach((input) => {
       input.value = ''
     })
+    let validatorMessage = clone.querySelector('.' + Validator.messageSelectorClass)
+    if (validatorMessage) { validatorMessage.remove() }
     clone.appendChild(this.removeButton)
     return clone
   }

--- a/app/javascript/controllers/validator.js
+++ b/app/javascript/controllers/validator.js
@@ -1,0 +1,42 @@
+export default class Validator {
+  constructor (element) {
+    this.element = element
+  }
+
+  // WARNING: jQuery dependency ahead!
+  // It was just a lot easier to write this using jQuery than to use XMLHttpRequest
+  call () {
+    $.ajaxSetup({
+      headers: { 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content') }
+    })
+
+    this.resetMessage()
+
+    $.post(this.element.dataset.url, { value: this.element.value })
+      .done((data) => {
+        if (!data.valid) { this.setMessage(data.errors) }
+      })
+      .fail(() => {
+        this.setMessage(Array('Unable to validate input'))
+      })
+  }
+
+  resetMessage () {
+    let currentMessage = this.element.parentElement.querySelector('.' + this.constructor.messageSelectorClass)
+    if (currentMessage) { currentMessage.remove() }
+    this.element.closest('form').querySelector('input[type="submit"]').disabled = false
+  }
+
+  setMessage (errors) {
+    let node = document.createElement('p')
+    node.classList.toggle(this.constructor.messageSelectorClass)
+    let content = document.createTextNode(errors.join('<br/>'))
+    node.appendChild(content)
+    this.element.parentElement.appendChild(node)
+    this.element.closest('form').querySelector('input[type="submit"]').disabled = true
+  }
+
+  static get messageSelectorClass () {
+    return 'error-invalid'
+  }
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,4 +69,6 @@ Rails.application.routes.draw do
   get '/batch/delete', to: 'batch/delete#index'
   post '/batch/delete', to: 'batch/delete#confirm'
   delete '/batch/delete', to: 'batch/delete#destroy'
+
+  post '/validations/:validation', to: 'validation/validations#validate', as: 'validations'
 end

--- a/spec/cho/schema/input_field_spec.rb
+++ b/spec/cho/schema/input_field_spec.rb
@@ -16,8 +16,10 @@ RSpec.describe Schema::InputField, type: :model do
           default_value: 'abc123',
           display_name: 'My Abc123',
           display_transformation: 'no_transformation',
-          multiple: false, validation: 'no_validation',
-          core_field: false, order_index: 0,
+          multiple: false,
+          validation: 'no_validation',
+          core_field: false,
+          order_index: 0,
           work_type: 'something'
   end
 
@@ -103,6 +105,25 @@ RSpec.describe Schema::InputField, type: :model do
       before { metadata_field.requirement_designation = 'required' }
 
       it { is_expected.to include("aria-required": true, required: true) }
+    end
+
+    context 'with validation' do
+      before { metadata_field.validation = 'unique' }
+
+      it { is_expected.to include(data: { action: 'fields#validate', url: '/validations/unique' }) }
+    end
+
+    context 'with validation and a controlled vocabulary' do
+      before do
+        metadata_field.validation = 'creator'
+        metadata_field.controlled_vocabulary = 'creator_vocabulary'
+      end
+
+      it { is_expected.not_to have_key(:data) }
+    end
+
+    context 'without validation' do
+      it { is_expected.not_to have_key(:data) }
     end
   end
 

--- a/spec/cho/validation/routing_spec.rb
+++ b/spec/cho/validation/routing_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Validation::ValidationsController, type: :routing do
+  describe 'routing' do
+    it 'routes to #validate' do
+      expect(post: '/validations/my_validation').to route_to(
+        controller: 'validation/validations',
+        action: 'validate',
+        validation: 'my_validation'
+      )
+    end
+  end
+end

--- a/spec/cho/validation/validations_controller_spec.rb
+++ b/spec/cho/validation/validations_controller_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Validation::ValidationsController, type: :controller do
+  describe 'POST #validate' do
+    let(:json) { JSON.parse(response.body) }
+
+    context 'with valid input' do
+      before { post :validate, params: { validation: :edtf_date, value: '2016-09-uu' } }
+
+      specify do
+        expect(response).to be_success
+        expect(json.fetch('valid')).to be_truthy
+      end
+    end
+
+    context 'with invalid input' do
+      before { post :validate, params: { validation: :edtf_date, value: 'BAD DATES' } }
+
+      specify do
+        expect(response).to be_success
+        expect(json.fetch('valid')).to be_falsey
+        expect(json.fetch('errors')).to contain_exactly('Date BAD DATES is not a valid EDTF date')
+      end
+    end
+
+    context 'with empty input' do
+      before { post :validate, params: { validation: :edtf_date, value: '' } }
+
+      specify { expect(response).to be_success }
+    end
+
+    context 'with no input' do
+      before { post :validate, params: { validation: :edtf_date } }
+
+      specify { expect(response).to be_success }
+    end
+
+    context 'with a non-existent validator' do
+      before { post :validate, params: { validation: :bogus_validator, value: 'content' } }
+
+      specify { expect(response.status).to eq(422) }
+    end
+  end
+end

--- a/spec/cho/work/submissions/remote_validation_spec.rb
+++ b/spec/cho/work/submissions/remote_validation_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Works with remote validation enabled', with_named_js: :remote_validation, type: :feature do
+  def parent_div(field)
+    find("label[for='work_submission_#{field}']").first(:xpath, './/..')
+  end
+
+  # Allow CSRF tokens to be generated so we can test async responses
+  before(:all) { ActionController::Base.allow_forgery_protection = true }
+
+  after(:all) { ActionController::Base.allow_forgery_protection = false }
+
+  context 'when adding new fields for entry' do
+    it 'inserts new inputs with remove links' do
+      visit(root_path)
+      click_link('Create Resource')
+      click_link('Generic')
+      expect(page).to have_content('New Generic Resource', wait: Capybara.default_max_wait_time * 5)
+      fill_in('work_submission[created][]', with: 'Not a date')
+      find('#work_submission_created').send_keys(:tab)
+      within(parent_div(:created)) do
+        expect(page).to have_content('Date Not a date is not a valid EDTF date')
+      end
+      expect(find('input[type="submit"]')).to be_disabled
+      fill_in('work_submission[created][]', with: '2001')
+      find('#work_submission_created').send_keys(:tab)
+      within(parent_div(:created)) do
+        expect(page).not_to have_selector('#validatorMessage')
+      end
+      expect(find('input[type="submit"]')).not_to be_disabled
+    end
+  end
+end


### PR DESCRIPTION
## Description 

Augments the ES6 fields controller to add validation functionality with a remote validate endpoint that returns the same custom error messages, only as a json response so we can update the UI immediately when there is any invalid input.

## Changes

* ValidationsController for remote validating of input
* Validator js controller querying the rails controller
* changes to Fields js controller and UI elements for selecting the content and reporting outcomes
* introduces a dependency on jQuery

![Screen Shot 2019-06-27 at 4 16 03 PM](https://user-images.githubusercontent.com/312085/60297738-e43b9e80-98f6-11e9-9929-08e0ce940d20.png)
 